### PR TITLE
Fix crash on fullPath of fileRef.path

### DIFF
--- a/Sources/xcodeproj/PBXFileElement.swift
+++ b/Sources/xcodeproj/PBXFileElement.swift
@@ -152,7 +152,13 @@ public extension PBXFileElement {
             guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot }
             guard let groupPath = try group.value.fullPath(sourceRoot: sourceRoot) else { return nil }
             guard let filePath = self is PBXVariantGroup ? try baseVariantGroupPath() : path else { return groupPath }
-            return groupPath.appending(RelativePath(filePath))
+            if filePath.hasPrefix("/") {
+                // Swift PM generated pbxproj can have AbsolutePath
+                // e.g. OBJ_191 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/toshi0383/Documents/workspace/hackscode/.build/checkouts/AEXML.git--1992474868199569405/Package.swift"; sourceTree = "<group>"; };
+                return AbsolutePath(filePath)
+            } else {
+                return groupPath.appending(RelativePath(filePath))
+            }
         default:
             return nil
         }

--- a/Sources/xcodeproj/PBXFileElement.swift
+++ b/Sources/xcodeproj/PBXFileElement.swift
@@ -152,13 +152,10 @@ public extension PBXFileElement {
             guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot }
             guard let groupPath = try group.value.fullPath(sourceRoot: sourceRoot) else { return nil }
             guard let filePath = self is PBXVariantGroup ? try baseVariantGroupPath() : path else { return groupPath }
-            if filePath.hasPrefix("/") {
-                // Swift PM generated pbxproj can have AbsolutePath
-                // e.g. OBJ_191 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/toshi0383/Documents/workspace/hackscode/.build/checkouts/AEXML.git--1992474868199569405/Package.swift"; sourceTree = "<group>"; };
-                return AbsolutePath(filePath)
-            } else {
-                return groupPath.appending(RelativePath(filePath))
-            }
+
+            // Swift PM generated pbxproj can have AbsolutePath
+            // e.g. OBJ_191 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/toshi0383/Documents/workspace/hackscode/.build/checkouts/AEXML.git--1992474868199569405/Package.swift"; sourceTree = "<group>"; };
+            return AbsolutePath(filePath, relativeTo: groupPath)
         default:
             return nil
         }

--- a/Sources/xcodeproj/PBXFileElement.swift
+++ b/Sources/xcodeproj/PBXFileElement.swift
@@ -152,9 +152,6 @@ public extension PBXFileElement {
             guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot }
             guard let groupPath = try group.value.fullPath(sourceRoot: sourceRoot) else { return nil }
             guard let filePath = self is PBXVariantGroup ? try baseVariantGroupPath() : path else { return groupPath }
-
-            // Swift PM generated pbxproj can have AbsolutePath
-            // e.g. OBJ_191 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/toshi0383/Documents/workspace/hackscode/.build/checkouts/AEXML.git--1992474868199569405/Package.swift"; sourceTree = "<group>"; };
             return AbsolutePath(filePath, relativeTo: groupPath)
         default:
             return nil

--- a/Tests/xcodeprojTests/PBXFileElementSpec.swift
+++ b/Tests/xcodeprojTests/PBXFileElementSpec.swift
@@ -1,5 +1,6 @@
+import Basic
 import Foundation
-import xcodeproj
+@testable import xcodeproj
 import XCTest
 
 final class PBXFileElementSpec: XCTestCase {
@@ -33,6 +34,29 @@ final class PBXFileElementSpec: XCTestCase {
                                      includeInIndex: false,
                                      wrapsLines: true)
         XCTAssertEqual(subject, another)
+    }
+
+    func test_fullPath() {
+        let sourceRoot = AbsolutePath("/")
+        do {
+            let fileref = PBXFileReference(sourceTree: .group,
+                                           fileEncoding: 1,
+                                           explicitFileType: "sourcecode.swift",
+                                           lastKnownFileType: nil,
+                                           path: "/a/path")
+            let group = PBXGroup(childrenReferences: [fileref.reference],
+                                 sourceTree: .group,
+                                 name: "/to/be/ignored")
+
+            let objects = PBXObjects(objects: [fileref, group])
+            fileref.reference.objects = objects
+            group.reference.objects = objects
+
+            let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
+            XCTAssertEqual(fullPath?.asString, "/a/path")
+        } catch {
+            XCTFail("error: \(error)")
+        }
     }
 
     private func testDictionary() -> [String: Any] {

--- a/Tests/xcodeprojTests/PBXFileElementSpec.swift
+++ b/Tests/xcodeprojTests/PBXFileElementSpec.swift
@@ -36,27 +36,23 @@ final class PBXFileElementSpec: XCTestCase {
         XCTAssertEqual(subject, another)
     }
 
-    func test_fullPath() {
+    func test_fullPath() throws {
         let sourceRoot = AbsolutePath("/")
-        do {
-            let fileref = PBXFileReference(sourceTree: .group,
-                                           fileEncoding: 1,
-                                           explicitFileType: "sourcecode.swift",
-                                           lastKnownFileType: nil,
-                                           path: "/a/path")
-            let group = PBXGroup(childrenReferences: [fileref.reference],
-                                 sourceTree: .group,
-                                 name: "/to/be/ignored")
+        let fileref = PBXFileReference(sourceTree: .group,
+                                       fileEncoding: 1,
+                                       explicitFileType: "sourcecode.swift",
+                                       lastKnownFileType: nil,
+                                       path: "/a/path")
+        let group = PBXGroup(childrenReferences: [fileref.reference],
+                             sourceTree: .group,
+                             name: "/to/be/ignored")
 
-            let objects = PBXObjects(objects: [fileref, group])
-            fileref.reference.objects = objects
-            group.reference.objects = objects
+        let objects = PBXObjects(objects: [fileref, group])
+        fileref.reference.objects = objects
+        group.reference.objects = objects
 
-            let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
-            XCTAssertEqual(fullPath?.asString, "/a/path")
-        } catch {
-            XCTFail("error: \(error)")
-        }
+        let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
+        XCTAssertEqual(fullPath?.asString, "/a/path")
     }
 
     private func testDictionary() -> [String: Any] {


### PR DESCRIPTION
### Short description 📝
`PBXFileElement.fullPath(sourceRoot:)` crashes by `precondition` when the `PBXFileReference` is generated using SwiftPM `generate-xcodeproj`.

### Solution 📦
Check if it's an absolute path and return as is if it is.