### PR TITLE
Fix failing to get PBXSourcesBuildPhase from target

### DIFF
--- a/Sources/xcodeproj/PBXTarget.swift
+++ b/Sources/xcodeproj/PBXTarget.swift
@@ -138,10 +138,7 @@ public extension PBXTarget {
     /// - Throws: an error if the build phase cannot be obtained.
     public func sourcesBuildPhase() throws -> PBXSourcesBuildPhase? {
         return try buildPhasesReferences
-
-            // object() throws internally if failed to cast to inferred type T.
             .compactMap({ try $0.object() as PBXBuildPhase })
-
             .filter({ $0.type() == .sources })
             .compactMap { $0 as? PBXSourcesBuildPhase }
             .first

--- a/Sources/xcodeproj/PBXTarget.swift
+++ b/Sources/xcodeproj/PBXTarget.swift
@@ -138,8 +138,13 @@ public extension PBXTarget {
     /// - Throws: an error if the build phase cannot be obtained.
     public func sourcesBuildPhase() throws -> PBXSourcesBuildPhase? {
         return try buildPhasesReferences
-            .compactMap({ try $0.object() as PBXSourcesBuildPhase })
+
+            // Cannot cast to PBXSourcesBuildPhase here.
+            // object() throws internally if failed to cast to inferred type T.
+            .compactMap({ try $0.object() as PBXBuildPhase })
+
             .filter({ $0.type() == .sources })
+            .compactMap { $0 as? PBXSourcesBuildPhase }
             .first
     }
 

--- a/Sources/xcodeproj/PBXTarget.swift
+++ b/Sources/xcodeproj/PBXTarget.swift
@@ -139,7 +139,6 @@ public extension PBXTarget {
     public func sourcesBuildPhase() throws -> PBXSourcesBuildPhase? {
         return try buildPhasesReferences
 
-            // Cannot cast to PBXSourcesBuildPhase here.
             // object() throws internally if failed to cast to inferred type T.
             .compactMap({ try $0.object() as PBXBuildPhase })
 


### PR DESCRIPTION
### Short description 📝
If the BuildPhase section contains non-source BuildPhase at first, `PBXTarget#sourcesBuildPhase()` always fail.

```
▸---▸---C71198791B8EEB0E00F8DEC9 /* Tests */ = {
▸---▸---▸---isa = PBXNativeTarget;
▸---▸---▸---buildConfigurationList = C71198911B8EEB0E00F8DEC9 /* Build configuration list for PBXNativeTarget "Tests" */;
▸---▸---▸---buildPhases = (
▸---▸---▸---▸---7AE11F1585EF29FE98BC7F5B /* [CP] Check Pods Manifest.lock */,
▸---▸---▸---▸---F2C7F6AE20F5EFE500B0618A /* SwiftLint */,
▸---▸---▸---▸---C71198761B8EEB0E00F8DEC9 /* Sources */,
▸---▸---▸---▸---C71198771B8EEB0E00F8DEC9 /* Frameworks */,
▸---▸---▸---▸---C71198781B8EEB0E00F8DEC9 /* Resources */,
▸---▸---▸---▸---803199551C75DB10000DC667 /* CopyFiles */,
▸---▸---▸---▸---6FF9D6AFBAADAC0E0CCEAC2E /* [CP] Embed Pods Frameworks */,
▸---▸---▸---);
▸---▸---▸---buildRules = (
▸---▸---▸---);
▸---▸---▸---dependencies = (
▸---▸---▸---▸---C711987C1B8EEB0E00F8DEC9 /* PBXTargetDependency */,
▸---▸---▸---);
▸---▸---▸---name = Tests;
▸---▸---▸---productName = Tests;
▸---▸---▸---productReference = C711987A1B8EEB0E00F8DEC9 /* Tests.xctest */;
▸---▸---▸---productType = "com.apple.product-type.bundle.unit-test";
▸---▸---};
```

### Solution 📦
Ignore casting failure at fetching object step and filter and cast afterwards.