### PR TITLE
Add some convenient public methods to XCConfigurationList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 - Xcode 10 inputFileListPaths and outputFileListPaths attributes https://github.com/tuist/xcodeproj/pull/271 by @pepibumur
 - Split up `XCScheme` models and make them conform the `Equatable` protocol https://github.com/tuist/xcodeproj/pull/273 by @pepibumur
+- Convenient methods to add and fetch build configurations https://github.com/tuist/xcodeproj/pull/283 by @pepibumur
 
 ## 5.0.0-rc1
 

--- a/Tests/xcodeprojTests/Objects/XCConfigurationListSpec.swift
+++ b/Tests/xcodeprojTests/Objects/XCConfigurationListSpec.swift
@@ -6,4 +6,35 @@ final class XCConfigurationListSpec: XCTestCase {
     func test_isa_returnsTheCorrectValue() {
         XCTAssertEqual(XCConfigurationList.isa, "XCConfigurationList")
     }
+
+    func test_add_configuration() throws {
+        let objects = PBXObjects()
+        let configurationList = XCConfigurationList()
+        objects.addObject(configurationList)
+        let configuration = try configurationList.add(configuration: "Debug")
+
+        XCTAssertEqual(configuration.name, "Debug")
+        XCTAssertTrue(configurationList.buildConfigurationsReferences.contains(configuration.reference))
+    }
+
+    func test_addDefaultConfigurations() throws {
+        let objects = PBXObjects()
+        let configurationList = XCConfigurationList()
+        objects.addObject(configurationList)
+        let configurations = try configurationList.addDefaultConfigurations()
+        let names = configurations.map({ $0.name })
+
+        XCTAssertEqual(configurations.count, 2)
+        XCTAssertTrue(names.contains("Debug"))
+        XCTAssertTrue(names.contains("Release"))
+    }
+
+    func test_configuration_with_name() throws {
+        let objects = PBXObjects()
+        let configurationList = XCConfigurationList()
+        objects.addObject(configurationList)
+        let configuration = try configurationList.add(configuration: "Debug")
+
+        XCTAssertEqual(try configurationList.configuration(name: "Debug"), configuration)
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/281

Add convenient methods to XCConfigurationList for fetching and adding build configurations.

##### Notes
I worked on [this issue](https://github.com/tuist/xcodeproj/issues/281) but it turned out that most of the objects already offer convenient APIs. I couldn't think of more use cases of the API where it'd be great to have more convenience. 

As we use the API more use case will show up and give us hints of things we could improve in the interface.