### PR TITLE
Expose a public interface for setting/removing project target attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,20 @@
 
 ## next version
 
+### Added
+- `setAttributes`, `removeAttributes` and `attributes` to `PBXProject` https://github.com/tuist/xcodeproj/pull/295 by @pepibumur
+
 ### Changed
 - **Breaking** Change `blueprintIdentifier` type to `PBXObjectReference` https://github.com/tuist/xcodeproj/pull/289 by @pepibumur
+
 
 ### Fixed
 - Fix grammatical issues and add some convenient getters https://github.com/tuist/xcodeproj/pull/291 by @pepibumur
 - Fix targets not getting the reference generated https://github.com/tuist/xcodeproj/pull/290 by @pepibumur
 - Product references not being generated https://github.com/tuist/xcodeproj/pull/294 by @pepibumur
+
+### Removed
+- **Breaking** Make `PBXProject.attributes` internal https://github.com/tuist/xcodeproj/pull/295 by @pepibumur
 
 ## 5.0.0
 

--- a/Sources/xcodeproj/Objects/Project/PBXObjects.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjects.swift
@@ -115,12 +115,12 @@ public class PBXObjects: Equatable {
         }
         return objectReference
     }
-    
+
     /// Adds a new object to the project.
     ///
     /// - Parameter object: object to be added.
     public func add(object: PBXObject) {
-        self.addObject(object)
+        addObject(object)
     }
 
     /// Deletes the object with the given reference.
@@ -177,12 +177,12 @@ public class PBXObjects: Equatable {
         }
         return nil
     }
-    
+
     /// Deletes an object from the project.
     ///
     /// - Parameter object: object to be deleted.
     public func delete(object: PBXObject) {
-        self.delete(object.reference)
+        delete(object.reference)
     }
 
     /// It returns the object with the given reference.

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -126,6 +126,14 @@ public final class PBXProject: PBXObject {
         attributeReferences.removeValue(forKey: target.reference)
     }
 
+    /// Returns the attributes of a given target.
+    ///
+    /// - Parameter target: target whose attributes will be returned.
+    /// - Returns: target attributes.
+    public func attributes(target: PBXTarget) -> [String: Any]? {
+        return attributeReferences[target.reference]
+    }
+
     // MARK: - Init
 
     /// Initializes the project with its attributes

--- a/Sources/xcodeproj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/xcodeproj/Objects/Sourcery/Equality.generated.swift
@@ -5,269 +5,294 @@ import Foundation
 
 extension PBXAggregateTarget {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXAggregateTarget else { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXAggregateTarget else { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXBuildFile {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXBuildFile else { return false }
-      if self.fileReference != rhs.fileReference { return false }
-      if !NSDictionary(dictionary: self.settings ?? [:]).isEqual(to: rhs.settings ?? [:]) { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXBuildFile else { return false }
+        if fileReference != rhs.fileReference { return false }
+        if !NSDictionary(dictionary: settings ?? [:]).isEqual(to: rhs.settings ?? [:]) { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXBuildPhase else { return false }
-      if self.buildActionMask != rhs.buildActionMask { return false }
-      if self.fileReferences != rhs.fileReferences { return false }
-      if self.inputFileListPaths != rhs.inputFileListPaths { return false }
-      if self.outputFileListPaths != rhs.outputFileListPaths { return false }
-      if self.runOnlyForDeploymentPostprocessing != rhs.runOnlyForDeploymentPostprocessing { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXBuildPhase else { return false }
+        if buildActionMask != rhs.buildActionMask { return false }
+        if fileReferences != rhs.fileReferences { return false }
+        if inputFileListPaths != rhs.inputFileListPaths { return false }
+        if outputFileListPaths != rhs.outputFileListPaths { return false }
+        if runOnlyForDeploymentPostprocessing != rhs.runOnlyForDeploymentPostprocessing { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXBuildRule {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXBuildRule else { return false }
-      if self.compilerSpec != rhs.compilerSpec { return false }
-      if self.filePatterns != rhs.filePatterns { return false }
-      if self.fileType != rhs.fileType { return false }
-      if self.isEditable != rhs.isEditable { return false }
-      if self.name != rhs.name { return false }
-      if self.outputFiles != rhs.outputFiles { return false }
-      if self.outputFilesCompilerFlags != rhs.outputFilesCompilerFlags { return false }
-      if self.script != rhs.script { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXBuildRule else { return false }
+        if compilerSpec != rhs.compilerSpec { return false }
+        if filePatterns != rhs.filePatterns { return false }
+        if fileType != rhs.fileType { return false }
+        if isEditable != rhs.isEditable { return false }
+        if name != rhs.name { return false }
+        if outputFiles != rhs.outputFiles { return false }
+        if outputFilesCompilerFlags != rhs.outputFilesCompilerFlags { return false }
+        if script != rhs.script { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXContainerItem {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXContainerItem else { return false }
-      if self.comments != rhs.comments { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXContainerItem else { return false }
+        if comments != rhs.comments { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXContainerItemProxy {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXContainerItemProxy else { return false }
-      if self.containerPortalReference != rhs.containerPortalReference { return false }
-      if self.proxyType != rhs.proxyType { return false }
-      if self.remoteGlobalIDReference != rhs.remoteGlobalIDReference { return false }
-      if self.remoteInfo != rhs.remoteInfo { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXContainerItemProxy else { return false }
+        if containerPortalReference != rhs.containerPortalReference { return false }
+        if proxyType != rhs.proxyType { return false }
+        if remoteGlobalIDReference != rhs.remoteGlobalIDReference { return false }
+        if remoteInfo != rhs.remoteInfo { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXCopyFilesBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXCopyFilesBuildPhase else { return false }
-      if self.dstPath != rhs.dstPath { return false }
-      if self.dstSubfolderSpec != rhs.dstSubfolderSpec { return false }
-      if self.name != rhs.name { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXCopyFilesBuildPhase else { return false }
+        if dstPath != rhs.dstPath { return false }
+        if dstSubfolderSpec != rhs.dstSubfolderSpec { return false }
+        if name != rhs.name { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXFileElement {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXFileElement else { return false }
-      if self.sourceTree != rhs.sourceTree { return false }
-      if self.path != rhs.path { return false }
-      if self.name != rhs.name { return false }
-      if self.includeInIndex != rhs.includeInIndex { return false }
-      if self.usesTabs != rhs.usesTabs { return false }
-      if self.indentWidth != rhs.indentWidth { return false }
-      if self.tabWidth != rhs.tabWidth { return false }
-      if self.wrapsLines != rhs.wrapsLines { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXFileElement else { return false }
+        if sourceTree != rhs.sourceTree { return false }
+        if path != rhs.path { return false }
+        if name != rhs.name { return false }
+        if includeInIndex != rhs.includeInIndex { return false }
+        if usesTabs != rhs.usesTabs { return false }
+        if indentWidth != rhs.indentWidth { return false }
+        if tabWidth != rhs.tabWidth { return false }
+        if wrapsLines != rhs.wrapsLines { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXFileReference {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXFileReference else { return false }
-      if self.fileEncoding != rhs.fileEncoding { return false }
-      if self.explicitFileType != rhs.explicitFileType { return false }
-      if self.lastKnownFileType != rhs.lastKnownFileType { return false }
-      if self.lineEnding != rhs.lineEnding { return false }
-      if self.languageSpecificationIdentifier != rhs.languageSpecificationIdentifier { return false }
-      if self.xcLanguageSpecificationIdentifier != rhs.xcLanguageSpecificationIdentifier { return false }
-      if self.plistStructureDefinitionIdentifier != rhs.plistStructureDefinitionIdentifier { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXFileReference else { return false }
+        if fileEncoding != rhs.fileEncoding { return false }
+        if explicitFileType != rhs.explicitFileType { return false }
+        if lastKnownFileType != rhs.lastKnownFileType { return false }
+        if lineEnding != rhs.lineEnding { return false }
+        if languageSpecificationIdentifier != rhs.languageSpecificationIdentifier { return false }
+        if xcLanguageSpecificationIdentifier != rhs.xcLanguageSpecificationIdentifier { return false }
+        if plistStructureDefinitionIdentifier != rhs.plistStructureDefinitionIdentifier { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXFrameworksBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXFrameworksBuildPhase else { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXFrameworksBuildPhase else { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXGroup {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXGroup else { return false }
-      if self.childrenReferences != rhs.childrenReferences { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXGroup else { return false }
+        if childrenReferences != rhs.childrenReferences { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXHeadersBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXHeadersBuildPhase else { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXHeadersBuildPhase else { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXLegacyTarget {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXLegacyTarget else { return false }
-      if self.buildToolPath != rhs.buildToolPath { return false }
-      if self.buildArgumentsString != rhs.buildArgumentsString { return false }
-      if self.passBuildSettingsInEnvironment != rhs.passBuildSettingsInEnvironment { return false }
-      if self.buildWorkingDirectory != rhs.buildWorkingDirectory { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXLegacyTarget else { return false }
+        if buildToolPath != rhs.buildToolPath { return false }
+        if buildArgumentsString != rhs.buildArgumentsString { return false }
+        if passBuildSettingsInEnvironment != rhs.passBuildSettingsInEnvironment { return false }
+        if buildWorkingDirectory != rhs.buildWorkingDirectory { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXNativeTarget {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXNativeTarget else { return false }
-      if self.productInstallPath != rhs.productInstallPath { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXNativeTarget else { return false }
+        if productInstallPath != rhs.productInstallPath { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXProject {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXProject else { return false }
-      if self.name != rhs.name { return false }
-      if self.buildConfigurationListReference != rhs.buildConfigurationListReference { return false }
-      if self.compatibilityVersion != rhs.compatibilityVersion { return false }
-      if self.developmentRegion != rhs.developmentRegion { return false }
-      if self.hasScannedForEncodings != rhs.hasScannedForEncodings { return false }
-      if self.knownRegions != rhs.knownRegions { return false }
-      if self.mainGroupReference != rhs.mainGroupReference { return false }
-      if self.productsGroupReference != rhs.productsGroupReference { return false }
-      if self.projectDirPath != rhs.projectDirPath { return false }
-      if self.projectReferences != rhs.projectReferences { return false }
-      if self.projectRoots != rhs.projectRoots { return false }
-      if self.targetReferences != rhs.targetReferences { return false }
-      if !NSDictionary(dictionary: self.attributes ).isEqual(to: rhs.attributes ) { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXProject else { return false }
+        if name != rhs.name { return false }
+        if buildConfigurationListReference != rhs.buildConfigurationListReference { return false }
+        if compatibilityVersion != rhs.compatibilityVersion { return false }
+        if developmentRegion != rhs.developmentRegion { return false }
+        if hasScannedForEncodings != rhs.hasScannedForEncodings { return false }
+        if knownRegions != rhs.knownRegions { return false }
+        if mainGroupReference != rhs.mainGroupReference { return false }
+        if productsGroupReference != rhs.productsGroupReference { return false }
+        if projectDirPath != rhs.projectDirPath { return false }
+        if projectReferences != rhs.projectReferences { return false }
+        if projectRoots != rhs.projectRoots { return false }
+        if targetReferences != rhs.targetReferences { return false }
+        if !NSDictionary(dictionary: attributeReferences).isEqual(to: rhs.attributeReferences) { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXReferenceProxy {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXReferenceProxy else { return false }
-      if self.fileType != rhs.fileType { return false }
-      if self.path != rhs.path { return false }
-      if self.remoteReference != rhs.remoteReference { return false }
-      if self.sourceTree != rhs.sourceTree { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXReferenceProxy else { return false }
+        if fileType != rhs.fileType { return false }
+        if path != rhs.path { return false }
+        if remoteReference != rhs.remoteReference { return false }
+        if sourceTree != rhs.sourceTree { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXResourcesBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXResourcesBuildPhase else { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXResourcesBuildPhase else { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXRezBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXRezBuildPhase else { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXRezBuildPhase else { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXShellScriptBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXShellScriptBuildPhase else { return false }
-      if self.name != rhs.name { return false }
-      if self.inputPaths != rhs.inputPaths { return false }
-      if self.outputPaths != rhs.outputPaths { return false }
-      if self.shellPath != rhs.shellPath { return false }
-      if self.shellScript != rhs.shellScript { return false }
-      if self.showEnvVarsInLog != rhs.showEnvVarsInLog { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXShellScriptBuildPhase else { return false }
+        if name != rhs.name { return false }
+        if inputPaths != rhs.inputPaths { return false }
+        if outputPaths != rhs.outputPaths { return false }
+        if shellPath != rhs.shellPath { return false }
+        if shellScript != rhs.shellScript { return false }
+        if showEnvVarsInLog != rhs.showEnvVarsInLog { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXSourcesBuildPhase {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXSourcesBuildPhase else { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXSourcesBuildPhase else { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXTarget {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXTarget else { return false }
-      if self.buildConfigurationListReference != rhs.buildConfigurationListReference { return false }
-      if self.buildPhaseReferences != rhs.buildPhaseReferences { return false }
-      if self.buildRuleReferences != rhs.buildRuleReferences { return false }
-      if self.dependencyReferences != rhs.dependencyReferences { return false }
-      if self.name != rhs.name { return false }
-      if self.productName != rhs.productName { return false }
-      if self.productReference != rhs.productReference { return false }
-      if self.productType != rhs.productType { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXTarget else { return false }
+        if buildConfigurationListReference != rhs.buildConfigurationListReference { return false }
+        if buildPhaseReferences != rhs.buildPhaseReferences { return false }
+        if buildRuleReferences != rhs.buildRuleReferences { return false }
+        if dependencyReferences != rhs.dependencyReferences { return false }
+        if name != rhs.name { return false }
+        if productName != rhs.productName { return false }
+        if productReference != rhs.productReference { return false }
+        if productType != rhs.productType { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXTargetDependency {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXTargetDependency else { return false }
-      if self.name != rhs.name { return false }
-      if self.targetReference != rhs.targetReference { return false }
-      if self.targetProxyReference != rhs.targetProxyReference { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXTargetDependency else { return false }
+        if name != rhs.name { return false }
+        if targetReference != rhs.targetReference { return false }
+        if targetProxyReference != rhs.targetProxyReference { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension PBXVariantGroup {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? PBXVariantGroup else { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXVariantGroup else { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension XCBuildConfiguration {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? XCBuildConfiguration else { return false }
-      if self.baseConfigurationReference != rhs.baseConfigurationReference { return false }
-      if !NSDictionary(dictionary: self.buildSettings ).isEqual(to: rhs.buildSettings ) { return false }
-      if self.name != rhs.name { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? XCBuildConfiguration else { return false }
+        if baseConfigurationReference != rhs.baseConfigurationReference { return false }
+        if !NSDictionary(dictionary: buildSettings).isEqual(to: rhs.buildSettings) { return false }
+        if name != rhs.name { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension XCConfigurationList {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? XCConfigurationList else { return false }
-      if self.buildConfigurationReferences != rhs.buildConfigurationReferences { return false }
-      if self.defaultConfigurationIsVisible != rhs.defaultConfigurationIsVisible { return false }
-      if self.defaultConfigurationName != rhs.defaultConfigurationName { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? XCConfigurationList else { return false }
+        if buildConfigurationReferences != rhs.buildConfigurationReferences { return false }
+        if defaultConfigurationIsVisible != rhs.defaultConfigurationIsVisible { return false }
+        if defaultConfigurationName != rhs.defaultConfigurationName { return false }
+        return super.isEqual(to: rhs)
     }
 }
+
 extension XCVersionGroup {
     /// :nodoc:
-    @objc override public func isEqual(to object: Any?) -> Bool {
-      guard let rhs = object as? XCVersionGroup else { return false }
-      if self.currentVersionReference != rhs.currentVersionReference { return false }
-      if self.versionGroupType != rhs.versionGroupType { return false }
-      return super.isEqual(to: rhs)
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? XCVersionGroup else { return false }
+        if currentVersionReference != rhs.currentVersionReference { return false }
+        if versionGroupType != rhs.versionGroupType { return false }
+        return super.isEqual(to: rhs)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/288

### Short description 📝
As @yonaskolb pointed out, after introducing object reference with xcodeproj 5, it was not possible to update the target attributes. The property depended on the object reference value being public, which we intentionally made internal.

### Solution 📦
- Make the `attributes` property internal.
- Expose three methods to set, remove, and read the attributes given a target.