### PR TITLE
Some fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## next version
 
+### Changed
+- **Breaking** Change `PBXBuildFile.file` attribute to be of type `PBXFileElement` https://github.com/tuist/xcodeproj/pull/297 by @pepibumur.
+
+### Added
+- Add `PBXBuildPhase.add(file:)` method that takes a file element and returns a build file https://github.com/tuist/xcodeproj/pull/297 by @pepibumur.
+- Add `PBXProj.rootObject` attribute https://github.com/tuist/xcodeproj/pull/297 by @pepibumur.
+
+### Fixed
+- `XCBuildConfiguration.baseConfiguration` type https://github.com/tuist/xcodeproj/pull/297 @pepibumur.
+
 ## 5.1.0
 
 ### Added

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -9,7 +9,7 @@ public final class PBXBuildFile: PBXObject {
     public var fileReference: PBXObjectReference?
 
     /// Returns the file the build file refers to.
-    public var file: PBXFileReference? {
+    public var file: PBXFileElement? {
         get {
             // swiftlint:disable:next force_try
             return try! fileReference?.object()
@@ -42,7 +42,7 @@ public final class PBXBuildFile: PBXObject {
     /// - Parameters:
     ///   - file: file the build file refers to.
     ///   - settings: build file settings.
-    public convenience init(file: PBXFileReference,
+    public convenience init(file: PBXFileElement,
                             settings: [String: Any]? = nil) {
         self.init(fileReference: file.reference,
                   settings: settings)

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
@@ -107,6 +107,7 @@ public extension PBXBuildPhase {
     /// - Parameter reference: reference to the file element.
     /// - Returns: reference to the build file added to the build phase.
     /// - Throws: an error if the reference cannot be added
+    @available(*, deprecated, renamed: "add(file:)")
     public func addFile(_ reference: PBXObjectReference) throws -> PBXObjectReference {
         if let existing = try fileReferences.compactMap({ try $0.object() as PBXBuildFile }).first(where: { $0.fileReference == reference }) {
             return existing.reference
@@ -116,6 +117,22 @@ public extension PBXBuildPhase {
         let buildFileReference = projectObjects.addObject(buildFile)
         fileReferences.append(buildFileReference)
         return buildFileReference
+    }
+
+    /// Adds a file to a build phase, creating a proxy build file that points to the given file element.
+    ///
+    /// - Parameter file: file element to be added to the build phase.
+    /// - Returns: proxy build file.
+    /// - Throws: an error if the file cannot be added.
+    public func add(file: PBXFileElement) throws -> PBXBuildFile {
+        if let existing = try files.first(where: { $0.fileReference == reference }) {
+            return existing
+        }
+        let projectObjects = try objects()
+        let buildFile = PBXBuildFile(file: file)
+        projectObjects.add(object: buildFile)
+        files.append(buildFile)
+        return buildFile
     }
 }
 

--- a/Sources/xcodeproj/Objects/Configuration/XCBuildConfiguration.swift
+++ b/Sources/xcodeproj/Objects/Configuration/XCBuildConfiguration.swift
@@ -4,12 +4,12 @@ import Foundation
 public final class XCBuildConfiguration: PBXObject {
     // MARK: - Attributes
 
-    /// The path to a xcconfig file
+    /// Base xcconfig file reference.
     @available(*, deprecated, message: "Use baseConfiguration instead")
     public var baseConfigurationReference: PBXObjectReference?
 
-    /// Base configuration
-    public var baseConfiguration: XCBuildConfiguration? {
+    /// Base xcconfig file reference.
+    public var baseConfiguration: PBXFileReference? {
         get {
             // swiftlint:disable:next force_try
             return baseConfigurationReference.flatMap({ try! $0.object() })

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -23,10 +23,10 @@ public final class PBXProj: Decodable {
     /// Project root object.
     public var rootObject: PBXProject? {
         set {
-            // swiftlint:disable:next force_try
             rootObjectReference = rootObject?.reference
         }
         get {
+            // swiftlint:disable:next force_try
             return try! rootObjectReference?.object()
         }
     }

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -17,7 +17,18 @@ public final class PBXProj: Decodable {
     public var classes: [String: Any]
 
     /// Project root object.
+    @available(*, deprecated, message: "Use rootObject instead")
     public var rootObjectReference: PBXObjectReference?
+
+    /// Project root object.
+    public var rootObject: PBXProject? {
+        set {
+            rootObjectReference = rootObject?.reference
+        }
+        get {
+            return try! rootObjectReference?.object()
+        }
+    }
 
     /// Initializes the project with its attributes.
     ///
@@ -37,6 +48,26 @@ public final class PBXProj: Decodable {
         self.classes = classes
         self.rootObjectReference = rootObjectReference
         self.objects = PBXObjects(objects: objects)
+    }
+
+    /// Initializes the project with its attributes.
+    ///
+    /// - Parameters:
+    ///   - rootObject: project root object.
+    ///   - objectVersion: project object version.
+    ///   - archiveVersion: project archive version.
+    ///   - classes: project classes.
+    ///   - objects: project objects
+    public convenience init(rootObject: PBXProject? = nil,
+                            objectVersion: UInt = 0,
+                            archiveVersion: UInt = 1,
+                            classes: [String: Any] = [:],
+                            objects: [PBXObject] = []) {
+        self.init(rootObjectReference: rootObject?.reference,
+                  objectVersion: objectVersion,
+                  archiveVersion: archiveVersion,
+                  classes: classes,
+                  objects: objects)
     }
 
     // MARK: - Decodable

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -23,6 +23,7 @@ public final class PBXProj: Decodable {
     /// Project root object.
     public var rootObject: PBXProject? {
         set {
+            // swiftlint:disable:next force_try
             rootObjectReference = rootObject?.reference
         }
         get {


### PR DESCRIPTION
### Description 📝
- Change `PBXBuildFile.file` attribute to be of type `PBXFileElement`.
- Add `PBXBuildPhase.add(file:)` method that takes a file element and returns a build file.
- Add `PBXProj.rootObject` attribute.
- Fix `XCBuildConfiguration.baseConfiguration` type.