### PR TITLE
Add a CI step to build the release configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           command: |
             swiftlint
       - run:
+          name: Release build
+          command: |
+            swift build -c release
+      - run:
           name: Run tests
           command: |
             swift package generate-xcodeproj


### PR DESCRIPTION
### Short description 📝
We could have caught the compilation issue by building the project with the release configuration on CI.

### Solution 📦
Add a new step on the CI pipeline to build the project for release.
