### PR TITLE
Add union merge for CHANGELOG

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG merge=union


### PR DESCRIPTION
This makes git use a union merge strategy for CHANGELOG.
This will cut down on merge conflicts. Please merge this before #315 and #316