### PR TITLE
Sorting XML attributes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-package-manager",
         "state": {
           "branch": null,
-          "revision": "6983434787dec4e543e9d398a0a9acf63ccd4da1",
-          "version": "0.2.1"
+          "revision": "235aacc514cb81a6881364b0fedcb3dd083228f3",
+          "version": "0.3.0"
         }
       }
     ]

--- a/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
@@ -10,6 +10,10 @@ extension AEXMLDocument {
 }
 
 let attributesOrder: [String: [String]] = [
+    "BuildAction": [
+        "parallelizeBuildables",
+        "buildImplicitDependencies",
+    ],
     "BuildActionEntry": [
         "buildForTesting",
         "buildForRunning",
@@ -74,21 +78,24 @@ extension AEXMLElement {
         xml += indent(withDepth: parentsCount - 1)
         xml += "<\(name)"
 
+        func print(key: String, value: String) {
+            xml += "\n"
+            xml += indent(withDepth: parentsCount)
+            xml += "\(key) = \"\(value.xmlEscaped)\""
+        }
+
         if attributes.count > 0 {
-            // insert attributes
+            // insert known attributes in the specified order.
             var attributes = self.attributes
             for key in attributesOrder[self.name] ?? [] {
                 if let value = attributes.removeValue(forKey: key) {
-                    xml += "\n"
-                    xml += indent(withDepth: parentsCount)
-                    xml += "\(key) = \"\(value.xmlEscaped)\""
+                    print(key: key, value: value)
                 }
             }
 
-            for (key, value) in attributes.sorted(by: { $0.key < $1.key }) /* Sorted to avoid uncessary file changes. */ {
-                xml += "\n"
-                xml += indent(withDepth: parentsCount)
-                xml += "\(key) = \"\(value.xmlEscaped)\""
+            // Print any remaining attributes.
+            for (key, value) in attributes {
+                print(key: key, value: value)
             }
         }
 

--- a/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
@@ -85,7 +85,7 @@ extension AEXMLElement {
                 }
             }
 
-            for (key, value) in attributes {
+            for (key, value) in attributes.sorted(by: { $0.key < $1.key }) /* Sorted to avoid uncessary file changes. */ {
                 xml += "\n"
                 xml += indent(withDepth: parentsCount)
                 xml += "\(key) = \"\(value.xmlEscaped)\""

--- a/Tests/xcodeprojTests/Extensions/AEXML+XcodeFormatTests.swift
+++ b/Tests/xcodeprojTests/Extensions/AEXML+XcodeFormatTests.swift
@@ -5,9 +5,7 @@ import AEXML
 
 extension String {
     var cleaned: String {
-        return self
-            .replacingOccurrences(of: "\n", with: "")
-            .replacingOccurrences(of: "   ", with: "")
+        return self.replacingOccurrences(of: "   ", with: "").components(separatedBy: "\n").filter { !$0.isEmpty }.joined(separator: " ")
     }
 }
 
@@ -16,29 +14,29 @@ class AEXML_XcodeFormatTests: XCTestCase {
     private let expectedXml =
     """
     <?xml version="1.0" encoding="UTF-8"?>
-    <child
-       abc = "123"
-       def = "456">
-    </child>
+    <BuildAction
+       parallelizeBuildables = "YES"
+       buildImplicitDependencies = "NO">
+    </BuildAction>
     """
 
-    func test_elements_are_sorted_when_original_sorted() {
+    func test_BuildAction_attributes_sorted_when_original_sorted() {
         validateAttributes(attributes: [
-            "abc": "123",
-            "def": "456",
+            "parallelizeBuildables": "YES",
+            "buildImplicitDependencies": "NO",
             ])
     }
 
-    func test_elements_are_sorted_when_original_unsorted() {
+    func test_BuildAction_attributes_sorted_when_original_unsorted() {
         validateAttributes(attributes: [
-            "def": "456",
-            "abc": "123",
+            "buildImplicitDependencies": "NO",
+            "parallelizeBuildables": "YES",
         ])
     }
 
-    func validateAttributes(attributes: [String:String], line: UInt = #line) {
+    func validateAttributes(attributes: [String: String], line: UInt = #line) {
         let document = AEXMLDocument()
-        let child = document.addChild(name: "child")
+        let child = document.addChild(name: "BuildAction")
         child.attributes = attributes
         let result = document.xmlXcodeFormat
         XCTAssertEqual(expectedXml.cleaned, result.cleaned, line: line)

--- a/Tests/xcodeprojTests/Extensions/AEXML+XcodeFormatTests.swift
+++ b/Tests/xcodeprojTests/Extensions/AEXML+XcodeFormatTests.swift
@@ -1,0 +1,46 @@
+
+import XCTest
+@testable import xcodeproj
+import AEXML
+
+extension String {
+    var cleaned: String {
+        return self
+            .replacingOccurrences(of: "\n", with: "")
+            .replacingOccurrences(of: "   ", with: "")
+    }
+}
+
+class AEXML_XcodeFormatTests: XCTestCase {
+
+    private let expectedXml =
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <child
+       abc = "123"
+       def = "456">
+    </child>
+    """
+
+    func test_elements_are_sorted_when_original_sorted() {
+        validateAttributes(attributes: [
+            "abc": "123",
+            "def": "456",
+            ])
+    }
+
+    func test_elements_are_sorted_when_original_unsorted() {
+        validateAttributes(attributes: [
+            "def": "456",
+            "abc": "123",
+        ])
+    }
+
+    func validateAttributes(attributes: [String:String], line: UInt = #line) {
+        let document = AEXMLDocument()
+        let child = document.addChild(name: "child")
+        child.attributes = attributes
+        let result = document.xmlXcodeFormat
+        XCTAssertEqual(expectedXml.cleaned, result.cleaned, line: line)
+    }
+}


### PR DESCRIPTION
Found that every times I saved a test project, that the order of the attributes in the schemes were changing. This resulted in Git thinking the files had changed when in fact they hadn't as the attribute values were the same. 

This PR sorts the XML attributes when writing XML files. This ensures that (after the first time), the attributes will always be in the same order and therefore the file will not be seen as changed unless an actual value changes.