### PR TITLE
Add OSLogs to facilitate measuring times with Instruments

### DIFF
--- a/Sources/xcodeproj/Extensions/OSLog+Extras.swift
+++ b/Sources/xcodeproj/Extensions/OSLog+Extras.swift
@@ -1,0 +1,13 @@
+import Foundation
+import os.signpost
+
+extension OSLog {
+    @available(OSX 10.12, *)
+    /// Returns an instance of OSLog with the default xcodeproj subsystem.
+    ///
+    /// - Parameter category: Category the OSLog should be initialized with.
+    /// - Returns: Initialized OSLog.
+    static func xcodeproj(category: String) -> OSLog {
+        return OSLog(subsystem: "io.tuist.xcodeproj", category: category)
+    }
+}

--- a/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
@@ -128,7 +128,7 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
     /// - Returns: object the reference is referring to.
     /// - Throws: an errof it the objects property has been released or the reference doesn't exist.
     func getThrowingObject<T: PBXObject>() throws -> T {
-        return try OSLogger.instance.log(category: String(describing: self), name: "Materialize Object") {
+        return try OSLogger.instance.log(category: #file, name: "Materialize Object") {
           if let object = object as? T {
               return object
           }

--- a/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
@@ -128,7 +128,7 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
     /// - Returns: object the reference is referring to.
     /// - Throws: an errof it the objects property has been released or the reference doesn't exist.
     func getThrowingObject<T: PBXObject>() throws -> T {
-        return try OSLogger.instance.log(category: #file, name: "Materialize Object") {
+        return try OSLogger.instance.log(name: "Materialize Object") {
           if let object = object as? T {
               return object
           }

--- a/Sources/xcodeproj/Project/XcodeProj.swift
+++ b/Sources/xcodeproj/Project/XcodeProj.swift
@@ -21,7 +21,7 @@ public final class XcodeProj: Equatable {
         var workspace: XCWorkspace!
         var sharedData: XCSharedData?
 
-        try OSLogger.instance.log(category: #file, name: "Write workspace", path.asString) {
+        try OSLogger.instance.log(name: "Write workspace", path.asString) {
             if !path.exists { throw XCodeProjError.notFound(path: path) }
             let pbxprojPaths = path.glob("*.pbxproj")
             if pbxprojPaths.count == 0 {
@@ -91,16 +91,16 @@ extension XcodeProj: Writable {
     ///   If false will throw error if project already exists at the given path.
     public func write(path: AbsolutePath, override: Bool = true, outputSettings: PBXOutputSettings) throws {
         try path.mkpath()
-        try OSLogger.instance.log(category: #file, name: "Write workspace", path.asString) {
+        try OSLogger.instance.log(name: "Write workspace", path.asString) {
             try writeWorkspace(path: path, override: override)
         }
-        try OSLogger.instance.log(category: #file, name: "Write pbxproj", path.asString) {
+        try OSLogger.instance.log(name: "Write pbxproj", path.asString) {
             try writePBXProj(path: path, override: override, outputSettings: outputSettings)
         }
-        try OSLogger.instance.log(category: #file, name: "Write schemes", path.asString) {
+        try OSLogger.instance.log(name: "Write schemes", path.asString) {
             try writeSchemes(path: path, override: override)
         }
-        try OSLogger.instance.log(category: #file, name: "Write breakpoints", path.asString) {
+        try OSLogger.instance.log(name: "Write breakpoints", path.asString) {
             try writeBreakPoints(path: path, override: override)
         }
     }

--- a/Sources/xcodeproj/Project/XcodeProj.swift
+++ b/Sources/xcodeproj/Project/XcodeProj.swift
@@ -21,7 +21,7 @@ public final class XcodeProj: Equatable {
         var workspace: XCWorkspace!
         var sharedData: XCSharedData?
 
-        try OSLogger.instance.log(category: "XcodeProj", name: "Write workspace", path.asString) {
+        try OSLogger.instance.log(category: #file, name: "Write workspace", path.asString) {
             if !path.exists { throw XCodeProjError.notFound(path: path) }
             let pbxprojPaths = path.glob("*.pbxproj")
             if pbxprojPaths.count == 0 {
@@ -91,16 +91,16 @@ extension XcodeProj: Writable {
     ///   If false will throw error if project already exists at the given path.
     public func write(path: AbsolutePath, override: Bool = true, outputSettings: PBXOutputSettings) throws {
         try path.mkpath()
-        try OSLogger.instance.log(category: String(describing: self), name: "Write workspace", path.asString) {
+        try OSLogger.instance.log(category: #file, name: "Write workspace", path.asString) {
             try writeWorkspace(path: path, override: override)
         }
-        try OSLogger.instance.log(category: String(describing: self), name: "Write pbxproj", path.asString) {
+        try OSLogger.instance.log(category: #file, name: "Write pbxproj", path.asString) {
             try writePBXProj(path: path, override: override, outputSettings: outputSettings)
         }
-        try OSLogger.instance.log(category: String(describing: self), name: "Write schemes", path.asString) {
+        try OSLogger.instance.log(category: #file, name: "Write schemes", path.asString) {
             try writeSchemes(path: path, override: override)
         }
-        try OSLogger.instance.log(category: String(describing: self), name: "Write breakpoints", path.asString) {
+        try OSLogger.instance.log(category: #file, name: "Write breakpoints", path.asString) {
             try writeBreakPoints(path: path, override: override)
         }
     }

--- a/Sources/xcodeproj/Project/XcodeProj.swift
+++ b/Sources/xcodeproj/Project/XcodeProj.swift
@@ -17,24 +17,34 @@ public final class XcodeProj: Equatable {
     // MARK: - Init
 
     public init(path: AbsolutePath) throws {
-        if !path.exists { throw XCodeProjError.notFound(path: path) }
-        let pbxprojPaths = path.glob("*.pbxproj")
-        if pbxprojPaths.count == 0 {
-            throw XCodeProjError.pbxprojNotFound(path: path)
+        var pbxproj: PBXProj!
+        var workspace: XCWorkspace!
+        var sharedData: XCSharedData?
+
+        try OSLogger.instance.log(category: "XcodeProj", name: "Write workspace", path.asString) {
+            if !path.exists { throw XCodeProjError.notFound(path: path) }
+            let pbxprojPaths = path.glob("*.pbxproj")
+            if pbxprojPaths.count == 0 {
+                throw XCodeProjError.pbxprojNotFound(path: path)
+            }
+            let pbxProjData = try Data(contentsOf: pbxprojPaths.first!.url)
+            let context = ProjectDecodingContext()
+            let plistDecoder = XcodeprojPropertyListDecoder(context: context)
+            pbxproj = try plistDecoder.decode(PBXProj.self, from: pbxProjData)
+            try pbxproj.updateProjectName(path: pbxprojPaths.first!)
+            let xcworkspacePaths = path.glob("*.xcworkspace")
+            if xcworkspacePaths.count == 0 {
+                workspace = XCWorkspace()
+            } else {
+                workspace = try XCWorkspace(path: xcworkspacePaths.first!)
+            }
+            let sharedDataPath = path.appending(component: "xcshareddata")
+            sharedData = try? XCSharedData(path: sharedDataPath)
         }
-        let pbxProjData = try Data(contentsOf: pbxprojPaths.first!.url)
-        let context = ProjectDecodingContext()
-        let plistDecoder = XcodeprojPropertyListDecoder(context: context)
-        pbxproj = try plistDecoder.decode(PBXProj.self, from: pbxProjData)
-        try pbxproj.updateProjectName(path: pbxprojPaths.first!)
-        let xcworkspacePaths = path.glob("*.xcworkspace")
-        if xcworkspacePaths.count == 0 {
-            workspace = XCWorkspace()
-        } else {
-            workspace = try XCWorkspace(path: xcworkspacePaths.first!)
-        }
-        let sharedDataPath = path.appending(component: "xcshareddata")
-        sharedData = try? XCSharedData(path: sharedDataPath)
+
+        self.pbxproj = pbxproj
+        self.workspace = workspace
+        self.sharedData = sharedData
     }
 
     public convenience init(pathString: String) throws {
@@ -81,10 +91,18 @@ extension XcodeProj: Writable {
     ///   If false will throw error if project already exists at the given path.
     public func write(path: AbsolutePath, override: Bool = true, outputSettings: PBXOutputSettings) throws {
         try path.mkpath()
-        try writeWorkspace(path: path, override: override)
-        try writePBXProj(path: path, override: override, outputSettings: outputSettings)
-        try writeSchemes(path: path, override: override)
-        try writeBreakPoints(path: path, override: override)
+        try OSLogger.instance.log(category: String(describing: self), name: "Write workspace", path.asString) {
+            try writeWorkspace(path: path, override: override)
+        }
+        try OSLogger.instance.log(category: String(describing: self), name: "Write pbxproj", path.asString) {
+            try writePBXProj(path: path, override: override, outputSettings: outputSettings)
+        }
+        try OSLogger.instance.log(category: String(describing: self), name: "Write schemes", path.asString) {
+            try writeSchemes(path: path, override: override)
+        }
+        try OSLogger.instance.log(category: String(describing: self), name: "Write breakpoints", path.asString) {
+            try writeBreakPoints(path: path, override: override)
+        }
     }
 
     /// Returns workspace file path relative to the given path.

--- a/Sources/xcodeproj/Scheme/XCScheme+BuildableReference.swift
+++ b/Sources/xcodeproj/Scheme/XCScheme+BuildableReference.swift
@@ -13,8 +13,8 @@ extension XCScheme {
 
             var string: String {
                 switch self {
-                case .reference(let object): return object.value
-                case .string(let string): return string
+                case let .reference(object): return object.value
+                case let .string(string): return string
                 }
             }
         }
@@ -65,7 +65,7 @@ extension XCScheme {
                 throw XCSchemeError.missing(property: "ReferencedContainer")
             }
             self.buildableIdentifier = buildableIdentifier
-            self.blueprint = .string(blueprintIdentifier)
+            blueprint = .string(blueprintIdentifier)
             self.buildableName = buildableName
             self.blueprintName = blueprintName
             self.referencedContainer = referencedContainer

--- a/Sources/xcodeproj/Utils/OSLogger.swift
+++ b/Sources/xcodeproj/Utils/OSLogger.swift
@@ -16,7 +16,7 @@ class OSLogger {
     ///   - arguments: Arguments to be passed to the function.
     ///   - closure: Piece of code that will be logged.
     /// - Throws: An error if the given closure throws.
-    func log(category: String, name: StaticString, _ arguments: CVarArg..., closure: () throws -> Void) throws {
+    func log(category: String = #file, name: StaticString, _ arguments: CVarArg..., closure: () throws -> Void) throws {
         if !shouldLog {
             try closure()
             return
@@ -56,7 +56,7 @@ class OSLogger {
     ///   - closure: Piece of code that will be logged.
     /// - Returns: The value returned by the closure.
     /// - Throws: An error if the given closure throws.
-    func log<T>(category: String, name: StaticString, _ arguments: CVarArg..., closure: () throws -> T) throws -> T {
+    func log<T>(category: String = #file, name: StaticString, _ arguments: CVarArg..., closure: () throws -> T) throws -> T {
         if !shouldLog {
             return try closure()
         }

--- a/Sources/xcodeproj/Utils/OSLogger.swift
+++ b/Sources/xcodeproj/Utils/OSLogger.swift
@@ -1,0 +1,95 @@
+import Foundation
+import os.signpost
+
+/// OSLog wrapper that runs logging functions if logging is enabled through
+/// environment variables and the feature is available in the system where
+/// the user is using the project.
+class OSLogger {
+    /// Shared instance of OSLogger
+    static var instance: OSLogger = OSLogger()
+
+    /// Logs when the given closure starts and ends.
+    ///
+    /// - Parameters:
+    ///   - category: Category of the code being logged. For example, if it's a function in PBXObjectReference, that can be the category.
+    ///   - name: Name for the code being logged. If we are logging the time it takes to write a project, the name can be "Project Writing"
+    ///   - arguments: Arguments to be passed to the function.
+    ///   - closure: Piece of code that will be logged.
+    /// - Throws: An error if the given closure throws.
+    func log(category: String, name: StaticString, _ arguments: CVarArg..., closure: () throws -> Void) throws {
+        if !shouldLog {
+            try closure()
+            return
+        }
+
+        if #available(OSX 10.14, *) {
+            let log: OSLog = OSLog.xcodeproj(category: category)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.begin,
+                        log: log,
+                        name: name,
+                        signpostID: signpostID,
+                        "%{public}s",
+                        arguments)
+        }
+
+        try closure()
+
+        if #available(OSX 10.14, *) {
+            let log: OSLog = OSLog.xcodeproj(category: category)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.end,
+                        log: log,
+                        name: name,
+                        signpostID: signpostID,
+                        "%{public}s",
+                        arguments)
+        }
+    }
+
+    /// Logs when the given closure starts and ends.
+    ///
+    /// - Parameters:
+    ///   - category: Category of the code being logged. For example, if it's a function in PBXObjectReference, that can be the category.
+    ///   - name: Name for the code being logged. If we are logging the time it takes to write a project, the name can be "Project Writing"
+    ///   - arguments: Arguments to be passed to the function.
+    ///   - closure: Piece of code that will be logged.
+    /// - Returns: The value returned by the closure.
+    /// - Throws: An error if the given closure throws.
+    func log<T>(category: String, name: StaticString, _ arguments: CVarArg..., closure: () throws -> T) throws -> T {
+        if !shouldLog {
+            return try closure()
+        }
+
+        if #available(OSX 10.14, *) {
+            let log: OSLog = OSLog.xcodeproj(category: category)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.begin,
+                        log: log,
+                        name: name,
+                        signpostID: signpostID,
+                        "%{public}s",
+                        arguments)
+        }
+
+        let result = try closure()
+
+        if #available(OSX 10.14, *) {
+            let log: OSLog = OSLog.xcodeproj(category: category)
+            let signpostID = OSSignpostID(log: log)
+            os_signpost(.end,
+                        log: log,
+                        name: name,
+                        signpostID: signpostID,
+                        "%{public}s",
+                        arguments)
+        }
+
+        return result
+    }
+
+    /// Returns true if the XCODEPROJ_OSLOG environment variable is defined in the environment.
+    lazy var shouldLog: Bool = {
+        ProcessInfo.processInfo.environment["XCODEPROJ_OSLOG"] != nil
+    }()
+}

--- a/Tests/xcodeprojTests/Extensions/AEXML+XcodeFormatTests.swift
+++ b/Tests/xcodeprojTests/Extensions/AEXML+XcodeFormatTests.swift
@@ -1,30 +1,29 @@
 
-import XCTest
-@testable import xcodeproj
 import AEXML
+@testable import xcodeproj
+import XCTest
 
 extension String {
     var cleaned: String {
-        return self.replacingOccurrences(of: "   ", with: "").components(separatedBy: "\n").filter { !$0.isEmpty }.joined(separator: " ")
+        return replacingOccurrences(of: "   ", with: "").components(separatedBy: "\n").filter { !$0.isEmpty }.joined(separator: " ")
     }
 }
 
 class AEXML_XcodeFormatTests: XCTestCase {
-
     private let expectedXml =
-    """
-    <?xml version="1.0" encoding="UTF-8"?>
-    <BuildAction
-       parallelizeBuildables = "YES"
-       buildImplicitDependencies = "NO">
-    </BuildAction>
-    """
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <BuildAction
+           parallelizeBuildables = "YES"
+           buildImplicitDependencies = "NO">
+        </BuildAction>
+        """
 
     func test_BuildAction_attributes_sorted_when_original_sorted() {
         validateAttributes(attributes: [
             "parallelizeBuildables": "YES",
             "buildImplicitDependencies": "NO",
-            ])
+        ])
     }
 
     func test_BuildAction_attributes_sorted_when_original_unsorted() {

--- a/Tests/xcodeprojTests/Objects/Project/PBXOutputSettingsTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXOutputSettingsTests.swift
@@ -1,9 +1,8 @@
 
-import XCTest
 @testable import xcodeproj
+import XCTest
 
 class PBXOutputSettingsTsts: XCTestCase {
-
     var proj: PBXProj!
     var buildFileAssets: PBXBuildFile!
     var buildFileMain: PBXBuildFile!
@@ -53,7 +52,6 @@ class PBXOutputSettingsTsts: XCTestCase {
         objectGroupProducts = (groupProducts.reference, groupProducts)
 
         navigatorFileGroup = proj.groups.first { $0.fileName() == "iOS" }!
-
     }
 
     // MARK: - PBXFileOrder - PBXBuldFile
@@ -140,7 +138,7 @@ class PBXOutputSettingsTsts: XCTestCase {
             "Protected.h",
             "Public.h",
             "ViewController.swift",
-            ], sorted)
+        ], sorted)
     }
 
     func test_PBXNavigatorFileOrder_by_filename_groups_first() {
@@ -158,7 +156,7 @@ class PBXOutputSettingsTsts: XCTestCase {
             "Protected.h",
             "Public.h",
             "ViewController.swift",
-            ], sorted)
+        ], sorted)
     }
 
     // MARK: - PBXBuildPhaseFileOrder
@@ -171,5 +169,4 @@ class PBXOutputSettingsTsts: XCTestCase {
         XCTAssertTrue(PBXBuildPhaseFileOrder.byFilename.sort!(buildFileAssets, buildFileMain))
         XCTAssertFalse(PBXBuildPhaseFileOrder.byFilename.sort!(buildFileMain, buildFileAssets))
     }
-
 }

--- a/Tests/xcodeprojTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProjectTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class PBXProjectTests: XCTestCase {
-
     func test_attributes() throws {
         let target = PBXTarget(name: "")
         target.reference.fix("test")


### PR DESCRIPTION
### Short description 📝
I've added some logs using the new `os_signpost` to help track down performance bottlenecks.

### Solution 📦
Add a `OSLogger` class that logs only if the `XCODEPROJ_OSLOG` environment variable is defined , and the API is available in the OS.

I added some logs in the reading and writing functions.