### PR TITLE
Sort xml attributes

### DIFF
--- a/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
@@ -94,7 +94,7 @@ extension AEXMLElement {
             }
 
             // Print any remaining attributes.
-            for (key, value) in attributes {
+            for (key, value) in attributes.sorted(by: { $0.key < $1.key }) {
                 print(key: key, value: value)
             }
         }


### PR DESCRIPTION
This re-introduces the sorting from #325.

When this is sorted it seems to matches the default sorting of Swift 4. Without this fields like `buildConfiguration` and `revealArchiveInOrganizer` get sorted incorrectly randomly by Swift 4.2 and causes a diff when writing a scheme.