### PR TITLE
Reference updates

### DIFF
--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -10,9 +10,7 @@ public final class PBXBuildFile: PBXObject {
     /// Returns the file the build file refers to.
     public var file: PBXFileElement? {
         get {
-            return fileReference.flatMap { (reference) -> PBXFileElement? in
-                try? reference.object()
-            }
+            return fileReference?.object()
         }
         set {
             fileReference = newValue?.reference
@@ -63,8 +61,8 @@ extension PBXBuildFile {
     /// - Returns: file name.
     /// - Throws: an error if the name cannot be obtained.
     func fileName() throws -> String? {
-        guard let fileElement: PBXFileElement? = try? fileReference?.object() else { return nil }
-        return fileElement?.fileName()
+        guard let fileElement: PBXFileElement = fileReference?.object() else { return nil }
+        return fileElement.fileName()
     }
 
     /// Returns the type of the build phase the build file belongs to.
@@ -118,7 +116,7 @@ extension PBXBuildFile: PlistSerializable {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(PBXBuildFile.isa))
         if let fileReference = fileReference {
-            let fileElement: PBXFileElement? = try? fileReference.object()
+            let fileElement: PBXFileElement? = fileReference.object()
             dictionary["fileRef"] = .string(CommentedString(fileReference.value, comment: fileElement?.fileName()))
         }
         if let settings = settings {

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
@@ -85,7 +85,7 @@ public class PBXBuildPhase: PBXContainerItem {
         var dictionary = try super.plistValues(proj: proj, reference: reference)
         dictionary["buildActionMask"] = .string(CommentedString("\(buildActionMask)"))
         let files: PlistValue = .array(fileReferences.map { fileReference in
-            let buildFile: PBXBuildFile? = try? fileReference.object()
+            let buildFile: PBXBuildFile? = fileReference.object()
             let name = buildFile.flatMap { try? $0.fileName() } ?? nil
             let fileName: String = name ?? "(null)"
             let type = self.name()

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
@@ -14,10 +14,10 @@ public class PBXBuildPhase: PBXContainerItem {
     /// Build files.
     public var files: [PBXBuildFile] {
         get {
-            return fileReferences.compactMap({ try? $0.object() })
+            return fileReferences.objects()
         }
         set {
-            fileReferences = newValue.map({ $0.reference })
+            fileReferences = newValue.references()
         }
     }
 
@@ -50,7 +50,7 @@ public class PBXBuildPhase: PBXContainerItem {
                 outputFileListPaths: [String]? = nil,
                 buildActionMask: UInt = defaultBuildActionMask,
                 runOnlyForDeploymentPostprocessing: Bool = false) {
-        fileReferences = files.map({ $0.reference })
+        fileReferences = files.references()
         self.inputFileListPaths = inputFileListPaths
         self.outputFileListPaths = outputFileListPaths
         self.buildActionMask = buildActionMask

--- a/Sources/xcodeproj/Objects/Configuration/XCBuildConfiguration.swift
+++ b/Sources/xcodeproj/Objects/Configuration/XCBuildConfiguration.swift
@@ -10,9 +10,7 @@ public final class XCBuildConfiguration: PBXObject {
     /// Base xcconfig file reference.
     public var baseConfiguration: PBXFileReference? {
         get {
-            return baseConfigurationReference.flatMap { (reference) -> PBXFileReference? in
-                try? reference.object()
-            }
+            return baseConfigurationReference?.object()
         }
         set {
             if let newValue = newValue {
@@ -76,7 +74,7 @@ extension XCBuildConfiguration: PlistSerializable {
         dictionary["name"] = .string(CommentedString(name))
         dictionary["buildSettings"] = buildSettings.plist()
         if let baseConfigurationReference = baseConfigurationReference {
-            let fileElement: PBXFileElement? = try? baseConfigurationReference.object()
+            let fileElement: PBXFileElement? = baseConfigurationReference.object()
             dictionary["baseConfigurationReference"] = .string(CommentedString(baseConfigurationReference.value, comment: fileElement?.fileName()))
         }
         return (key: CommentedString(reference, comment: name), value: .dictionary(dictionary))

--- a/Sources/xcodeproj/Objects/Configuration/XCConfigurationList.swift
+++ b/Sources/xcodeproj/Objects/Configuration/XCConfigurationList.swift
@@ -111,7 +111,7 @@ extension XCConfigurationList: PlistSerializable {
         dictionary["isa"] = .string(CommentedString(XCConfigurationList.isa))
         dictionary["buildConfigurations"] = .array(buildConfigurationReferences
             .map { configReference in
-                let config: XCBuildConfiguration? = try? configReference.object()
+                let config: XCBuildConfiguration? = configReference.object()
                 return .string(CommentedString(configReference.value, comment: config?.name))
         })
         dictionary["defaultConfigurationIsVisible"] = .string(CommentedString("\(defaultConfigurationIsVisible.int)"))

--- a/Sources/xcodeproj/Objects/Configuration/XCConfigurationList.swift
+++ b/Sources/xcodeproj/Objects/Configuration/XCConfigurationList.swift
@@ -10,10 +10,10 @@ public final class XCConfigurationList: PBXObject {
     /// Build configurations
     public var buildConfigurations: [XCBuildConfiguration] {
         set {
-            buildConfigurationReferences = newValue.map({ $0.reference })
+            buildConfigurationReferences = newValue.references()
         }
         get {
-            return buildConfigurationReferences.compactMap({ try? $0.object() })
+            return buildConfigurationReferences.objects()
         }
     }
 
@@ -34,7 +34,7 @@ public final class XCConfigurationList: PBXObject {
     public init(buildConfigurations: [XCBuildConfiguration] = [],
                 defaultConfigurationName: String? = nil,
                 defaultConfigurationIsVisible: Bool = false) {
-        buildConfigurationReferences = buildConfigurations.map({ $0.reference })
+        buildConfigurationReferences = buildConfigurations.references()
         self.defaultConfigurationName = defaultConfigurationName
         self.defaultConfigurationIsVisible = defaultConfigurationIsVisible
         super.init()

--- a/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
@@ -14,7 +14,7 @@ public final class PBXContainerItemProxy: PBXObject {
     /// Returns the project that contains the remote object.
     public var containerPortal: PBXProject! {
         get {
-            return try? containerPortalReference.object()
+            return containerPortalReference.object()
         }
         set {
             containerPortalReference = newValue.reference
@@ -30,9 +30,7 @@ public final class PBXContainerItemProxy: PBXObject {
     /// Remote global object
     public var remoteGlobalID: PBXObject? {
         get {
-            return remoteGlobalIDReference.flatMap { (reference) -> PBXObject? in
-                try? reference.object()
-            }
+            return remoteGlobalIDReference?.object()
         }
         set {
             remoteGlobalIDReference = newValue?.reference

--- a/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
@@ -162,10 +162,10 @@ public extension PBXFileElement {
     /// - Returns: path to the variant group base file.
     /// - Throws: an error if the path cannot be obtained.
     private func baseVariantGroupPath() throws -> String? {
-        guard let variantGroup: PBXVariantGroup = try self.reference.object() else { return nil }
+        guard let variantGroup: PBXVariantGroup = self.reference.object() else { return nil }
         guard let baseReference = try variantGroup
             .childrenReferences
-            .compactMap({ try $0.object() as PBXFileElement })
+            .compactMap({ try $0.objectOrThrow() as PBXFileElement })
             .first(where: { $0.name == "Base" }) else { return nil }
         return baseReference.path
     }

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -72,7 +72,7 @@ public class PBXGroup: PBXFileElement {
         var dictionary: [CommentedString: PlistValue] = try super.plistKeyAndValue(proj: proj, reference: reference).value.dictionary ?? [:]
         dictionary["isa"] = .string(CommentedString(type(of: self).isa))
         dictionary["children"] = .array(childrenReferences.map({ (fileReference) -> PlistValue in
-            let fileElement: PBXFileElement? = try? fileReference.object()
+            let fileElement: PBXFileElement? = fileReference.object()
             return .string(CommentedString(fileReference.value, comment: fileElement?.fileName()))
         }))
 

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -10,10 +10,10 @@ public class PBXGroup: PBXFileElement {
     /// Group children.
     public var children: [PBXFileElement] {
         set {
-            childrenReferences = newValue.map({ $0.reference })
+            childrenReferences = newValue.references()
         }
         get {
-            return childrenReferences.compactMap({ try? $0.object() })
+            return childrenReferences.objects()
         }
     }
 
@@ -40,7 +40,7 @@ public class PBXGroup: PBXFileElement {
                 usesTabs: Bool? = nil,
                 indentWidth: UInt? = nil,
                 tabWidth: UInt? = nil) {
-        childrenReferences = children.map({ $0.reference })
+        childrenReferences = children.references()
         super.init(sourceTree: sourceTree,
                    path: path,
                    name: name,
@@ -107,7 +107,7 @@ public extension PBXGroup {
     /// - Returns: group with the given name contained in the given parent group.
     public func group(named name: String) -> PBXGroup? {
         return childrenReferences
-            .compactMap({ try? $0.object() as PBXGroup })
+            .objects()
             .first(where: { $0.name == name })
     }
 
@@ -117,7 +117,7 @@ public extension PBXGroup {
     /// - Returns: file with the given name contained in the given parent group.
     public func file(named name: String) -> PBXFileReference? {
         return childrenReferences
-            .compactMap({ try? $0.object() as PBXFileReference })
+            .objects()
             .first(where: { $0.name == name })
     }
 

--- a/Sources/xcodeproj/Objects/Files/XCVersionGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/XCVersionGroup.swift
@@ -12,9 +12,7 @@ public final class XCVersionGroup: PBXGroup {
     /// Returns the current version file reference.
     public var currentVersion: PBXFileReference? {
         get {
-            return currentVersionReference.flatMap { (reference) -> PBXFileReference? in
-                try? reference.object()
-            }
+            return currentVersionReference?.object()
         }
         set {
             currentVersionReference = newValue?.reference
@@ -93,7 +91,7 @@ public final class XCVersionGroup: PBXGroup {
             dictionary["versionGroupType"] = .string(CommentedString(versionGroupType))
         }
         if let currentVersionReference = currentVersionReference {
-            let fileElement: PBXFileElement? = try? currentVersionReference.object()
+            let fileElement: PBXFileElement? = currentVersionReference.object()
             dictionary["currentVersion"] = .string(CommentedString(currentVersionReference.value, comment: fileElement?.fileName()))
         }
         return (key: CommentedString(reference, comment: path?.split(separator: "/").last.map(String.init)),

--- a/Sources/xcodeproj/Objects/Project/PBXObject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObject.swift
@@ -17,6 +17,7 @@ public class PBXObject: Hashable, Decodable, Equatable, AutoEquatable {
 
     init() {
         reference = PBXObjectReference()
+        reference.setObject(self)
     }
 
     // MARK: - Decodable

--- a/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
@@ -105,9 +105,16 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
 
     /// Returns the object the reference is referfing to.
     ///
+    /// - Returns: object the reference is referring to. Returns nil if the objects property has been released or the reference doesn't exist
+    func object<T>() -> T? {
+        return try? objectOrThrow()
+    }
+
+    /// Returns the object the reference is referfing to.
+    ///
     /// - Returns: object the reference is referring to.
     /// - Throws: an errof it the objects property has been released or the reference doesn't exist.
-    func object<T>() throws -> T {
+    func objectOrThrow<T>() throws -> T {
         guard let objects = objects else {
             throw PBXObjectError.objectsReleased
         }
@@ -128,6 +135,6 @@ extension Array where Element: PBXObject {
 extension Array where Element: PBXObjectReference {
 
     func objects<T: PBXObject>() -> [T] {
-        return compactMap { try? $0.object() }
+        return compactMap { $0.object() }
     }
 }

--- a/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
@@ -12,6 +12,9 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
     /// Weak reference to the objects instance that contains the project objects.
     weak var objects: PBXObjects?
 
+    /// A weak reference to the object
+    weak var objectRef: PBXObject?
+
     /// Initializes a non-temporary reference.
     ///
     /// - Parameter reference: reference.
@@ -103,10 +106,17 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
         return lhs.value < rhs.value
     }
 
+    /// Sets the object so it can be retrieved quickly again later
+    ///
+    /// - Parameter object: The object
+    func setObject(_ object: PBXObject) {
+        objectRef = object
+    }
+
     /// Returns the object the reference is referfing to.
     ///
     /// - Returns: object the reference is referring to. Returns nil if the objects property has been released or the reference doesn't exist
-    func object<T>() -> T? {
+    func object<T: PBXObject>() -> T? {
         return try? objectOrThrow()
     }
 
@@ -114,13 +124,17 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
     ///
     /// - Returns: object the reference is referring to.
     /// - Throws: an errof it the objects property has been released or the reference doesn't exist.
-    func objectOrThrow<T>() throws -> T {
+    func objectOrThrow<T: PBXObject>() throws -> T {
+        if let object = objectRef as? T {
+            return object
+        }
         guard let objects = objects else {
             throw PBXObjectError.objectsReleased
         }
         guard let object = objects.get(reference: self) as? T else {
             throw PBXObjectError.objectNotFound(value)
         }
+        self.objectRef = object
         return object
     }
 }

--- a/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
@@ -48,18 +48,11 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
     }
 
     /// Fixes its value making it permanent.
-    /// Since this object is used as a key in to refer objects from the PBXObjects instance, we need to delete
-    /// the object and add it again to index the new reference. Otherwise we cannot access the element using
-    /// the reference with the updated value.
     ///
     /// - Parameter value: value.
     func fix(_ value: String) {
-        let object = objects?.delete(reference: self)
         self.value = value
         temporary = false
-        if let object = object {
-            objects?.add(object: object)
-        }
     }
 
     /// Invalidates the reference making it temporary.

--- a/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
@@ -117,3 +117,17 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
         return object
     }
 }
+
+extension Array where Element: PBXObject {
+
+    func references() -> [PBXObjectReference] {
+        return map { $0.reference }
+    }
+}
+
+extension Array where Element: PBXObjectReference {
+
+    func objects<T: PBXObject>() -> [T] {
+        return compactMap { try? $0.object() }
+    }
+}

--- a/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectReference.swift
@@ -26,7 +26,7 @@ class PBXObjectReference: NSObject, Comparable, NSCopying {
 
     /// Initializes a temporary reference
     init(objects: PBXObjects? = nil) {
-        value = String.random()
+        value = "TEMP_\(String.random())"
         temporary = true
         self.objects = objects
     }

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -25,9 +25,7 @@ public final class PBXProj: Decodable {
             rootObjectReference = newValue?.reference
         }
         get {
-            return rootObjectReference.flatMap { (reference) -> PBXProject? in
-                try? reference.object()
-            }
+            return rootObjectReference?.object()
         }
     }
 
@@ -119,13 +117,13 @@ public extension PBXProj {
 
     /// Returns root project.
     public func rootProject() throws -> PBXProject? {
-        return try rootObjectReference?.object()
+        return try rootObjectReference?.objectOrThrow()
     }
 
     /// Returns root project's root group.
     public func rootGroup() throws -> PBXGroup? {
         let project = try rootProject()
-        return try project?.mainGroupReference.object()
+        return try project?.mainGroupReference.objectOrThrow()
     }
 
     /// Adds a new object to the project.

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -15,7 +15,7 @@ public final class PBXProject: PBXObject {
             buildConfigurationListReference = newValue.reference
         }
         get {
-            return try? buildConfigurationListReference.object()
+            return buildConfigurationListReference.object()
         }
     }
 
@@ -40,7 +40,7 @@ public final class PBXProject: PBXObject {
             mainGroupReference = newValue.reference
         }
         get {
-            return try? mainGroupReference.object()
+            return mainGroupReference.object()
         }
     }
 
@@ -53,9 +53,7 @@ public final class PBXProject: PBXObject {
             productsGroupReference = newValue?.reference
         }
         get {
-            return productsGroupReference.flatMap { (reference) -> PBXGroup? in
-                try? reference.object()
-            }
+            return productsGroupReference?.object()
         }
     }
 
@@ -78,7 +76,7 @@ public final class PBXProject: PBXObject {
         }
         get {
             return projectReferences.map { project in
-                project.flatMapValues({ try? $0.object() })
+                project.flatMapValues({ $0.object() })
             }
         }
     }
@@ -118,7 +116,7 @@ public final class PBXProject: PBXObject {
         } get {
             var attributes: [PBXTarget: [String: Any]] = [:]
             targetAttributeReferences.forEach {
-                if let object: PBXTarget = try? $0.key.object() {
+                if let object: PBXTarget = $0.key.object() {
                     attributes[object] = $0.value
                 }
             }
@@ -290,10 +288,10 @@ extension PBXProject: PlistSerializable {
             dictionary["knownRegions"] = PlistValue.array(knownRegions
                 .map { .string(CommentedString("\($0)")) })
         }
-        let mainGroupObject: PBXGroup? = try? mainGroupReference.object()
+        let mainGroupObject: PBXGroup? = mainGroupReference.object()
         dictionary["mainGroup"] = .string(CommentedString(mainGroupReference.value, comment: mainGroupObject?.fileName()))
         if let productsGroupReference = productsGroupReference {
-            let productRefGroupObject: PBXGroup? = try? productsGroupReference.object()
+            let productRefGroupObject: PBXGroup? = productsGroupReference.object()
             dictionary["productRefGroup"] = .string(CommentedString(productsGroupReference.value,
                                                                     comment: productRefGroupObject?.fileName()))
         }
@@ -308,7 +306,7 @@ extension PBXProject: PlistSerializable {
         }
         dictionary["targets"] = PlistValue.array(targetReferences
             .map { targetReference in
-                let target: PBXTarget? = try? targetReference.object()
+                let target: PBXTarget? = targetReference.object()
                 return .string(CommentedString(targetReference.value, comment: target?.name))
         })
 
@@ -334,9 +332,9 @@ extension PBXProject: PlistSerializable {
             guard let productGroupReference = reference["ProductGroup"], let projectRef = reference["ProjectRef"] else {
                 return nil
             }
-            let producGroup: PBXGroup? = try? productGroupReference.object()
+            let producGroup: PBXGroup? = productGroupReference.object()
             let groupName = producGroup?.fileName()
-            let project: PBXFileElement? = try? projectRef.object()
+            let project: PBXFileElement? = projectRef.object()
             let fileRefName = project?.fileName()
 
             return [

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -94,10 +94,10 @@ public final class PBXProject: PBXObject {
     /// Project targets.
     public var targets: [PBXTarget] {
         set {
-            targetReferences = newValue.map({ $0.reference })
+            targetReferences = newValue.references()
         }
         get {
-            return targetReferences.compactMap({ try? $0.object() })
+            return targetReferences.objects()
         }
     }
 
@@ -197,7 +197,7 @@ public final class PBXProject: PBXObject {
         self.projectDirPath = projectDirPath
         projectReferences = projects.map({ project in project.mapValues({ $0.reference }) })
         self.projectRoots = projectRoots
-        targetReferences = targets.map({ $0.reference })
+        targetReferences = targets.references()
         self.attributes = attributes
         targetAttributeReferences = [:]
         super.init()

--- a/Sources/xcodeproj/Objects/Targets/PBXReferenceProxy.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXReferenceProxy.swift
@@ -18,9 +18,7 @@ public final class PBXReferenceProxy: PBXObject {
     /// Element remote.
     public var remote: PBXContainerItemProxy? {
         get {
-            return remoteReference.flatMap { (reference) -> PBXContainerItemProxy? in
-                try? reference.object()
-            }
+            return remoteReference?.object()
         }
         set {
             remoteReference = newValue?.reference

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -23,10 +23,10 @@ public class PBXTarget: PBXContainerItem {
     /// Target build phases.
     public var buildPhases: [PBXBuildPhase] {
         get {
-            return buildPhaseReferences.compactMap({ try? $0.object() })
+            return buildPhaseReferences.objects()
         }
         set {
-            buildPhaseReferences = newValue.map({ $0.reference })
+            buildPhaseReferences = newValue.references()
         }
     }
 
@@ -36,10 +36,10 @@ public class PBXTarget: PBXContainerItem {
     /// Target build rules.
     public var buildRules: [PBXBuildRule] {
         get {
-            return buildRuleReferences.compactMap({ try? $0.object() })
+            return buildRuleReferences.objects()
         }
         set {
-            buildRuleReferences = newValue.map({ $0.reference })
+            buildRuleReferences = newValue.references()
         }
     }
 
@@ -49,10 +49,10 @@ public class PBXTarget: PBXContainerItem {
     /// Target dependencies.
     public var dependencies: [PBXTargetDependency] {
         get {
-            return dependencyReferences.compactMap({ try? $0.object() })
+            return dependencyReferences.objects()
         }
         set {
-            dependencyReferences = newValue.map({ $0.reference })
+            dependencyReferences = newValue.references()
         }
     }
 
@@ -100,9 +100,9 @@ public class PBXTarget: PBXContainerItem {
                 product: PBXFileReference? = nil,
                 productType: PBXProductType? = nil) {
         buildConfigurationListReference = buildConfigurationList?.reference
-        buildPhaseReferences = buildPhases.map({ $0.reference })
-        buildRuleReferences = buildRules.map({ $0.reference })
-        dependencyReferences = dependencies.map({ $0.reference })
+        buildPhaseReferences = buildPhases.references()
+        buildRuleReferences = buildRules.references()
+        dependencyReferences = dependencies.references()
         self.name = name
         self.productName = productName
         productReference = product?.reference

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -8,9 +8,7 @@ public class PBXTarget: PBXContainerItem {
     /// Build configuration list.
     public var buildConfigurationList: XCConfigurationList? {
         get {
-            return buildConfigurationListReference.flatMap { (reference) -> XCConfigurationList? in
-                try? reference.object()
-            }
+            return buildConfigurationListReference?.object()
         }
         set {
             buildConfigurationListReference = newValue?.reference
@@ -68,9 +66,7 @@ public class PBXTarget: PBXContainerItem {
     /// Target product.
     public var product: PBXFileReference? {
         get {
-            return productReference.flatMap { (reference) -> PBXFileReference? in
-                try? reference.object()
-            }
+            return productReference?.object()
         }
         set {
             productReference = newValue?.reference
@@ -160,7 +156,7 @@ public class PBXTarget: PBXContainerItem {
         }
         dictionary["buildPhases"] = .array(buildPhaseReferences
             .map { (buildPhaseReference: PBXObjectReference) in
-                let buildPhase: PBXBuildPhase? = try? buildPhaseReference.object()
+                let buildPhase: PBXBuildPhase? = buildPhaseReference.object()
                 return .string(CommentedString(buildPhaseReference.value, comment: buildPhase?.name()))
         })
 
@@ -178,7 +174,7 @@ public class PBXTarget: PBXContainerItem {
             dictionary["productType"] = .string(CommentedString(productType.rawValue))
         }
         if let productReference = productReference {
-            let fileElement: PBXFileElement? = try? productReference.object()
+            let fileElement: PBXFileElement? = productReference.object()
             dictionary["productReference"] = .string(CommentedString(productReference.value, comment: fileElement?.fileName()))
         }
         return (key: CommentedString(reference, comment: name),
@@ -204,7 +200,7 @@ public extension PBXTarget {
     /// - Throws: an error if the build phase cannot be obtained.
     public func sourcesBuildPhase() throws -> PBXSourcesBuildPhase? {
         return try buildPhaseReferences
-            .compactMap({ try $0.object() as PBXBuildPhase })
+            .compactMap({ try $0.objectOrThrow() as PBXBuildPhase })
             .filter({ $0.type() == .sources })
             .compactMap { $0 as? PBXSourcesBuildPhase }
             .first
@@ -216,7 +212,7 @@ public extension PBXTarget {
     /// - Throws: an error if the build phase cannot be obtained.
     public func resourcesBuildPhase() throws -> PBXResourcesBuildPhase? {
         return try buildPhaseReferences
-            .compactMap({ try $0.object() as PBXResourcesBuildPhase })
+            .compactMap({ try $0.objectOrThrow() as PBXResourcesBuildPhase })
             .filter({ $0.type() == .sources })
             .first
     }
@@ -227,9 +223,9 @@ public extension PBXTarget {
     /// - Throws: an error if something goes wrong.
     public func sourceFiles() throws -> [PBXFileElement] {
         return try sourcesBuildPhase()?.fileReferences
-            .compactMap { try $0.object() as PBXBuildFile }
+            .compactMap { try $0.objectOrThrow() as PBXBuildFile }
             .filter { $0.fileReference != nil }
-            .compactMap { try $0.fileReference!.object() as PBXFileElement }
+            .compactMap { try $0.fileReference!.objectOrThrow() as PBXFileElement }
             ?? []
     }
 }

--- a/Sources/xcodeproj/Objects/Targets/PBXTargetDependency.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTargetDependency.swift
@@ -13,9 +13,7 @@ public final class PBXTargetDependency: PBXObject {
     /// Target.
     public var target: PBXTarget? {
         get {
-            return targetReference.flatMap { (reference) -> PBXTarget? in
-                try? reference.object()
-            }
+            return targetReference?.object()
         }
         set {
             targetReference = newValue?.reference
@@ -28,9 +26,7 @@ public final class PBXTargetDependency: PBXObject {
     /// Target proxy.
     public var targetProxy: PBXContainerItemProxy? {
         get {
-            return targetProxyReference.flatMap { (reference) -> PBXContainerItemProxy? in
-                try? reference.object()
-            }
+            return targetProxyReference?.object()
         }
         set {
             targetProxyReference = newValue?.reference
@@ -87,7 +83,7 @@ extension PBXTargetDependency: PlistSerializable {
             dictionary["name"] = .string(CommentedString(name))
         }
         if let targetReference = targetReference {
-            let targetObject: PBXTarget? = try? targetReference.object()
+            let targetObject: PBXTarget? = targetReference.object()
             dictionary["target"] = .string(CommentedString(targetReference.value, comment: targetObject?.name))
         }
         if let targetProxyReference = targetProxyReference {

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -20,7 +20,7 @@ final class ReferenceGenerator: ReferenceGenerating {
     ///
     /// - Parameter proj: project whose objects references will be generated.
     func generateReferences(proj: PBXProj) throws {
-        guard let project: PBXProject = try proj.rootObjectReference?.object() else {
+        guard let project: PBXProject = try proj.rootObjectReference?.objectOrThrow() else {
             return
         }
 
@@ -47,12 +47,12 @@ final class ReferenceGenerator: ReferenceGenerating {
 
         // Project references
         try project.projectReferences.flatMap({ $0.values }).forEach { objectReference in
-            guard let fileReference: PBXFileReference = try? objectReference.object() else { return }
+            guard let fileReference: PBXFileReference = objectReference.object() else { return }
             try generateFileReference(fileReference, identifiers: identifiers)
         }
 
         /// Configuration list
-        if let configurationList: XCConfigurationList = try? project.buildConfigurationListReference.object() {
+        if let configurationList: XCConfigurationList = project.buildConfigurationListReference.object() {
             try generateConfigurationListReferences(configurationList, identifiers: identifiers)
         }
     }
@@ -103,7 +103,7 @@ final class ReferenceGenerator: ReferenceGenerating {
 
         // Children
         try group.childrenReferences.forEach { child in
-            guard let childFileElement: PBXFileElement = try? child.object() else { return }
+            guard let childFileElement: PBXFileElement = child.object() else { return }
             if let childGroup = childFileElement as? PBXGroup {
                 try generateGroupReferences(childGroup, identifiers: identifiers)
             } else if let childFileReference = childFileElement as? PBXFileReference {
@@ -242,13 +242,13 @@ final class ReferenceGenerator: ReferenceGenerating {
         buildPhase.fileReferences.forEach { buildFileReference in
             if !buildFileReference.temporary { return }
 
-            guard let buildFile: PBXBuildFile = try? buildFileReference.object() else { return }
+            guard let buildFile: PBXBuildFile = buildFileReference.object() else { return }
 
             var identifiers = identifiers
             identifiers.append(String(describing: buildFile))
 
             if let fileReference = buildFile.fileReference,
-                let fileReferenceObject: PBXObject = try? fileReference.object() {
+                let fileReferenceObject: PBXObject = fileReference.object() {
                 identifiers.append(fileReferenceObject.reference.value)
             }
 

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -70,7 +70,7 @@ final class ReferenceGenerator: ReferenceGenerating {
         }
 
         // Targets
-        let targets: [PBXTarget] = project.targetReferences.compactMap({ try? $0.object() as PBXTarget })
+        let targets: [PBXTarget] = project.targetReferences.objects()
         targets.forEach { target in
 
             var identifiers = identifiers
@@ -174,16 +174,16 @@ final class ReferenceGenerator: ReferenceGenerating {
         }
 
         // Build phases
-        let buildPhases = target.buildPhaseReferences.compactMap({ try? $0.object() as PBXBuildPhase })
+        let buildPhases: [PBXBuildPhase] = target.buildPhaseReferences.objects()
         try buildPhases.forEach({ try generateBuildPhaseReferences($0,
                                                                    identifiers: identifiers) })
 
         // Build rules
-        let buildRules = target.buildRuleReferences.compactMap({ try? $0.object() as PBXBuildRule })
+        let buildRules: [PBXBuildRule] = target.buildRuleReferences.objects()
         try buildRules.forEach({ try generateBuildRules($0, identifiers: identifiers) })
 
         // Dependencies
-        let dependencies = target.dependencyReferences.compactMap({ try? $0.object() as PBXTargetDependency })
+        let dependencies: [PBXTargetDependency] = target.dependencyReferences.objects()
         try dependencies.forEach({ try generateTargetDependencyReferences($0, identifiers: identifiers) })
     }
 

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -258,9 +258,14 @@ extension PBXObject {
     /// - Returns: object reference.
     func fixReference(identifiers: [String]) {
         if reference.temporary {
-            let identifiers = [String(describing: type(of: self))] + identifiers
-            let value = identifiers.joined(separator: "-").md5.uppercased()
-            reference.fix(value)
+            let typeName = String(describing: type(of: self))
+            let acronym = typeName
+                .replacingOccurrences(of: "PBX", with: "")
+                .replacingOccurrences(of: "XC", with: "")
+                .filter { String($0).lowercased() != String($0) }
+
+            let id = ([typeName] + identifiers).joined(separator: "-").md5.uppercased()
+            reference.fix("\(acronym)_\(id)")
         }
     }
 }

--- a/Tests/xcodeprojTests/Objects/Targets/PBXNativeTargetTests.swift
+++ b/Tests/xcodeprojTests/Objects/Targets/PBXNativeTargetTests.swift
@@ -48,11 +48,11 @@ final class PBXNativeTargetTests: XCTestCase {
         objects.add(object: target)
         objects.add(object: dependency)
         _ = try target.addDependency(target: dependency)
-        let targetDependency: PBXTargetDependency? = try target.dependencyReferences.first?.object()
+        let targetDependency: PBXTargetDependency? = target.dependencyReferences.first?.object()
 
         XCTAssertEqual(targetDependency?.name, "Dependency")
         XCTAssertEqual(targetDependency?.targetReference, dependency.reference)
-        let containerItemProxy: PBXContainerItemProxy? = try targetDependency?.targetProxyReference?.object()
+        let containerItemProxy: PBXContainerItemProxy? = targetDependency?.targetProxyReference?.object()
         XCTAssertEqual(containerItemProxy?.containerPortalReference, project.reference)
         XCTAssertEqual(containerItemProxy?.remoteGlobalIDReference, dependency.reference)
         XCTAssertEqual(containerItemProxy?.proxyType, .nativeTarget)


### PR DESCRIPTION
This changes a few things about object references.
This is best reviewed by commit, as each commit changes a single thing:

- reference array helpers to remove duplicated code - reimplements the lost commits of #306 (still not sure what happened to them)
- change `PBXObjectRefernce.object()` from a throwing function to an optional return as the error was usually discarded. This makes a lot of the code simpler. There is a new `PBXObjectRefernce.objectOrThrow()` for the rare cases the error is propagated.
- improve performance of object lookups by caching the PBXObject within the reference
- improve the performance of fixing references by removing the un-needed deletion and re-addition of objects
- add helper function for fixing references which removes duplicated code
- add class acronym prefix to the generated UUID
- add `TEMP` prefix to temporary UUIDs