### PR TITLE
Encode PBXObject reference in target attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Added
+- Added ability to pass in a `PBXObject` into the `PBXProject.targetAttributes` dictionary, which will be encoded into its UUID. Can be used for `TestTargetID` https://github.com/tuist/xcodeproj/pull/333 by @yonaskolb.
+
 ### Changed
 - Changed `XCScheme.BuildableReference` init to make `blueprint` a `PBXObject` and added a `setBlueprint(:)` function https://github.com/tuist/xcodeproj/pull/320 by @yonaskolb.
 - Bump AEXML version to 4.3.3 https://github.com/tuist/xcodeproj/pull/310 by @pepibumur.

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -314,7 +314,11 @@ extension PBXProject: PlistSerializable {
         if !targetAttributeReferences.isEmpty {
             // merge target attributes
             var plistTargetAttributes: [String: Any] = [:]
-            targetAttributeReferences.forEach({ plistTargetAttributes[$0.key.value] = $0.value })
+            for (reference, value) in targetAttributeReferences {
+                plistTargetAttributes[reference.value] = value.mapValues { value in
+                    (value as? PBXObject)?.reference.value ?? value
+                }
+            }
             plistAttributes[PBXProject.targetAttributesKey] = plistTargetAttributes
         }
         dictionary["attributes"] = plistAttributes.plist()

--- a/Tests/xcodeprojTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProjectTests.swift
@@ -5,7 +5,10 @@ final class PBXProjectTests: XCTestCase {
 
     func test_attributes() throws {
         let target = PBXTarget(name: "")
-        target.reference.fix("test")
+        target.reference.fix("app")
+
+        let testTarget = PBXTarget(name: "")
+        testTarget.reference.fix("test")
 
         let project = PBXProject(name: "",
                                  buildConfigurationList: XCConfigurationList(),
@@ -14,15 +17,16 @@ final class PBXProjectTests: XCTestCase {
                                  attributes: ["LastUpgradeCheck": "0940"],
                                  targetAttributes: [target: ["TestTargetID": "123"]])
 
-        project.setTargetAttributes(["custom": "abc"], target: target)
+        project.setTargetAttributes(["custom": "abc", "TestTargetID": testTarget], target: target)
 
         let plist = try project.plistKeyAndValue(proj: PBXProj(), reference: "")
         let attributes = plist.value.dictionary?["attributes"]?.dictionary ?? [:]
 
         let expectedAttributes: [CommentedString: PlistValue] = [
             "LastUpgradeCheck": "0940",
-            "TargetAttributes": ["test": [
+            "TargetAttributes": ["app": [
                 "custom": "abc",
+                "TestTargetID": "test"
             ]],
         ]
         XCTAssertEqual(attributes, expectedAttributes)


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/321

This lets us pass a `PBXObject` in the target attributes dictionary which will then be encoded into it's reference value