### PR TITLE
Performance improvement: Set reference object after object decoding

### DIFF
--- a/Sources/xcodeproj/Objects/Project/PBXObject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObject.swift
@@ -36,6 +36,7 @@ public class PBXObject: Hashable, Decodable, Equatable, AutoEquatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let reference: String = try container.decode(.reference)
         self.reference = referenceRepository.getOrCreate(reference: reference, objects: objects)
+        self.reference.setObject(self)
     }
 
     /// Object isa (type id)


### PR DESCRIPTION
This is a continuation of https://github.com/tuist/xcodeproj/pull/332

This sets the cached reference object when decoding a `PBXObject`