### PR TITLE
Performance improvement: cache build phase for build files

### DIFF
--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
@@ -17,6 +17,7 @@ public class PBXBuildPhase: PBXContainerItem {
             return fileReferences.objects()
         }
         set {
+            newValue.forEach { $0.buildPhase = self }
             fileReferences = newValue.references()
         }
     }
@@ -56,6 +57,7 @@ public class PBXBuildPhase: PBXContainerItem {
         self.buildActionMask = buildActionMask
         self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
         super.init()
+        files.forEach { $0.buildPhase = self }
     }
 
     // MARK: - Decodable
@@ -131,23 +133,7 @@ extension PBXBuildPhase {
     ///
     /// - Returns: build phase type.
     public func type() -> BuildPhase? {
-        if self is PBXSourcesBuildPhase {
-            return .sources
-        } else if self is PBXFrameworksBuildPhase {
-            return .frameworks
-        } else if self is PBXResourcesBuildPhase {
-            return .resources
-        } else if self is PBXCopyFilesBuildPhase {
-            return .copyFiles
-        } else if self is PBXShellScriptBuildPhase {
-            return .runScript
-        } else if self is PBXHeadersBuildPhase {
-            return .headers
-        } else if self is PBXRezBuildPhase {
-            return .carbonResources
-        } else {
-            return nil
-        }
+        return buildPhase
     }
 
     /// Build phase name.

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -201,7 +201,7 @@ public extension PBXTarget {
     public func sourcesBuildPhase() throws -> PBXSourcesBuildPhase? {
         return try buildPhaseReferences
             .compactMap({ try $0.getThrowingObject() as PBXBuildPhase })
-            .filter({ $0.type() == .sources })
+            .filter({ $0.buildPhase == .sources })
             .compactMap { $0 as? PBXSourcesBuildPhase }
             .first
     }
@@ -213,7 +213,7 @@ public extension PBXTarget {
     public func resourcesBuildPhase() throws -> PBXResourcesBuildPhase? {
         return try buildPhaseReferences
             .compactMap({ try $0.getThrowingObject() as PBXResourcesBuildPhase })
-            .filter({ $0.type() == .sources })
+            .filter({ $0.buildPhase == .sources })
             .first
     }
 


### PR DESCRIPTION
This improves performance when writing build files by caching the build phase they belong to.

On one test it halved the writing time. The more build files in a project the bigger the gain 👍 