### PR TITLE
Add parallelizable and randomly ordered tests support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Added
+- Added `parallelizable` and `randomExecutionOrdering` attributes to `XCScheme.TestableReference` https://github.com/tuist/xcodeproj/pull/340 by @alvarhansen.
+
 ## 6.2.0
 
 ### Added

--- a/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/xcodeproj/Extensions/AEXML+XcodeFormat.swift
@@ -68,6 +68,11 @@ let attributesOrder: [String: [String]] = [
         "value",
         "isEnabled",
     ],
+    "TestableReference": [
+        "skipped",
+        "parallelizable",
+        "testExecutionOrdering"
+    ],
 ]
 
 extension AEXMLElement {

--- a/Sources/xcodeproj/Scheme/XCScheme+TestableReference.swift
+++ b/Sources/xcodeproj/Scheme/XCScheme+TestableReference.swift
@@ -6,21 +6,29 @@ extension XCScheme {
         // MARK: - Attributes
 
         public var skipped: Bool
+        public var parallelizable: Bool
+        public var randomExecutionOrdering: Bool
         public var buildableReference: BuildableReference
         public var skippedTests: [SkippedTest]
 
         // MARK: - Init
 
         public init(skipped: Bool,
+                    parallelizable: Bool = false,
+                    randomExecutionOrdering: Bool = false,
                     buildableReference: BuildableReference,
                     skippedTests: [SkippedTest] = []) {
             self.skipped = skipped
+            self.parallelizable = parallelizable
+            self.randomExecutionOrdering = randomExecutionOrdering
             self.buildableReference = buildableReference
             self.skippedTests = skippedTests
         }
 
         init(element: AEXMLElement) throws {
             skipped = element.attributes["skipped"] == "YES"
+            parallelizable = element.attributes["parallelizable"] == "YES"
+            randomExecutionOrdering = element.attributes["testExecutionOrdering"] == "random"
             buildableReference = try BuildableReference(element: element["BuildableReference"])
             if let skippedTests = element["SkippedTests"]["Test"].all, !skippedTests.isEmpty {
                 self.skippedTests = try skippedTests.map(SkippedTest.init)
@@ -32,9 +40,12 @@ extension XCScheme {
         // MARK: - XML
 
         func xmlElement() -> AEXMLElement {
+            var attributes: [String : String] = ["skipped": skipped.xmlString]
+            attributes["parallelizable"] = parallelizable ? parallelizable.xmlString : nil
+            attributes["testExecutionOrdering"] = randomExecutionOrdering ? "random" : nil
             let element = AEXMLElement(name: "TestableReference",
                                        value: nil,
-                                       attributes: ["skipped": skipped.xmlString])
+                                       attributes: attributes)
             element.addChild(buildableReference.xmlElement())
             if !skippedTests.isEmpty {
                 let skippedTestsElement = element.addChild(name: "SkippedTests")
@@ -49,6 +60,8 @@ extension XCScheme {
 
         public static func == (lhs: TestableReference, rhs: TestableReference) -> Bool {
             return lhs.skipped == rhs.skipped &&
+                lhs.parallelizable == rhs.parallelizable &&
+                lhs.randomExecutionOrdering == rhs.randomExecutionOrdering &&
                 lhs.buildableReference == rhs.buildableReference &&
                 lhs.skippedTests == rhs.skippedTests
         }

--- a/Tests/xcodeprojTests/Scheme/XCSchemeTests.swift
+++ b/Tests/xcodeprojTests/Scheme/XCSchemeTests.swift
@@ -36,6 +36,43 @@ final class XCSchemeIntegrationTests: XCTestCase {
                   assertion: { assert(minimalScheme: $1) })
     }
 
+    func test_write_testableReferenceDefaultAttributesValuesAreOmitted() {
+        let reference = XCScheme.TestableReference(
+            skipped: false,
+            parallelizable: false,
+            randomExecutionOrdering: false,
+            buildableReference: XCScheme.BuildableReference(
+                referencedContainer: "",
+                blueprint: PBXObject(),
+                buildableName: "",
+                blueprintName: ""
+            ),
+            skippedTests: []
+        )
+        let subject = reference.xmlElement()
+        XCTAssertNil(subject.attributes["parallelizable"])
+        XCTAssertNil(subject.attributes["testExecutionOrdering"])
+    }
+
+    func test_write_testableReferenceAttributesValues() {
+        let reference = XCScheme.TestableReference(
+            skipped: false,
+            parallelizable: true,
+            randomExecutionOrdering: true,
+            buildableReference: XCScheme.BuildableReference(
+                referencedContainer: "",
+                blueprint: PBXObject(),
+                buildableName: "",
+                blueprintName: ""
+            ),
+            skippedTests: []
+        )
+        let subject = reference.xmlElement()
+        XCTAssertEqual(subject.attributes["skipped"], "NO")
+        XCTAssertEqual(subject.attributes["parallelizable"], "YES")
+        XCTAssertEqual(subject.attributes["testExecutionOrdering"], "random")
+    }
+
     // MARK: - Private
 
     private func assert(scheme: XCScheme) {
@@ -65,6 +102,8 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.testAction?.shouldUseLaunchSchemeArgsEnv, true)
         XCTAssertEqual(scheme.testAction?.codeCoverageEnabled, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.skipped, false)
+        XCTAssertEqual(scheme.testAction?.testables.first?.parallelizable, false)
+        XCTAssertEqual(scheme.testAction?.testables.first?.randomExecutionOrdering, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableIdentifier, "primary")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.blueprintIdentifier, "23766C251EAA3484007A9026")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableName, "iOSTests.xctest")


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/335

### Short description 📝
Adds parallelizable and randomly ordered tests support

### Solution 📦
Adds `parallelizable: Bool` `randomExecutionOrdering: Bool` properties to `TestableReference`

### Implementation 👩‍💻👨‍💻
Added tests to make sure default old schema files won't be affected by making sure default values are not written.
