### PR TITLE
Resolve reference conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## next version
 
 ### Added
-- Added `parallelizable` and `randomExecutionOrdering` attributes to `XCScheme.TestableReference` https://github.com/tuist/xcodeproj/pull/340 by @alvarhansen.
+- Added `parallelizable` and `randomExecutionOrdering` attributes to `XCScheme.TestableReference` https://github.com/tuist/xcodeproj/pull/342 by @yonaskolb.
+
+### Fixed
+- Fixed possible generated UUID conflicts https://github.com/tuist/xcodeproj/pull/340 by @alvarhansen.
 
 ## 6.2.0
 

--- a/Sources/xcodeproj/Objects/Project/PBXObject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObject.swift
@@ -13,8 +13,16 @@ public class PBXObject: Hashable, Decodable, Equatable, AutoEquatable {
     /// The object reference in the project that contains it.
     let reference: PBXObjectReference
 
-    /// Used to differentiate this object from other equatable ones for the purpose of reference generation
-    public var identifier: String?
+    /**
+     Used to differentiate this object from other equatable ones for the purposes of uuid generation.
+
+     This shouldn't be required to be set in normal circumstances.
+     In some rare cases xcodeproj doesn't have enough context about otherwise equatable objects,
+     so it has to resolve automatic uuid conflicts by appending numbers.
+     This property can be used to provide more context to disambiguate these objects,
+     which will result in more deterministic uuids.
+    */
+    public var context: String?
 
     // MARK: - Init
 

--- a/Sources/xcodeproj/Objects/Project/PBXObject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObject.swift
@@ -13,6 +13,9 @@ public class PBXObject: Hashable, Decodable, Equatable, AutoEquatable {
     /// The object reference in the project that contains it.
     let reference: PBXObjectReference
 
+    /// Used to differentiate this object from other equatable ones for the purpose of reference generation
+    public var identifier: String?
+
     // MARK: - Init
 
     init() {

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -272,8 +272,8 @@ extension ReferenceGenerator {
     func fixReference<T: PBXObject>(for object: T, identifiers: [String]) {
         if object.reference.temporary {
             var identifiers = identifiers
-            if let identitifier = object.identifier {
-                identifiers.append(identitifier)
+            if let context = object.context {
+                identifiers.append(context)
             }
             let typeName = String(describing: type(of: object))
 

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -271,6 +271,10 @@ extension ReferenceGenerator {
     ///   - identifiers: list of identifiers used to generate the reference of the object.
     func fixReference<T: PBXObject>(for object: T, identifiers: [String]) {
         if object.reference.temporary {
+            var identifiers = identifiers
+            if let identitifier = object.identifier {
+                identifiers.append(identitifier)
+            }
             let typeName = String(describing: type(of: object))
 
             // Get acronym to be used as prefix for the reference.

--- a/Tests/xcodeprojTests/Utils/ObjectReferenceTests.swift
+++ b/Tests/xcodeprojTests/Utils/ObjectReferenceTests.swift
@@ -85,6 +85,16 @@ class ObjectReferenceTests: XCTestCase {
         XCTAssertEqual(object.reference.value, object2.reference.value)
     }
 
+    func test_reference_generation_usesIdentifier() {
+        let object = PBXFileReference()
+        object.identifier = "1"
+        let object2 = PBXFileReference()
+        object2.identifier = "2"
+        referenceGenerator.fixReference(for: object, identifiers: ["a"])
+        referenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        XCTAssertNotEqual(object.reference.value, object2.reference.value)
+    }
+
     func test_reference_generation_doesntChangeFixed() {
         let object = PBXFileReference()
         referenceGenerator.fixReference(for: object, identifiers: ["a"])

--- a/Tests/xcodeprojTests/Utils/ObjectReferenceTests.swift
+++ b/Tests/xcodeprojTests/Utils/ObjectReferenceTests.swift
@@ -87,9 +87,9 @@ class ObjectReferenceTests: XCTestCase {
 
     func test_reference_generation_usesIdentifier() {
         let object = PBXFileReference()
-        object.identifier = "1"
+        object.context = "1"
         let object2 = PBXFileReference()
-        object2.identifier = "2"
+        object2.context = "2"
         referenceGenerator.fixReference(for: object, identifiers: ["a"])
         referenceGenerator.fixReference(for: object2, identifiers: ["a"])
         XCTAssertNotEqual(object.reference.value, object2.reference.value)


### PR DESCRIPTION
### Short description 📝
This resolves cases where the reference generator generates the exact same value for multiple objects. This can happen when it doesn't have enough context

### Solution 📦
This PR solves the problem in 2 ways. 
- keeping track of what has already been generated, and differentiating duplicates by appending numbers.
- adding a `PBXObject.identifier` string that can be used to give more information about the object to differentiate it from equatable objects. This is used in XcodeGen for example to add a target name to cross platform product file references, which are otherwise all exactly the same as the product name is the same. Maybe this property could have a different name. `referenceContext` or `context` perhaps?
