### PR TITLE
Fixed not working PBXFileElement.fullPath(sourceRoot:) method

### DIFF
--- a/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
@@ -151,7 +151,7 @@ public extension PBXFileElement {
             guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot }
             guard let groupPath = try group.value.fullPath(sourceRoot: sourceRoot) else { return nil }
             guard let filePath = self is PBXVariantGroup ? try baseVariantGroupPath() : path else { return groupPath }
-            return Path(filePath).relative(to: groupPath)
+            return groupPath + filePath
         default:
             return nil
         }

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -54,6 +54,28 @@ final class PBXFileElementTests: XCTestCase {
         let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
         XCTAssertEqual(fullPath?.string, "/a/path")
     }
+    
+    func test_fullPath_with_nested_groups() throws {
+        let sourceRoot = Path("/")
+        let fileref = PBXFileReference(sourceTree: .group,
+                                       fileEncoding: 1,
+                                       explicitFileType: "sourcecode.swift",
+                                       lastKnownFileType: nil,
+                                       path: "file/path")
+        let nestedGroup = PBXGroup(children: [fileref],
+                             sourceTree: .group,
+                             path: "group/path")
+        let rootGroup = PBXGroup(children: [nestedGroup],
+                                 sourceTree: .group)
+
+        let objects = PBXObjects(objects: [fileref, nestedGroup, rootGroup])
+        fileref.reference.objects = objects
+        nestedGroup.reference.objects = objects
+
+        let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
+        XCTAssertEqual(fullPath?.string, "/group/path/file/path")
+    }
+    
 
     private func testDictionary() -> [String: Any] {
         return [


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/341

### Short description 📝

I discovered that `fullPath(sourceRoot:)` method doesn't work properly - it removes some part the base path instead of concatenating element's path with its parents' paths and `sourceRoot`. 

In PR: https://github.com/tuist/xcodeproj/pull/334/files#diff-0e1bd5e5f3fdbfcaa7ef8aa4727d3895 `swiftPM` package was removed,`PathKit` was added and all occurrences of `AbsolutePath(filePath, relativeTo: groupPath)` initialized was changed to `Path(filePath).relative(to: groupPath)`, which is not the same (see implementation [here](https://github.com/apple/swift-package-manager/blob/0af02ed21df87bd5bcf169132d0ee90a27c47bdf/Sources/Basic/Path.swift#L62) and [here](https://github.com/tuist/xcodeproj/blob/7a32fa0ebf0c6120ed8a7de03a632c2a10bbe243/Sources/xcodeproj/Extensions/Path%2BExtras.swift#L43) ).

### Solution 📦
I used `+` operator for `Path` instead of `relative` method.
