### PR TITLE
Generate XCode style UUID references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Added
+- Added `projReferenceFormat` to `PBXOutputSettings` to allow changing the output format of generated references. `withPrefixAndSuffix` will give the legacy behaviour `xcode` will generate 32 character references as XCode does. https://github.com/tuist/xcodeproj/pull/345 by @samskiter.
+
 ## 6.3.0
 
 ### Added
@@ -33,7 +36,7 @@
 - Add `TEMP` prefix to temporary unfixed reference values https://github.com/tuist/xcodeproj/pull/332 by @yonaskolb.
 
 ### Fixed
-- Fixed written order of scheme attributes in Swift 4.2 https://github.com/tuist/xcodeproj/pull/325 and https://github.com/tuist/xcodeproj/pull/331 by @yonaskolb and @drekka 
+- Fixed written order of scheme attributes in Swift 4.2 https://github.com/tuist/xcodeproj/pull/325 and https://github.com/tuist/xcodeproj/pull/331 by @yonaskolb and @drekka
 
 ## 6.0.1
 

--- a/Sources/xcodeproj/Objects/Project/PBXOutputSettings.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXOutputSettings.swift
@@ -120,6 +120,17 @@ public enum PBXBuildPhaseFileOrder {
     }
 }
 
+/// Defines the format of project file references
+public enum PBXReferenceFormat {
+    /// Adds prefix and suffix characters to the references.
+    /// The prefix characters identify the type of reference generated (e.g. BP for Build Phase).
+    /// The suffix number is only added for uniqueness if clashes occur.
+    case withPrefixAndSuffix
+    /// Standard 32 char format that XCode generates.
+    /// Note: Not guaranteed to be the same as XCode generates - only the format is the same.
+    case xcode
+}
+
 /// Struct of output settings passed to various methods.
 public struct PBXOutputSettings {
     /// The sorting order for the list of files in Xcode's project file.
@@ -131,6 +142,9 @@ public struct PBXOutputSettings {
     /// The sort order for lists of files in build phases.
     let projBuildPhaseFileOrder: PBXBuildPhaseFileOrder
 
+    /// The format of project file references
+    let projReferenceFormat: PBXReferenceFormat
+
     /**
      Default initializer
 
@@ -140,9 +154,11 @@ public struct PBXOutputSettings {
      */
     public init(projFileListOrder: PBXFileOrder = .byUUID,
                 projNavigatorFileOrder: PBXNavigatorFileOrder = .unsorted,
-                projBuildPhaseFileOrder: PBXBuildPhaseFileOrder = .unsorted) {
+                projBuildPhaseFileOrder: PBXBuildPhaseFileOrder = .unsorted,
+                projReferenceFormat: PBXReferenceFormat = .xcode) {
         self.projFileListOrder = projFileListOrder
         self.projNavigatorFileOrder = projNavigatorFileOrder
         self.projBuildPhaseFileOrder = projBuildPhaseFileOrder
+        self.projReferenceFormat = projReferenceFormat
     }
 }

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -201,8 +201,8 @@ extension PBXProj: Writable {
     }
 
     public func write(path: Path, override: Bool, outputSettings: PBXOutputSettings) throws {
-        let encoder = PBXProjEncoder()
-        let output = try encoder.encode(proj: self, outputSettings: outputSettings)
+        let encoder = PBXProjEncoder(outputSettings: outputSettings)
+        let output = try encoder.encode(proj: self)
         if override && path.exists {
             try path.delete()
         }

--- a/Sources/xcodeproj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProjEncoder.swift
@@ -12,13 +12,21 @@ extension PlistSerializable {
 
 /// Encodes your PBXProj files to String
 final class PBXProjEncoder {
-    let referenceGenerator: ReferenceGenerating = ReferenceGenerator()
+
+    let outputSettings: PBXOutputSettings
+    let referenceGenerator: ReferenceGenerating
     var indent: UInt = 0
     var output: String = ""
     var multiline: Bool = true
 
+    init(outputSettings: PBXOutputSettings) {
+
+        self.outputSettings = outputSettings
+        self.referenceGenerator = ReferenceGenerator(outputSettings: outputSettings)
+    }
+
     // swiftlint:disable function_body_length
-    func encode(proj: PBXProj, outputSettings: PBXOutputSettings) throws -> String {
+    func encode(proj: PBXProj) throws -> String {
         try referenceGenerator.generateReferences(proj: proj)
         guard let rootObject = proj.rootObjectReference else { throw PBXProjEncoderError.emptyProjectReference }
 

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -276,18 +276,22 @@ extension ReferenceGenerator {
                 identifiers.append(context)
             }
             let typeName = String(describing: type(of: object))
-            let id = ([typeName] + identifiers).joined(separator: "-").md5.uppercased()
-            
+
+            // Get acronym to be used as prefix for the reference.
+            // PBXFileReference is turned to FR.
+            let acronym = typeName
+                .replacingOccurrences(of: "PBX", with: "")
+                .replacingOccurrences(of: "XC", with: "")
+                .filter { String($0).lowercased() != String($0) }
+
+            let id = "\(acronym)_\(([typeName] + identifiers).joined(separator: "-"))"
+
             var reference = ""
             var counter = 0
-            // get the first reference that doesn't already exist
+            // Get the first reference that doesn't already exist
             repeat {
                 counter += 1
-                reference = id
-                if counter > 1 {
-                    reference += "_\(counter)"
-                    reference = reference.md5.uppercased()
-                }
+                reference = "\(id)_\(counter)".md5.uppercased()
             } while (references.contains(reference))
             references.insert(reference)
             object.reference.fix(reference)

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -8,15 +8,20 @@ protocol ReferenceGenerating: AnyObject {
     /// Generates the references of the objects of the given project.
     ///
     /// - Parameter proj: project whose objects references will be generated.
+    /// - Parameter settings: settings to control the output references
     func generateReferences(proj: PBXProj) throws
 }
 
 /// Reference generator.
 final class ReferenceGenerator: ReferenceGenerating {
-    /// Project pbxproj instance.
-    var proj: PBXProj?
 
+    let outputSettings: PBXOutputSettings
     var references: Set<String> = []
+
+    init(outputSettings: PBXOutputSettings) {
+
+        self.outputSettings = outputSettings
+    }
 
     /// Generates the references of the objects of the given project.
     ///
@@ -26,8 +31,6 @@ final class ReferenceGenerator: ReferenceGenerating {
             return
         }
 
-        self.proj = proj
-
         // cache current reference values
         var references: Set<String> = []
         proj.objects.forEach { object in
@@ -36,10 +39,6 @@ final class ReferenceGenerator: ReferenceGenerating {
             }
         }
         self.references = references
-
-        defer {
-            self.proj = nil
-        }
 
         // Projects, targets, groups and file references.
         // Note: The references of those type of objects should be generated first.
@@ -74,8 +73,8 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - project: project whose reference will be generated.
     ///   - identifiers: list of identifiers.
-    func generateProjectAndTargets(project: PBXProject,
-                                   identifiers: [String]) {
+    private func generateProjectAndTargets(project: PBXProject,
+                                           identifiers: [String]) {
         // Project
         fixReference(for: project, identifiers: identifiers)
 
@@ -95,8 +94,8 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - group: group instance.
     ///   - identifiers: list of identifiers.
-    fileprivate func generateGroupReferences(_ group: PBXGroup,
-                                             identifiers: [String]) throws {
+    private func generateGroupReferences(_ group: PBXGroup,
+                                         identifiers: [String]) throws {
         var identifiers = identifiers
         if let groupName = group.fileName() {
             identifiers.append(groupName)
@@ -121,7 +120,7 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - fileReference: file reference instance.
     ///   - identifiers: list of identifiers.
-    fileprivate func generateFileReference(_ fileReference: PBXFileReference, identifiers: [String]) throws {
+    private func generateFileReference(_ fileReference: PBXFileReference, identifiers: [String]) throws {
         var identifiers = identifiers
         if let groupName = fileReference.fileName() {
             identifiers.append(groupName)
@@ -135,8 +134,8 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - configurationList: configuration list instance.
     ///   - identifiers: list of identifiers.
-    fileprivate func generateConfigurationListReferences(_ configurationList: XCConfigurationList,
-                                                         identifiers: [String]) throws {
+    private func generateConfigurationListReferences(_ configurationList: XCConfigurationList,
+                                                     identifiers: [String]) throws {
 
         fixReference(for: configurationList, identifiers: identifiers)
 
@@ -157,8 +156,8 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - target: target instance.
     ///   - identifiers: list of identifiers.
-    fileprivate func generateTargetReferences(_ target: PBXTarget,
-                                              identifiers: [String]) throws {
+    private func generateTargetReferences(_ target: PBXTarget,
+                                          identifiers: [String]) throws {
         var identifiers = identifiers
         identifiers.append(target.name)
 
@@ -187,8 +186,8 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - targetDependency: target dependency instance.
     ///   - identifiers: list of identifiers.
-    fileprivate func generateTargetDependencyReferences(_ targetDependency: PBXTargetDependency,
-                                                        identifiers: [String]) throws {
+    private func generateTargetDependencyReferences(_ targetDependency: PBXTargetDependency,
+                                                    identifiers: [String]) throws {
         var identifiers = identifiers
 
         // Target proxy
@@ -218,8 +217,8 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - buildPhase: build phase instance.
     ///   - identifiers: list of identifiers.
-    fileprivate func generateBuildPhaseReferences(_ buildPhase: PBXBuildPhase,
-                                                  identifiers: [String]) throws {
+    private func generateBuildPhaseReferences(_ buildPhase: PBXBuildPhase,
+                                              identifiers: [String]) throws {
         var identifiers = identifiers
         if let name = buildPhase.name() {
             identifiers.append(name)
@@ -250,8 +249,8 @@ final class ReferenceGenerator: ReferenceGenerating {
     /// - Parameters:
     ///   - buildRule: build phase instance.
     ///   - identifiers: list of identifiers.
-    fileprivate func generateBuildRules(_ buildRule: PBXBuildRule,
-                                        identifiers: [String]) throws {
+    private func generateBuildRules(_ buildRule: PBXBuildRule,
+                                    identifiers: [String]) throws {
         var identifiers = identifiers
         if let name = buildRule.name {
             identifiers.append(name)
@@ -269,7 +268,8 @@ extension ReferenceGenerator {
     /// - Parameters:
     ///   - object: The object to generate a reference for
     ///   - identifiers: list of identifiers used to generate the reference of the object.
-    func fixReference<T: PBXObject>(for object: T, identifiers: [String]) {
+    func fixReference<T: PBXObject>(for object: T,
+                                    identifiers: [String]) {
         if object.reference.temporary {
             var identifiers = identifiers
             if let context = object.context {
@@ -284,17 +284,38 @@ extension ReferenceGenerator {
                 .replacingOccurrences(of: "XC", with: "")
                 .filter { String($0).lowercased() != String($0) }
 
-            let id = "\(acronym)_\(([typeName] + identifiers).joined(separator: "-"))"
-
             var reference = ""
             var counter = 0
             // Get the first reference that doesn't already exist
             repeat {
                 counter += 1
-                reference = "\(id)_\(counter)".md5.uppercased()
+                reference = self.generateReferenceFrom(acronym: acronym,
+                                                       typeName: typeName,
+                                                       identifiers: identifiers,
+                                                       counter: counter)
             } while (references.contains(reference))
             references.insert(reference)
             object.reference.fix(reference)
+        }
+    }
+
+    private func generateReferenceFrom(acronym: String,
+                                       typeName: String,
+                                       identifiers: [String],
+                                       counter: Int) -> String {
+
+        let typeNameAndIdentifiers = ([typeName] + identifiers).joined(separator: "-")
+        switch self.outputSettings.projReferenceFormat {
+
+        case .withPrefixAndSuffix:
+            let base = "\(acronym)_\(typeNameAndIdentifiers.md5.uppercased())"
+            if counter > 1 {
+                return "\(base)_\(counter)"
+            } else {
+                return base
+            }
+        case .xcode:
+            return "\(acronym)_\(typeNameAndIdentifiers)_\(counter)".md5.uppercased()
         }
     }
 }

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -276,15 +276,8 @@ extension ReferenceGenerator {
                 identifiers.append(context)
             }
             let typeName = String(describing: type(of: object))
-
-            // Get acronym to be used as prefix for the reference.
-            // PBXFileReference is turned to FR.
-            let acronym = typeName
-                .replacingOccurrences(of: "PBX", with: "")
-                .replacingOccurrences(of: "XC", with: "")
-                .filter { String($0).lowercased() != String($0) }
-
-            let id = "\(acronym)_\(([typeName] + identifiers).joined(separator: "-").md5.uppercased())"
+            let id = ([typeName] + identifiers).joined(separator: "-").md5.uppercased()
+            
             var reference = ""
             var counter = 0
             // get the first reference that doesn't already exist
@@ -293,6 +286,7 @@ extension ReferenceGenerator {
                 reference = id
                 if counter > 1 {
                     reference += "_\(counter)"
+                    reference = reference.md5.uppercased()
                 }
             } while (references.contains(reference))
             references.insert(reference)

--- a/Tests/xcodeprojTests/Objects/Project/PBXProj+XCTest.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProj+XCTest.swift
@@ -3,8 +3,8 @@ import Foundation
 
 extension PBXProj {
     func encode() throws -> String {
-        let encoder = PBXProjEncoder()
         let outputSettings = PBXOutputSettings()
-        return try encoder.encode(proj: self, outputSettings: outputSettings)
+        let encoder = PBXProjEncoder(outputSettings: outputSettings)
+        return try encoder.encode(proj: self)
     }
 }

--- a/Tests/xcodeprojTests/Objects/Project/PBXProjEncoderTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProjEncoderTests.swift
@@ -4,12 +4,10 @@ import Foundation
 import XCTest
 
 class PBXProjEncoderTests: XCTestCase {
-    var encoder: PBXProjEncoder!
     var proj: PBXProj!
 
     override func setUp() {
         super.setUp()
-        encoder = PBXProjEncoder()
         let dic = iosProjectDictionary()
         do {
             proj = try PBXProj(jsonDictionary: dic.1)
@@ -296,7 +294,7 @@ class PBXProjEncoderTests: XCTestCase {
 
     private func encodeProject(settings: PBXOutputSettings = PBXOutputSettings(), line: UInt = #line) -> String {
         do {
-            return try encoder.encode(proj: proj, outputSettings: settings)
+            return try PBXProjEncoder(outputSettings: settings).encode(proj: proj)
         } catch let error {
             XCTFail("Unexpected error encoding project: \(error)", line: line)
             return ""
@@ -305,7 +303,7 @@ class PBXProjEncoderTests: XCTestCase {
 
     private func encodeProjectThrows<E>(error expectedError: E, line: UInt = #line) where E: Error {
         do {
-            _ = try encoder.encode(proj: proj, outputSettings: PBXOutputSettings())
+            _ = try PBXProjEncoder(outputSettings: PBXOutputSettings()).encode(proj: proj)
             XCTFail("Expected '\(expectedError)' to be thrown", line: line)
         } catch let error {
             if type(of: expectedError) != type(of: error) {

--- a/Tests/xcodeprojTests/Utils/ObjectReferenceTests.swift
+++ b/Tests/xcodeprojTests/Utils/ObjectReferenceTests.swift
@@ -4,7 +4,8 @@ import XCTest
 
 class ObjectReferenceTests: XCTestCase {
 
-    let referenceGenerator = ReferenceGenerator()
+    let xcodeReferenceGenerator = ReferenceGenerator(outputSettings: PBXOutputSettings(projReferenceFormat: .xcode))
+    let prefixedReferenceGenerator = ReferenceGenerator(outputSettings: PBXOutputSettings(projReferenceFormat: .withPrefixAndSuffix))
 
     func test_reference_cachesObject() {
         let reference = PBXObjectReference()
@@ -41,6 +42,15 @@ class ObjectReferenceTests: XCTestCase {
         XCTAssertFalse(reference.temporary)
     }
 
+    func test_reference_tempHasPrefix() {
+        let reference = PBXObjectReference()
+        XCTAssertTrue(reference.value.hasPrefix("TEMP_"))
+        reference.fix("a")
+        XCTAssertFalse(reference.value.hasPrefix("TEMP_"))
+        reference.invalidate()
+        XCTAssertTrue(reference.value.hasPrefix("TEMP_"))
+    }
+
     func test_reference_changesTemporary() {
         let reference = PBXObjectReference()
         XCTAssertTrue(reference.temporary)
@@ -53,18 +63,9 @@ class ObjectReferenceTests: XCTestCase {
     func test_reference_generation_changesPerObject() {
         let file = PBXFileReference()
         let buildFile = PBXBuildFile(file: file)
-        referenceGenerator.fixReference(for: file, identifiers: ["a"])
-        referenceGenerator.fixReference(for: buildFile, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: file, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: buildFile, identifiers: ["a"])
         XCTAssertNotEqual(file.reference.value, buildFile.reference.value)
-    }
-
-    func test_reference_generation_isDeterministic() {
-        let object = PBXFileReference()
-        let object2 = PBXFileReference()
-        referenceGenerator.fixReference(for: object, identifiers: ["a"])
-        referenceGenerator.references.removeAll()
-        referenceGenerator.fixReference(for: object2, identifiers: ["a"])
-        XCTAssertEqual(object.reference.value, object2.reference.value)
     }
 
     func test_reference_generation_usesIdentifier() {
@@ -72,34 +73,26 @@ class ObjectReferenceTests: XCTestCase {
         object.context = "1"
         let object2 = PBXFileReference()
         object2.context = "2"
-        referenceGenerator.fixReference(for: object, identifiers: ["a"])
-        referenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object2, identifiers: ["a"])
         XCTAssertNotEqual(object.reference.value, object2.reference.value)
     }
 
     func test_reference_generation_doesntChangeFixed() {
         let object = PBXFileReference()
-        referenceGenerator.fixReference(for: object, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["a"])
         let value = object.reference.value
-        referenceGenerator.fixReference(for: object, identifiers: ["b"])
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["b"])
         XCTAssertEqual(value, object.reference.value)
     }
 
-    func test_reference_generation_handleDuplicates() {
-        let object = PBXFileReference()
-        let object2 = PBXFileReference()
-        referenceGenerator.fixReference(for: object, identifiers: ["a"])
-        referenceGenerator.fixReference(for: object2, identifiers: ["a"])
-        XCTAssertNotEqual(object.reference.value, object2.reference.value)
-    }
-
-    func test_reference_generation_handleMultipleDuplicates() {
+    func test_reference_generation_handlesMultipleDuplicates() {
         let object = PBXFileReference()
         let object2 = PBXFileReference()
         let object3 = PBXFileReference()
-        referenceGenerator.fixReference(for: object, identifiers: ["a"])
-        referenceGenerator.fixReference(for: object2, identifiers: ["a"])
-        referenceGenerator.fixReference(for: object3, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object3, identifiers: ["a"])
         XCTAssertNotEqual(object.reference.value, object2.reference.value)
         XCTAssertNotEqual(object2.reference.value, object3.reference.value)
         XCTAssertNotEqual(object3.reference.value, object.reference.value)
@@ -114,20 +107,69 @@ class ObjectReferenceTests: XCTestCase {
         XCTAssertTrue(reference.value.hasPrefix("TEMP_"))
     }
 
-    func test_reference_generation_nonTempHas32Characters() {
+
+    /// MARK: - XCode style generation
+
+    func test_reference_generation_xcode_isDeterministic() {
         let object = PBXFileReference()
-        referenceGenerator.fixReference(for: object, identifiers: ["a"])
+        let object2 = PBXFileReference()
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["a"])
+        xcodeReferenceGenerator.references.removeAll()
+        xcodeReferenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        XCTAssertEqual(object.reference.value, object2.reference.value)
+    }
+
+    func test_reference_generation_xcode_nonTempHas32Characters() {
+        let object = PBXFileReference()
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["a"])
         XCTAssertTrue(object.reference.value.count == 32)
     }
 
-
-    func test_reference_generation_duplicatesHasOnlyAlphaNumerics() {
+    func test_reference_generation_xcode_duplicatesHave32Characters() {
         let object = PBXFileReference()
         let object2 = PBXFileReference()
-        referenceGenerator.fixReference(for: object, identifiers: ["a"])
-        referenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        XCTAssertTrue(object.reference.value.count == 32)
+        XCTAssertTrue(object2.reference.value.count == 32)
+    }
+
+    func test_reference_generation_xcode_duplicatesHaveOnlyAlphaNumerics() {
+        let object = PBXFileReference()
+        let object2 = PBXFileReference()
+        xcodeReferenceGenerator.fixReference(for: object, identifiers: ["a"])
+        xcodeReferenceGenerator.fixReference(for: object2, identifiers: ["a"])
         XCTAssertTrue(object.reference.value.unicodeScalars.filter { CharacterSet.alphanumerics.inverted.contains($0) }.count == 0)
         XCTAssertTrue(object2.reference.value.unicodeScalars.filter { CharacterSet.alphanumerics.inverted.contains($0) }.count == 0)
     }
 
+
+    // MARK: - Prefix format generation
+
+    func test_reference_generation_prefixed_isDeterministic() {
+        let object = PBXFileReference()
+        let object2 = PBXFileReference()
+        prefixedReferenceGenerator.fixReference(for: object, identifiers: ["a"])
+        prefixedReferenceGenerator.references.removeAll()
+        prefixedReferenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        XCTAssertEqual(object.reference.value, object2.reference.value)
+    }
+
+    func test_reference_generation_prefixed_includesAcronym() {
+        let file = PBXFileReference()
+        let config = XCBuildConfiguration(name: "g")
+        prefixedReferenceGenerator.fixReference(for: file, identifiers: ["a"])
+        prefixedReferenceGenerator.fixReference(for: config, identifiers: ["a"])
+        XCTAssertTrue(file.reference.value.hasPrefix("FR_"))
+        XCTAssertTrue(config.reference.value.hasPrefix("BC_"))
+    }
+
+    func test_reference_generation_prefixed_duplicateHasSuffix() {
+        let object = PBXFileReference()
+        let object2 = PBXFileReference()
+        prefixedReferenceGenerator.fixReference(for: object, identifiers: ["a"])
+        prefixedReferenceGenerator.fixReference(for: object2, identifiers: ["a"])
+        XCTAssertNotEqual(object.reference.value, object2.reference.value)
+        XCTAssertTrue(object2.reference.value.hasSuffix("_2"))
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/YYY

### Short description 📝
Addresses https://github.com/tuist/xcodeproj/issues/344

### Solution 📦
- Applies the MD5 to the whole reference ID
- Appends the counter to the ID *before* applying the MD5 hash
- Simplified the reference search by always appending the counter
- @keefmoon added tests for the format of the reference to make sure it is compatible with common XCode project tools (like sort.sh)
