### PR TITLE
SwiftShell is only required by the test target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,8 @@ let package = Package(
                 dependencies: [
                     "PathKit",
                     "AEXML",
-                    "SwiftShell"
                 ]),
         .testTarget(name: "xcodeprojTests", dependencies: ["xcodeproj"]),
-        .testTarget(name: "xcodeprojIntegrationTests", dependencies: ["xcodeproj"]),
+        .testTarget(name: "xcodeprojIntegrationTests", dependencies: ["xcodeproj", "SwiftShell"]),
     ]
 )


### PR DESCRIPTION
Without this change SwiftPM will unnecessarily clone and build the `SwiftShell` library even though it is only used by one of the tests.