### PR TITLE
Add .instrpkg as known PBXProductType

### DIFF
--- a/Sources/xcodeproj/Objects/Targets/PBXProductType.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXProductType.swift
@@ -22,6 +22,7 @@ public enum PBXProductType: String, Decodable {
     case xpcService = "com.apple.product-type.xpc-service"
     case ocUnitTestBundle = "com.apple.product-type.bundle.ocunit-test"
     case xcodeExtension = "com.apple.product-type.xcode-extension"
+    case instrumentsPackage = "com.apple.product-type.instruments-package"
 
     /// Returns the file extension for the given product type.
     public var fileExtension: String? {
@@ -46,6 +47,8 @@ public enum PBXProductType: String, Decodable {
             return "xpc"
         case .ocUnitTestBundle:
             return "octest"
+        case .instrumentsPackage:
+            return "instrpkg"
         case .none:
             return nil
         }


### PR DESCRIPTION
### Short description 📝
xcodeproj fails to parse pbxproj which contains `*.instrpkg` file.

> dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "productType", intValue: nil)], debugDescription: "Cannot initialize PBXProductType from invalid String value com.apple.product-type.instruments-package", underlyingError: nil))

Replicable with this sample project. 
[sample.zip](https://github.com/tuist/xcodeproj/files/2655874/sample.zip)

### Implementation 👩‍💻👨‍💻

Added enum case for UTI `com.apple.product-type.instruments-package`.