### PR TITLE
Fix remote target dependency

### DIFF
--- a/Sources/xcodeproj/Objects/Configuration/XCConfigurationList.swift
+++ b/Sources/xcodeproj/Objects/Configuration/XCConfigurationList.swift
@@ -68,7 +68,7 @@ extension XCConfigurationList {
     ///
     /// - Parameter name: configuration name.
     /// - Returns: build configuration if it exists.
-    public func configuration(name: String) throws -> XCBuildConfiguration? {
+    public func configuration(name: String) -> XCBuildConfiguration? {
         return buildConfigurations.first(where: { $0.name == name })
     }
 

--- a/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
@@ -47,7 +47,7 @@ public final class PBXContainerItemProxy: PBXObject {
     ///   - remoteGlobalID: remote global ID.
     ///   - proxyType: proxy type.
     ///   - remoteInfo: remote info.
-    public init(containerPortal: PBXProject,
+    public init(containerPortal: PBXObject,
                 remoteGlobalID: PBXObject? = nil,
                 proxyType: ProxyType? = nil,
                 remoteInfo: String? = nil) {

--- a/Sources/xcodeproj/Objects/Targets/PBXNativeTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXNativeTarget.swift
@@ -77,7 +77,7 @@ public extension PBXNativeTarget {
     /// - Parameter target: dependency target.
     /// - Returns: target dependency reference.
     /// - Throws: an error if the dependency cannot be created.
-    public func addDependency(target: PBXNativeTarget) throws -> PBXTargetDependency? {
+    public func addDependency(target: PBXTarget) throws -> PBXTargetDependency? {
         let objects = try target.objects()
         guard let project = objects.projects.first?.value else {
             return nil

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -85,4 +85,19 @@ final class PBXFileElementTests: XCTestCase {
             "wrapsLines": "1",
         ]
     }
+    
+    func test_plistKeyAndValue_returns_dictionary_value() throws {
+        let foo = PBXFileElement()
+        let proj = PBXProj()
+        let reference = ""
+        if case .dictionary = try foo.plistKeyAndValue(proj: proj, reference: reference).value {
+            //noop we’re good!
+        } else {
+            XCTFail("""
+                The implementation of PBXFileElement.plistKeyAndValue has changed,
+                which will break PBXReferenceProxy’s overriden implementation.
+                This must be fixed!
+                """)
+        }
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/352

### Short description 📝

This PR allows creating fileref and target references that in other *embedded* projects and linking targets (in the primary project) to those target references (in the other project).

### Solution 📦

A small amount of changes to function parameter types and inheritances, but they are somewhat intrusive.

### Implementation 👩‍💻👨‍💻

1. `PBNativeTarget.addDependency` adapted to take `PBXTarget` rather than `PBXNativeTarget`
2. `PBContainerItemProxy`’s initializer modified to take `PBXObject` rather than only `PBXProject` because when adding references to another project’s targets you have to pass the target’s fileref.
3. In order to link to targets in other projects the `PBReferenceProxxy` had to made to derive `PBXFileElement`. AFAICT this is logical and an omission.

### Note

I also did the unrelated change: 9b0c6370ce751c120dc6e5f55a0105b4a3414794 which removes the `throws` type since the function doesn't in fact `throw`. This is API safe, but will show a warning for any end-users. Happy to remove this from this PR if desired.
