### PR TITLE
Project encoding performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## next version
 
 ### Fixed
+- Improve project encoding performance https://github.com/tuist/xcodeproj/pull/371 by @CognitiveDisson
+
+### Fixed
 - Project decoding performance issue https://github.com/tuist/xcodeproj/pull/365 by @CognitiveDisson.
 
 ### Added

--- a/Sources/xcodeproj/Extensions/Dictionary+Enumerate.swift
+++ b/Sources/xcodeproj/Extensions/Dictionary+Enumerate.swift
@@ -7,7 +7,10 @@ extension Dictionary {
         using block: (Any, Any, UnsafeMutablePointer<ObjCBool>) throws -> Void) throws
     {
         var blockError: Error?
-        (self as NSDictionary).enumerateKeysAndObjects(options: opts) { (key, obj, stops) in
+        // For performance it is very important to create a separate dictionary instance.
+        // (self as NSDictionary).enumerateKeys... - works much slower
+        let dictionary = NSDictionary(dictionary: self)
+        dictionary.enumerateKeysAndObjects(options: opts) { (key, obj, stops) in
             do {
                 try block(key, obj, stops)
             } catch {

--- a/Sources/xcodeproj/Extensions/Dictionary+Enumerate.swift
+++ b/Sources/xcodeproj/Extensions/Dictionary+Enumerate.swift
@@ -15,6 +15,7 @@ extension Dictionary {
                 try block(key, obj, stops)
             } catch {
                 blockError = error
+                stops.pointee = true
             }
         }
         if let error = blockError {

--- a/Sources/xcodeproj/Objects/Project/PBXObjects.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjects.swift
@@ -339,6 +339,20 @@ extension PBXObjects {
         phases.merge(frameworksBuildPhases as [PBXObjectReference: PBXBuildPhase], uniquingKeysWith: { first, _ in return first })
         return phases
     }
+    
+    var buildPhaseFile: [PBXObjectReference: PBXBuildPhaseFile] {
+        let values: [[PBXBuildPhaseFile]] = buildPhases.values.map ({ buildPhase in
+            let files = buildPhase.files
+            let buildPhaseFile: [PBXBuildPhaseFile] = files.compactMap({ (file: PBXBuildFile) -> (PBXBuildPhaseFile) in
+                return PBXBuildPhaseFile(
+                    buildFile: file,
+                    buildPhase: buildPhase
+                )
+            })
+            return buildPhaseFile
+        })
+        return Dictionary(uniqueKeysWithValues: values.flatMap({$0}).map({ ($0.buildFile.reference, $0) }))
+    }
 
     /// Runs the given closure for each of the objects that are part of the project.
     ///

--- a/Sources/xcodeproj/Objects/Project/PBXObjects.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjects.swift
@@ -340,6 +340,9 @@ extension PBXObjects {
         return phases
     }
     
+    // This dictionary is used to quickly get a connection between the build phase and the build files of this phase.
+    // This is used to decode build files. (we need the name of the build phase)
+    // Otherwise, we would have to go through all the build phases for each file.
     var buildPhaseFile: [PBXObjectReference: PBXBuildPhaseFile] {
         let values: [[PBXBuildPhaseFile]] = buildPhases.values.map ({ buildPhase in
             let files = buildPhase.files

--- a/Sources/xcodeproj/Objects/Project/PBXOutputSettings.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXOutputSettings.swift
@@ -46,6 +46,15 @@ public enum PBXFileOrder {
             return lhs.0 < rhs.0
         }
     }
+    
+    internal func sort(lhs: (PBXObjectReference, PBXBuildPhaseFile), rhs: (PBXObjectReference, PBXBuildPhaseFile)) -> Bool {
+        switch self {
+        case .byFilename:
+            return sortUsingNames(lhs.1.buildFile, rhs.1.buildFile)
+        default:
+            return lhs.0 < rhs.0
+        }
+    }
 
     internal func sort(lhs: (PBXObjectReference, PBXFileReference), rhs: (PBXObjectReference, PBXFileReference)) -> Bool {
         switch self {

--- a/Tests/xcodeprojTests/Objects/Project/PBXOutputSettingsTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXOutputSettingsTests.swift
@@ -9,6 +9,9 @@ class PBXOutputSettingsTsts: XCTestCase {
 
     var objectBuildFileAssets: (PBXObjectReference, PBXBuildFile)!
     var objectBuildFileMain: (PBXObjectReference, PBXBuildFile)!
+    
+    var objectBuildPhaseFileAssets: (PBXObjectReference, PBXBuildPhaseFile)!
+    var objectBuildPhaseFileMain: (PBXObjectReference, PBXBuildPhaseFile)!
 
     var fileReferenceAssets: PBXFileReference!
     var fileReferenceCoreData: PBXFileReference!
@@ -38,6 +41,9 @@ class PBXOutputSettingsTsts: XCTestCase {
 
         objectBuildFileAssets = (buildFileAssets.reference, buildFileAssets)
         objectBuildFileMain = (buildFileMain.reference, buildFileMain)
+        
+        objectBuildPhaseFileAssets = proj.objects.buildPhaseFile.first { $0.value.buildFile.file?.fileName() == "Assets.xcassets" }!
+        objectBuildPhaseFileMain = proj.objects.buildPhaseFile.first { $0.value.buildFile.file?.fileName() == "Main.storyboard" }!
 
         fileReferenceAssets = proj.fileReferences.first { $0.fileName() == "Assets.xcassets" }!
         fileReferenceCoreData = proj.fileReferences.first { $0.fileName() == "CoreData.framework" }!
@@ -82,6 +88,18 @@ class PBXOutputSettingsTsts: XCTestCase {
         buildFileMain.file = nil
         XCTAssertFalse(PBXFileOrder.byFilename.sort(lhs: (ref1, buildFileAssets), rhs: (ref2, buildFileMain)))
         XCTAssertTrue(PBXFileOrder.byFilename.sort(lhs: (ref2, buildFileMain), rhs: (ref1, buildFileAssets)))
+    }
+    
+    // MARK: - PBXFileOrder - PBXBuildPhaseFile
+    
+    func test_PBXFileOrder_PBXBuildPhaseFile_by_uuid() {
+        XCTAssertFalse(PBXFileOrder.byUUID.sort(lhs: objectBuildPhaseFileAssets, rhs: objectBuildPhaseFileMain))
+        XCTAssertTrue(PBXFileOrder.byUUID.sort(lhs: objectBuildPhaseFileMain, rhs: objectBuildPhaseFileAssets))
+    }
+    
+    func test_PBXFileOrder_PBXBuildPhaseFile_by_filename() {
+        XCTAssertTrue(PBXFileOrder.byFilename.sort(lhs: objectBuildPhaseFileAssets, rhs: objectBuildPhaseFileMain))
+        XCTAssertFalse(PBXFileOrder.byFilename.sort(lhs: objectBuildPhaseFileMain, rhs: objectBuildPhaseFileAssets))
     }
 
     // MARK: - PBXFileOrder - PBXFileReference


### PR DESCRIPTION
## Improve project encoding performance 📝
For my test project: `xcodeproject.write(path: path)` was 57 seconds, and it became 8 seconds.

## Improvements
## Obtain PBXBuildFile from PBXBuildPhase instead searching PBXBuildPhase in PBXObjects
The main blocker was obtaining build phase name for PBXBuildFile encoding from PBXObjects -`plistKeyAndValue`. For each file, we ran through all the build phases and searched for a file with the same identifier. Of course, it took a lot of time.

Instead, I added an utility class that contains the file and build phase from which this file is. I am building this class from the build phase files.

This speed up for encoding on 46 seconds. ( 11 seconds instead of 57 ).

## Replaced the append in the string to append into the array + join.
Append into a typed array faster than into a string. This gave about 3 seconds. ( 8 seconds instead of 11 ).

Also this preparation for the subsequent changes. For an array, we can pre-set the size. This will allow non-allocation of memory several times. And we can prepare the data for recording in parallel.

Now this code slows down the most:
```
        elements.forEach { (element, multiline) in
            write(dictionaryKey: element.key, dictionaryValue: element.value, multiline: multiline)
        }
```
We can pass an inout array for each thread. I'm working on it now.