### PR TITLE
Add intents service product type

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,22 +3,31 @@
 require 'fileutils'
 require 'colorize'
 
+task :style_correct do
+  system("swiftformat .")
+  system("swiftlint autocorrect")
+end
+
 task :release_check do
   puts "Running tests".colorize(:cyan)
-  system("swift test") || abort
+  system("swift test")
 
   puts "Building for release".colorize(:cyan)
-  system("swift build -c release") || abort
+  system("swift build -c release")
 
   puts "Compiling Carthage project".colorize(:cyan)
-  system("xcodebuild -project xcodeproj-Carthage.xcodeproj -scheme xcodeproj") || abort
+  system("xcodebuild -project xcodeproj-Carthage.xcodeproj -scheme xcodeproj")
 end
 
 task :arhive_carthage do
-  system("carthage build --no-skip-current --platform macOS") || abort
-  system("carthage archive xcodeproj") || abort
+  system("carthage build --no-skip-current --platform macOS")
+  system("carthage archive xcodeproj")
 end
 
 task :carthage_update_dependencies do
-  system("carthage update --platform macOS") || abort
+  system("carthage update --platform macOS")
+end
+
+def system(*args)
+  Kernel.system(*args) || abort
 end

--- a/Sources/xcodeproj/Objects/Targets/PBXProductType.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXProductType.swift
@@ -23,6 +23,7 @@ public enum PBXProductType: String, Decodable {
     case ocUnitTestBundle = "com.apple.product-type.bundle.ocunit-test"
     case xcodeExtension = "com.apple.product-type.xcode-extension"
     case instrumentsPackage = "com.apple.product-type.instruments-package"
+    case intentsServiceExtension = "com.apple.product-type.app-extension.intents-service"
 
     /// Returns the file extension for the given product type.
     public var fileExtension: String? {
@@ -39,7 +40,7 @@ public enum PBXProductType: String, Decodable {
             return "bundle"
         case .unitTestBundle, .uiTestBundle:
             return "xctest"
-        case .appExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension:
+        case .appExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension, .intentsServiceExtension:
             return "appex"
         case .commandLineTool:
             return nil

--- a/Tests/xcodeprojTests/Objects/Targets/PBXProductTypeTests.swift
+++ b/Tests/xcodeprojTests/Objects/Targets/PBXProductTypeTests.swift
@@ -86,4 +86,8 @@ final class PBXProductTypeTests: XCTestCase {
     func test_xcodeExtension_hasTheRightValue() {
         XCTAssertEqual(PBXProductType.xcodeExtension.rawValue, "com.apple.product-type.xcode-extension")
     }
+
+    func test_intentsServiceExtension_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.intentsServiceExtension.rawValue, "com.apple.product-type.app-extension.intents-service")
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/378

### Short description 📝
Include the product `com.apple.product-type.app-extension.intents-service` in the list of supported products.

cc @ileitch 