### PR TITLE
FileElement fullpath optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Fixed
+- Fixed file full path performance issue https://github.com/tuist/xcodeproj/pull/372 by @CognitiveDisson.
+
 ## 6.6.0
 
 ### Fixed

--- a/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
@@ -62,7 +62,7 @@ public class PBXFileElement: PBXContainerItem, PlistSerializable {
         self.tabWidth = tabWidth
         self.wrapsLines = wrapsLines
         super.init()
-        assignParentForChildren()
+        assignParentToChildren()
     }
 
     // MARK: - Decodable
@@ -180,12 +180,13 @@ public extension PBXFileElement {
         return baseReference.path
     }
     
-    func assignParentForChildren() {
-        if let group = self as? PBXGroup {
-            for child in group.children {
-                child.parent = self
-                child.assignParentForChildren()
-            }
+    // This method is needed to recursively set the parent to all elements.
+    // This allows us to more quickly find the full path to the elements.
+    func assignParentToChildren() {
+        guard let group = self as? PBXGroup else { return }
+        for child in group.children {
+            child.parent = self
+            child.assignParentToChildren()
         }
     }
 }

--- a/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
@@ -28,6 +28,9 @@ public class PBXFileElement: PBXContainerItem, PlistSerializable {
 
     /// Element wraps lines.
     public var wrapsLines: Bool?
+    
+    /// Element parent.
+    public weak var parent: PBXFileElement?
 
     // MARK: - Init
 
@@ -59,6 +62,7 @@ public class PBXFileElement: PBXContainerItem, PlistSerializable {
         self.tabWidth = tabWidth
         self.wrapsLines = wrapsLines
         super.init()
+        assignParentForChildren()
     }
 
     // MARK: - Decodable
@@ -141,15 +145,14 @@ public extension PBXFileElement {
     /// - Returns: file element absolute path.
     /// - Throws: an error if the absolute path cannot be obtained.
     func fullPath(sourceRoot: Path) throws -> Path? {
-        let projectObjects = try objects()
         switch sourceTree {
         case .absolute?:
             return path.flatMap { Path($0) }
         case .sourceRoot?:
             return path.flatMap { sourceRoot + $0 }
         case .group?:
-            guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot }
-            guard let groupPath = try group.value.fullPath(sourceRoot: sourceRoot) else { return nil }
+            guard let group = parent else { return sourceRoot }
+            guard let groupPath = try group.fullPath(sourceRoot: sourceRoot) else { return nil }
             guard let filePath = self is PBXVariantGroup ? try baseVariantGroupPath() : path else { return groupPath }
             return groupPath + filePath
         default:
@@ -168,5 +171,14 @@ public extension PBXFileElement {
             .compactMap({ try $0.getThrowingObject() as PBXFileElement })
             .first(where: { $0.name == "Base" }) else { return nil }
         return baseReference.path
+    }
+    
+    func assignParentForChildren() {
+        if let group = self as? PBXGroup {
+            for child in group.children {
+                child.parent = self
+                child.assignParentForChildren()
+            }
+        }
     }
 }

--- a/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
@@ -28,7 +28,7 @@ public class PBXFileElement: PBXContainerItem, PlistSerializable {
 
     /// Element wraps lines.
     public var wrapsLines: Bool?
-    
+
     /// Element parent.
     public weak var parent: PBXFileElement?
 
@@ -152,7 +152,7 @@ public extension PBXFileElement {
             return path.flatMap { sourceRoot + $0 }
         case .group?:
             let groupPath: Path?
-            
+
             if let group = parent {
                 groupPath = try group.fullPath(sourceRoot: sourceRoot) ?? sourceRoot
             } else {
@@ -168,7 +168,7 @@ public extension PBXFileElement {
                 guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot }
                 groupPath = try group.value.fullPath(sourceRoot: sourceRoot)
             }
-            
+
             guard let fullGroupPath: Path = groupPath else { return nil }
             guard let filePath = self is PBXVariantGroup ? try baseVariantGroupPath() : path else { return fullGroupPath }
             return fullGroupPath + filePath
@@ -189,7 +189,7 @@ public extension PBXFileElement {
             .first(where: { $0.name == "Base" }) else { return nil }
         return baseReference.path
     }
-    
+
     // This method is needed to recursively set the parent to all elements.
     // This allows us to more quickly find the full path to the elements.
     func assignParentToChildren() {

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -133,6 +133,7 @@ public extension PBXGroup {
         return groupName.components(separatedBy: "/").reduce(into: [PBXGroup](), { groups, name in
             let group = groups.last ?? self
             let newGroup = PBXGroup(children: [], sourceTree: .group, name: name, path: options.contains(.withoutFolder) ? nil : name)
+            newGroup.parent = self
             group.childrenReferences.append(newGroup.reference)
             objects.add(object: newGroup)
             groups.append(newGroup)
@@ -186,6 +187,7 @@ public extension PBXGroup {
             path: path
         )
         projectObjects.add(object: fileReference)
+        fileReference.parent = self
         if !childrenReferences.contains(fileReference.reference) {
             childrenReferences.append(fileReference.reference)
         }

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -89,7 +89,7 @@ public final class PBXProj: Decodable {
             objects.add(object: object)
         }
         self.objects = objects
-        
+
         try rootGroup()?.assignParentToChildren()
     }
 }

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -47,6 +47,9 @@ public final class PBXProj: Decodable {
         self.classes = classes
         rootObjectReference = rootObject?.reference
         self.objects = PBXObjects(objects: objects)
+        if let group = try? rootGroup(), let rootGroup = group {
+            rootGroup.assignParentForChildren()
+        }
     }
 
     // MARK: - Decodable
@@ -86,6 +89,8 @@ public final class PBXProj: Decodable {
             objects.add(object: object)
         }
         self.objects = objects
+        
+        try rootGroup()?.assignParentForChildren()
     }
 }
 

--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -48,7 +48,7 @@ public final class PBXProj: Decodable {
         rootObjectReference = rootObject?.reference
         self.objects = PBXObjects(objects: objects)
         if let group = try? rootGroup(), let rootGroup = group {
-            rootGroup.assignParentForChildren()
+            rootGroup.assignParentToChildren()
         }
     }
 
@@ -90,7 +90,7 @@ public final class PBXProj: Decodable {
         }
         self.objects = objects
         
-        try rootGroup()?.assignParentForChildren()
+        try rootGroup()?.assignParentToChildren()
     }
 }
 

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -55,7 +55,7 @@ final class PBXFileElementTests: XCTestCase {
         XCTAssertEqual(fullPath?.string, "/a/path")
         XCTAssertNotNil(group.children.first?.parent)
     }
-    
+
     func test_fullPath_without_parent() throws {
         let sourceRoot = Path("/")
         let fileref = PBXFileReference(sourceTree: .group,
@@ -66,13 +66,13 @@ final class PBXFileElementTests: XCTestCase {
         let group = PBXGroup(children: [fileref],
                              sourceTree: .group,
                              name: "/to/be/ignored")
-        
+
         let objects = PBXObjects(objects: [fileref, group])
         fileref.reference.objects = objects
         group.reference.objects = objects
         // Remove parent for fallback test
         fileref.parent = nil
-        
+
         let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
         XCTAssertEqual(fullPath?.string, "/a/path")
     }

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -36,7 +36,7 @@ final class PBXFileElementTests: XCTestCase {
         XCTAssertEqual(subject, another)
     }
 
-    func test_fullPath() throws {
+    func test_fullPath_with_parent() throws {
         let sourceRoot = Path("/")
         let fileref = PBXFileReference(sourceTree: .group,
                                        fileEncoding: 1,
@@ -51,6 +51,28 @@ final class PBXFileElementTests: XCTestCase {
         fileref.reference.objects = objects
         group.reference.objects = objects
 
+        let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
+        XCTAssertEqual(fullPath?.string, "/a/path")
+        XCTAssertNotNil(group.children.first?.parent)
+    }
+    
+    func test_fullPath_without_parent() throws {
+        let sourceRoot = Path("/")
+        let fileref = PBXFileReference(sourceTree: .group,
+                                       fileEncoding: 1,
+                                       explicitFileType: "sourcecode.swift",
+                                       lastKnownFileType: nil,
+                                       path: "/a/path")
+        let group = PBXGroup(children: [fileref],
+                             sourceTree: .group,
+                             name: "/to/be/ignored")
+        
+        let objects = PBXObjects(objects: [fileref, group])
+        fileref.reference.objects = objects
+        group.reference.objects = objects
+        // Remove parent for fallback test
+        fileref.parent = nil
+        
         let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
         XCTAssertEqual(fullPath?.string, "/a/path")
     }

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -1,10 +1,67 @@
 import Foundation
+import PathKit
 import xcodeproj
+import SwiftShell
 import XCTest
 
 final class PBXGroupTests: XCTestCase {
+    
     func test_isa_returnsTheCorrectValue() {
         XCTAssertEqual(PBXGroup.isa, "PBXGroup")
+    }
+    
+    func test_addFile_assignParent() {
+        let sourceRoot = Path("/")
+        let project = PBXProj(
+            rootObject: nil,
+            objectVersion: 0,
+            archiveVersion: 0,
+            classes: [:],
+            objects: []
+        )
+        let group = PBXGroup(children: [],
+                             sourceTree: .group,
+                             name: "group")
+        project.add(object: group)
+        let filePath = "\(Path.temporary.string)/file"
+        Files.createFile(atPath: filePath, contents: nil, attributes: nil)
+        let file = try? group.addFile(at: Path(filePath), sourceRoot: sourceRoot)
+        
+        try! Files.removeItem(atPath: filePath)
+        XCTAssertNotNil(file?.parent)
+    }
+    
+    func test_addGroup_assignParent() {
+        let project = PBXProj(
+            rootObject: nil,
+            objectVersion: 0,
+            archiveVersion: 0,
+            classes: [:],
+            objects: []
+        )
+        let group = PBXGroup(children: [],
+                             sourceTree: .group,
+                             name: "group")
+        project.add(object: group)
+        
+        let childGroup = try? group.addGroup(named: "child_group").first
+
+        XCTAssertNotNil(childGroup??.parent)
+    }
+    
+    func test_createGroupWithFile_assignParent() {
+        let fileref = PBXFileReference(sourceTree: .group,
+                                       fileEncoding: 1,
+                                       explicitFileType: "sourcecode.swift",
+                                       lastKnownFileType: nil,
+                                       path: "/a/path")
+        
+        let group = PBXGroup(children: [fileref],
+                             sourceTree: .group,
+                             name: "group")
+        
+        
+        XCTAssertNotNil(group.children.first?.parent)
     }
 
     private func testDictionary() -> [String: Any] {

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -1,15 +1,14 @@
 import Foundation
 import PathKit
-import xcodeproj
 import SwiftShell
+import xcodeproj
 import XCTest
 
 final class PBXGroupTests: XCTestCase {
-    
     func test_isa_returnsTheCorrectValue() {
         XCTAssertEqual(PBXGroup.isa, "PBXGroup")
     }
-    
+
     func test_addFile_assignParent() {
         let sourceRoot = Path("/")
         let project = PBXProj(
@@ -26,11 +25,11 @@ final class PBXGroupTests: XCTestCase {
         let filePath = "\(Path.temporary.string)/file"
         Files.createFile(atPath: filePath, contents: nil, attributes: nil)
         let file = try? group.addFile(at: Path(filePath), sourceRoot: sourceRoot)
-        
+
         try! Files.removeItem(atPath: filePath)
         XCTAssertNotNil(file?.parent)
     }
-    
+
     func test_addGroup_assignParent() {
         let project = PBXProj(
             rootObject: nil,
@@ -43,24 +42,23 @@ final class PBXGroupTests: XCTestCase {
                              sourceTree: .group,
                              name: "group")
         project.add(object: group)
-        
+
         let childGroup = try? group.addGroup(named: "child_group").first
 
         XCTAssertNotNil(childGroup??.parent)
     }
-    
+
     func test_createGroupWithFile_assignParent() {
         let fileref = PBXFileReference(sourceTree: .group,
                                        fileEncoding: 1,
                                        explicitFileType: "sourcecode.swift",
                                        lastKnownFileType: nil,
                                        path: "/a/path")
-        
+
         let group = PBXGroup(children: [fileref],
                              sourceTree: .group,
                              name: "group")
-        
-        
+
         XCTAssertNotNil(group.children.first?.parent)
     }
 


### PR DESCRIPTION
I significantly speed up the full path obtaining , by storing the parent reference.

Was:

```
guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot } // problem
guard let groupPath = try group.value.fullPath(sourceRoot: sourceRoot) else { return nil }
```
Now:

```
guard let group = parent else { return sourceRoot }
guard let groupPath = try group.fullPath(sourceRoot: sourceRoot) else { return nil }
```