### PR TITLE
Add location variable to XCWorkspaceDataElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Added
+- Add location variable to XCWorkspaceDataElement https://github.com/tuist/xcodeproj/pull/387 by @pepibumur.
+
 ### Fixed
 - Fixed file full path performance issue https://github.com/tuist/xcodeproj/pull/372 by @CognitiveDisson.
 

--- a/Sources/xcodeproj/Workspace/XCWorkspaceDataElement.swift
+++ b/Sources/xcodeproj/Workspace/XCWorkspaceDataElement.swift
@@ -1,15 +1,25 @@
 import Foundation
 
-public enum XCWorkspaceDataElement {
+public enum XCWorkspaceDataElement: Equatable {
     public enum Error: Swift.Error {
         case unknownName(String)
     }
 
     case file(XCWorkspaceDataFileRef)
     case group(XCWorkspaceDataGroup)
-}
 
-extension XCWorkspaceDataElement: Equatable {
+    /// Returns the location to the workspace data element.
+    public var location: XCWorkspaceDataElementLocationType {
+        switch self {
+        case let .file(ref):
+            return ref.location
+        case let .group(ref):
+            return ref.location
+        }
+    }
+
+    // MARK: - Equatable
+
     public static func == (lhs: XCWorkspaceDataElement, rhs: XCWorkspaceDataElement) -> Bool {
         switch (lhs, rhs) {
         case let (.file(lhs), .file(rhs)):

--- a/Tests/xcodeprojTests/Workspace/XCWorkspaceDataElementTests.swift
+++ b/Tests/xcodeprojTests/Workspace/XCWorkspaceDataElementTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import PathKit
+import xcodeproj
+import XCTest
+
+final class XCWorkspaceDataElementTests: XCTestCase {
+    func test_location_when_group() {
+        let location: XCWorkspaceDataElementLocationType = .absolute("/path/to/group")
+        let group = XCWorkspaceDataGroup(location: location,
+                                         name: "group",
+                                         children: [])
+        let element = XCWorkspaceDataElement.group(group)
+
+        XCTAssertEqual(element.location, location)
+    }
+
+    func test_location_when_file() {
+        let location: XCWorkspaceDataElementLocationType = .absolute("/path/to/file.swift")
+        let file = XCWorkspaceDataFileRef(location: location)
+        let element = XCWorkspaceDataElement.file(file)
+
+        XCTAssertEqual(element.location, location)
+    }
+}


### PR DESCRIPTION
### Short description 📝
Add a new public convenience method to `XCWorkspaceDataElement` that returns the location of the element.