### PR TITLE
Fix conditional binding issue with swift 5

### DIFF
--- a/Sources/xcodeproj/Objects/Project/PBXProj.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProj.swift
@@ -47,7 +47,7 @@ public final class PBXProj: Decodable {
         self.classes = classes
         rootObjectReference = rootObject?.reference
         self.objects = PBXObjects(objects: objects)
-        if let group = try? rootGroup(), let rootGroup = group {
+        if let rootGroup = try? rootGroup() {
             rootGroup.assignParentToChildren()
         }
     }


### PR DESCRIPTION
### Short description 📝
Error from Xcode: `Initializer for conditional binding must have Optional type, not 'PBXGroup'`

Happening in new macOS project in Xcode 10.2 with Swift 5.

### Solution 📦
Remove rebinding of non-optional returned type

### Implementation 👩‍💻👨‍💻
Removed rebinding