### PR TITLE
Swift 5 Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **Breaking** Swift 5 support https://github.com/tuist/xcodeproj/pull/397 by @pepibumur.
 - `WorkspaceSettings.autoCreateSchemes` attribute https://github.com/tuist/xcodeproj/pull/399 by @pepibumur
+- Additional Swift 5 fixes: https://github.com/tuist/xcodeproj/pull/402 by @samisuteria
 
 ## 6.7.0
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 

--- a/Tests/xcodeprojTests/Extensions/XCTestCase+Assertions.swift
+++ b/Tests/xcodeprojTests/Extensions/XCTestCase+Assertions.swift
@@ -13,7 +13,7 @@ extension XCTestCase {
     }
 
     func XCTAssertThrowsSpecificError<T, E: EquatableError>(_ expression: @autoclosure () throws -> T, _ error: E, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
-        XCTAssertThrowsError(expression, message, file: file, line: line) { actualError in
+        XCTAssertThrowsError(try expression(), message(), file: file, line: line) { actualError in
             let message = "Expected \(error) got \(actualError)"
 
             guard let actualCastedError = actualError as? E else {

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -43,7 +43,7 @@ final class PBXGroupTests: XCTestCase {
 
         let childGroup = try? group.addGroup(named: "child_group").first
 
-        XCTAssertNotNil(childGroup??.parent)
+        XCTAssertNotNil(childGroup?.parent)
     }
 
     func test_createGroupWithFile_assignParent() {


### PR DESCRIPTION
### Short description 📝

Tests were not passing on CircleCI because project was not set up for Swift 5.

### Solution 📦

Update Package.swift for Swift 5 and update tests.

### Implementation 👩‍💻👨‍💻

- Update Package.swift for Swift 5.
- Update Tests
