### PR TITLE
Build phase name is inaccessible from outside.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Breaking** Swift 5 support https://github.com/tuist/xcodeproj/pull/397 by @pepibumur.
 - `WorkspaceSettings.autoCreateSchemes` attribute https://github.com/tuist/xcodeproj/pull/399 by @pepibumur
 - Additional Swift 5 fixes: https://github.com/tuist/xcodeproj/pull/402 by @samisuteria
+- Make build phase name public.
 
 ## 6.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - **Breaking** Swift 5 support https://github.com/tuist/xcodeproj/pull/397 by @pepibumur.
 - `WorkspaceSettings.autoCreateSchemes` attribute https://github.com/tuist/xcodeproj/pull/399 by @pepibumur
 - Additional Swift 5 fixes: https://github.com/tuist/xcodeproj/pull/402 by @samisuteria
-- Make build phase name public.
+- Make build phase name public by @llinardos.
 
 ## 6.7.0
 

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildPhase.swift
@@ -130,11 +130,11 @@ public extension PBXBuildPhase {
 
 // MARK: - Utils
 
-extension PBXBuildPhase {
+public extension PBXBuildPhase {
     /// Returns the build phase type.
     ///
     /// - Returns: build phase type.
-    public func type() -> BuildPhase? {
+    func type() -> BuildPhase? {
         return buildPhase
     }
 


### PR DESCRIPTION
Change visibility of build phase name making it public.

Resolves #404.

### Short description 📝
Makes the name public.

### Solution 📦
Change visibility of the extension including the method.

### Implementation 👩‍💻👨‍💻
- [ ] Change visibility of the extension including the method.