### PR TITLE
Embed frameworks build phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
       - run:
           name: Install Tools
           command: |
+            brew upgrade
             brew install swiftformat
-            brew install swiftlint
             bundle config build.sqlite3 --with-sqlite3-dir=/opt/local
       - run:
           name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Breaking** Swift 5 support https://github.com/tuist/xcodeproj/pull/397 by @pepibumur.
 - `WorkspaceSettings.autoCreateSchemes` attribute https://github.com/tuist/xcodeproj/pull/399 by @pepibumur
 - Additional Swift 5 fixes: https://github.com/tuist/xcodeproj/pull/402 by @samisuteria
+- Can access embed frameworks build phase for a target by @llinardos.
 
 ## 6.7.0
 

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -228,4 +228,14 @@ public extension PBXTarget {
             .compactMap { try $0.fileReference!.getThrowingObject() as? PBXFileElement }
             ?? []
     }
+
+    /// Returns the embed frameworks build phases.
+    ///
+    /// - Returns: Embed frameworks build phases.
+    func embedFrameworksBuildPhases() -> [PBXCopyFilesBuildPhase] {
+        return self.buildPhases
+            .filter { $0.buildPhase == .copyFiles }
+            .compactMap { $0 as? PBXCopyFilesBuildPhase }
+            .filter { $0.dstSubfolderSpec == .frameworks }
+    }
 }

--- a/Tests/xcodeprojTests/Objects/Targets/PBXTargetTests.swift
+++ b/Tests/xcodeprojTests/Objects/Targets/PBXTargetTests.swift
@@ -15,4 +15,74 @@ final class PBXTargetTests: XCTestCase {
         let expected = "\(subject.productName!).\(subject.productType!.fileExtension!)"
         XCTAssertEqual(subject.productNameWithExtension(), expected)
     }
+  
+    func test_embedFrameworks_returnsEmpty() {
+        XCTAssertTrue(subject.embedFrameworksBuildPhases().isEmpty)
+    }
+  
+    func test_embedFrameworks_returnsEmptyIfNoCopyFilesFrameworks() {
+        let buildPhase1 = PBXFrameworksBuildPhase(
+            files: [],
+            inputFileListPaths: nil,
+            outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+            runOnlyForDeploymentPostprocessing: true
+        )
+        let buildPhase2 = PBXCopyFilesBuildPhase(
+            dstPath: nil,
+            dstSubfolderSpec: .resources,
+            name: "Embed Frameworks",
+            buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+            files: [],
+            runOnlyForDeploymentPostprocessing: true
+        )
+      
+        subject.buildPhases.append(buildPhase1)
+        subject.buildPhases.append(buildPhase2)
+      
+        XCTAssertTrue(subject.embedFrameworksBuildPhases().isEmpty)
+    }
+  
+    func test_embedFrameworks_returnsUniqueEmbedFrameworksBuildPhase() {
+       let embedFrameworkBuildPhase = PBXCopyFilesBuildPhase(
+         dstPath: nil,
+         dstSubfolderSpec: .frameworks,
+         name: "Embed Frameworks",
+         buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+         files: [],
+         runOnlyForDeploymentPostprocessing: true
+       )
+       subject.buildPhases.append(embedFrameworkBuildPhase)
+    
+       let embedFrameworkBuildPhases = subject.embedFrameworksBuildPhases()
+    
+       XCTAssertTrue(embedFrameworkBuildPhases.count == 1)
+       XCTAssertEqual(embedFrameworkBuildPhases.first, embedFrameworkBuildPhase)
+    }
+  
+    func test_embedFrameworks_returnsTwoBuildPhasesIfCorresponds() {
+        let embedFrameworkBuildPhase1 = PBXCopyFilesBuildPhase(
+          dstPath: nil,
+          dstSubfolderSpec: .frameworks,
+          name: "Embed Frameworks",
+          buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+          files: [],
+          runOnlyForDeploymentPostprocessing: true
+        )
+        let embedFrameworkBuildPhase2 = PBXCopyFilesBuildPhase(
+          dstPath: nil,
+          dstSubfolderSpec: .frameworks,
+          name: "Others Embed Frameworks",
+          buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+          files: [],
+          runOnlyForDeploymentPostprocessing: true
+        )
+        subject.buildPhases.append(embedFrameworkBuildPhase1)
+        subject.buildPhases.append(embedFrameworkBuildPhase2)
+     
+        let embedFrameworkBuildPhases = subject.embedFrameworksBuildPhases()
+     
+        XCTAssertTrue(embedFrameworkBuildPhases.count == 2)
+        XCTAssertTrue(embedFrameworkBuildPhases.contains(embedFrameworkBuildPhase1))
+        XCTAssertTrue(embedFrameworkBuildPhases.contains(embedFrameworkBuildPhase2))
+    }
 }


### PR DESCRIPTION
Resolves #406.

### Short description 📝
Allows fetching the Embed Frameworks build phases from a target.

### Solution 📦
Imitating the methods mentioned on the issue, I added a similar method to retrieve the embed frameworks build phases.

### Implementation 👩‍💻👨‍💻
- [ ] Given that embed framework build phases are copy file build phases with frameworks destination subfolder, the implementation is a filter over all the build phases: first filters the copy files build phases (`buildPhase == .copyFiles`), then cast them as `PBXCopyFilesBuildPhase`, finally filter for `dstSubfolderSpec == .frameworks`
- [ ] Add the tests for no build phases, no matching build phases, one matching build phase and more than one matching build phase.
