### PR TITLE
Fix issue on CI when installing tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
 jobs:
   build:
     macos:
-      xcode: "10.2.0"
+      xcode: "10.2.1"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
 jobs:
   build:
     macos:
-      xcode: "10.2.1"
+      xcode: "10.2.0"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
           command: |
             brew upgrade
             brew install swiftformat
-            brew install swiftlint
             bundle config build.sqlite3 --with-sqlite3-dir=/opt/local
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       - run:
           name: Install Tools
           command: |
+            brew upgrade
             brew install swiftformat
             brew install swiftlint
             bundle config build.sqlite3 --with-sqlite3-dir=/opt/local


### PR DESCRIPTION
### Short description 📝
Buils were failing on CI because Homebrew was tried to install a version of Swifltint that is not compatible with the latest macOS and Xcode versions. This PR fixes the issue.

cc @llinardos