### PR TITLE
Add -addNewFile method to PBXGroup to support adding file reference duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **Breaking** Renamed module from `xcodeproj` to `XcodeProj` https://github.com/tuist/xcodeproj/pull/398 by @pepibumur.
+- Add `override` flag to `PBXGroup.addFile(at:,sourceTree:,sourceRoot:)` https://github.com/tuist/xcodeproj/pull/410 by @mrylmz
 
 ### Added
 


### PR DESCRIPTION
### Short description 📝
We had an issue using `-addFile(at:sourceTree:sourceRoot:)` resulting in a broken file reference inside the pbx file because the old path is overridden inside, which is not the expected behaviour for out problem. For more detailed informations about the issue see [here](https://github.com/JamitLabs/Accio/issues/29).

### Solution 📦
Added a new method to PBXGroup which is not performing a lookup for an already existing file reference.
