### PR TITLE
Add not existent file to a group.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Make build phase name public by @llinardos.
 - Can access embed frameworks build phase for a target by @llinardos.
 - Added `com.apple.product-type.framework.static` to `PBXProductType`. https://github.com/tuist/xcodeproj/pull/347 by @ileitch.
+- Can add a not existing file to a group https://github.com/tuist/xcodeproj/pull/418 by @llinardos.
 
 ### Fixed
 

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -147,16 +147,18 @@ public extension PBXGroup {
     ///   - sourceTree: file sourceTree, default is `.group`.
     ///   - sourceRoot: path to project's source root.
     ///   - override: flag to enable overriding of existing file references, default is `true`.
+    ///   - validatePresence: flag to validate the existence of the file in the file system, default is `true`.
     /// - Returns: new or existing file and its reference.
     @discardableResult
     func addFile(
         at filePath: Path,
         sourceTree: PBXSourceTree = .group,
         sourceRoot: Path,
-        override: Bool = true
+        override: Bool = true,
+        validatePresence: Bool = true
     ) throws -> PBXFileReference {
         let projectObjects = try objects()
-        guard filePath.exists else {
+        if validatePresence && !filePath.exists {
             throw XcodeprojEditingError.unexistingFile(filePath)
         }
         let groupPath = try fullPath(sourceRoot: sourceRoot)

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -59,7 +59,61 @@ final class PBXGroupTests: XCTestCase {
 
         XCTAssertNotNil(group.children.first?.parent)
     }
-
+    
+    func test_addNotExistingFileWithoutValidatinPresence_throws() {
+        do {
+            let sourceRoot = Path("/")
+            let project = PBXProj(
+                rootObject: nil,
+                objectVersion: 0,
+                archiveVersion: 0,
+                classes: [:],
+                objects: []
+            )
+            let group = PBXGroup(children: [],
+                                 sourceTree: .group,
+                                 name: "group")
+            project.add(object: group)
+            let filePath = try Path.uniqueTemporary() + "file"
+            
+            // ensure it doesnt exist
+            let fileManager = FileManager.default
+            if fileManager.fileExists(atPath: filePath.string) {
+                try FileManager.default.removeItem(atPath: filePath.string)
+            }
+            try group.addFile(at: filePath, sourceRoot: sourceRoot)
+            XCTFail("Should throw XcodeprojEditingError.unexistingFile")
+        } catch XcodeprojEditingError.unexistingFile {
+            XCTAssertTrue(true)
+        } catch {
+            XCTFail("Should throw XcodeprojEditingError.unexistingFile but throws \(error)")
+        }
+    }
+    
+    func test_addNotExistingFileValidatinPresence_assignsParent() throws {
+        let sourceRoot = Path("/")
+        let project = PBXProj(
+            rootObject: nil,
+            objectVersion: 0,
+            archiveVersion: 0,
+            classes: [:],
+            objects: []
+        )
+        let group = PBXGroup(children: [],
+                             sourceTree: .group,
+                             name: "group")
+        project.add(object: group)
+        let filePath = try Path.uniqueTemporary() + "file"
+        
+        // ensure it doesnt exist
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: filePath.string) {
+            try FileManager.default.removeItem(atPath: filePath.string)
+        }
+        let file = try? group.addFile(at: filePath, sourceRoot: sourceRoot, validatePresence: false)
+        XCTAssertNotNil(file?.parent)
+    }
+    
     private func testDictionary() -> [String: Any] {
         return [
             "children": ["child"],


### PR DESCRIPTION
Adds a flag to validate or not file existance. Defaults to true for backwards compatibility.
Adds tests for not existing file with and without validate presence flag.

Resolves https://github.com/tuist/xcodeproj/issues/409