### PR TITLE
Add the codeCoverageTargets attribute to the TestAction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       terminal-table (~> 1)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    danger-swiftformat (0.4.0)
+    danger-swiftformat (0.5.0)
       danger-plugin-api (~> 1.0)
     danger-swiftlint (0.19.0)
       danger
@@ -150,7 +150,7 @@ DEPENDENCIES
   cocoapods (= 1.6.0.beta.1)
   colorize (~> 0.8.1)
   danger (~> 6.0)
-  danger-swiftformat (~> 0.4.0)
+  danger-swiftformat (~> 0.5.0)
   danger-swiftlint (~> 0.19.0)
   jazzy
   rake

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -158,7 +158,7 @@ public extension PBXGroup {
         validatePresence: Bool = true
     ) throws -> PBXFileReference {
         let projectObjects = try objects()
-        if validatePresence && !filePath.exists {
+        if validatePresence, !filePath.exists {
             throw XcodeprojEditingError.unexistingFile(filePath)
         }
         let groupPath = try fullPath(sourceRoot: sourceRoot)

--- a/Sources/xcodeproj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/xcodeproj/Scheme/XCScheme+TestAction.swift
@@ -15,6 +15,7 @@ extension XCScheme {
         // MARK: - Attributes
 
         public var testables: [TestableReference]
+        public var codeCoverageTargets: [BuildableReference]
         public var buildConfiguration: String
         public var selectedDebuggerIdentifier: String
         public var selectedLauncherIdentifier: String
@@ -45,6 +46,7 @@ extension XCScheme {
                     selectedLauncherIdentifier: String = XCScheme.defaultLauncher,
                     shouldUseLaunchSchemeArgsEnv: Bool = true,
                     codeCoverageEnabled: Bool = false,
+                    codeCoverageTargets: [BuildableReference] = [],
                     enableAddressSanitizer: Bool = false,
                     enableASanStackUseAfterReturn: Bool = false,
                     enableThreadSanitizer: Bool = false,
@@ -64,6 +66,7 @@ extension XCScheme {
             self.selectedLauncherIdentifier = selectedLauncherIdentifier
             self.shouldUseLaunchSchemeArgsEnv = shouldUseLaunchSchemeArgsEnv
             self.codeCoverageEnabled = codeCoverageEnabled
+            self.codeCoverageTargets = codeCoverageTargets
             self.enableAddressSanitizer = enableAddressSanitizer
             self.enableASanStackUseAfterReturn = enableASanStackUseAfterReturn
             self.enableThreadSanitizer = enableThreadSanitizer
@@ -93,7 +96,9 @@ extension XCScheme {
             testables = try element["Testables"]["TestableReference"]
                 .all?
                 .map(TestableReference.init) ?? []
-
+            codeCoverageTargets = try element["CodeCoverageTargets"]["BuildableReference"]
+                .all?
+                .map(BuildableReference.init) ?? []
             let buildableReferenceElement = element["MacroExpansion"]["BuildableReference"]
             if buildableReferenceElement.error == nil {
                 macroExpansion = try BuildableReference(element: buildableReferenceElement)
@@ -181,6 +186,12 @@ extension XCScheme {
             additionalOptions.forEach { additionalOption in
                 additionalOptionsElement.addChild(additionalOption.xmlElement())
             }
+
+            let codeCoverageTargetsElement = element.addChild(AEXMLElement(name: "CodeCoverageTargets"))
+            codeCoverageTargets.forEach { target in
+                codeCoverageTargetsElement.addChild(target.xmlElement())
+            }
+
             return element
         }
 
@@ -206,7 +217,8 @@ extension XCScheme {
                 language == rhs.language &&
                 region == rhs.region &&
                 systemAttachmentLifetime == rhs.systemAttachmentLifetime &&
-                userAttachmentLifetime == rhs.userAttachmentLifetime
+                userAttachmentLifetime == rhs.userAttachmentLifetime &&
+                codeCoverageTargets == rhs.codeCoverageTargets
         }
     }
 }

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -59,7 +59,7 @@ final class PBXGroupTests: XCTestCase {
 
         XCTAssertNotNil(group.children.first?.parent)
     }
-    
+
     func test_addNotExistingFileWithoutValidatinPresence_throws() {
         do {
             let sourceRoot = Path("/")
@@ -75,7 +75,7 @@ final class PBXGroupTests: XCTestCase {
                                  name: "group")
             project.add(object: group)
             let filePath = try Path.uniqueTemporary() + "file"
-            
+
             // ensure it doesnt exist
             let fileManager = FileManager.default
             if fileManager.fileExists(atPath: filePath.string) {
@@ -89,7 +89,7 @@ final class PBXGroupTests: XCTestCase {
             XCTFail("Should throw XcodeprojEditingError.unexistingFile but throws \(error)")
         }
     }
-    
+
     func test_addNotExistingFileValidatinPresence_assignsParent() throws {
         let sourceRoot = Path("/")
         let project = PBXProj(
@@ -104,7 +104,7 @@ final class PBXGroupTests: XCTestCase {
                              name: "group")
         project.add(object: group)
         let filePath = try Path.uniqueTemporary() + "file"
-        
+
         // ensure it doesnt exist
         let fileManager = FileManager.default
         if fileManager.fileExists(atPath: filePath.string) {
@@ -113,7 +113,7 @@ final class PBXGroupTests: XCTestCase {
         let file = try? group.addFile(at: filePath, sourceRoot: sourceRoot, validatePresence: false)
         XCTAssertNotNil(file?.parent)
     }
-    
+
     private func testDictionary() -> [String: Any] {
         return [
             "children": ["child"],


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/421

### Short description 📝
As described on [this issue](https://github.com/tuist/xcodeproj/issues/421), they would like to expose an API in XcodeGen to modify the list of targets for which test coverage is enabled.

### Solution 📦
Add `codeCoverageTargets` attribute to the `TestAction`.

cc @marcelofabri
