### PR TITLE
Remote project support for PBXContainerItemProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Added `com.apple.product-type.framework.static` to `PBXProductType`. https://github.com/tuist/xcodeproj/pull/347 by @ileitch.
 - Can add a not existing file to a group https://github.com/tuist/xcodeproj/pull/418 by @llinardos.
 - **Breaking** Add `SWIFT_COMPILATION_MODE` and `CODE_SIGN_IDENTITY` build settings, remove `DEBUG` flag for Release https://github.com/tuist/xcodeproj/pull/417 @dangthaison91 
-- Added remote project support to PBXContainerItemProxy by @damirdavletov
+- **Breaking** Added remote project support to PBXContainerItemProxy by @damirdavletov
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `com.apple.product-type.framework.static` to `PBXProductType`. https://github.com/tuist/xcodeproj/pull/347 by @ileitch.
 - Can add a not existing file to a group https://github.com/tuist/xcodeproj/pull/418 by @llinardos.
 - **Breaking** Add `SWIFT_COMPILATION_MODE` and `CODE_SIGN_IDENTITY` build settings, remove `DEBUG` flag for Release https://github.com/tuist/xcodeproj/pull/417 @dangthaison91 
+- Added remote project support to PBXContainerItemProxy by @damirdavletov
 
 ### Fixed
 

--- a/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+public enum ContainerPortal {
+    case project(PBXProject)                /// Project where the proxied object is located in
+    case fileReference(PBXFileReference)    /// File reference to .xcodeproj where the proxied object is located
+    case unknownObject(PBXObject?)          /// This is used only for reading from corrupted projects. Don't use it.
+}
+
 /// This is the element to decorate a target item.
 public final class PBXContainerItemProxy: PBXObject {
     public enum ProxyType: UInt, Decodable {
@@ -12,103 +18,43 @@ public final class PBXContainerItemProxy: PBXObject {
     var containerPortalReference: PBXObjectReference
 
     /// Returns the project that contains the remote object. If container portal is a remote project this getter will fail. Use isContainerPortalFileReference to check if you can use the getter
-    public var containerPortal: PBXProject! {
+    public var containerPortal: ContainerPortal {
         get {
-            return containerPortalReference.getObject()
+            return ContainerPortal(object: containerPortalReference.getObject())
         }
         set {
-            containerPortalReference = newValue.reference
+            guard let reference = newValue.reference else { fatalError("Container portal is mandatory field that has to be set to a known value instead of: \(newValue)") }
+            containerPortalReference = reference
         }
-    }
-
-    /// Returns file reference of the remote xcodeproj bundle. Use isContainerPortalFileReference to check if you can use the getter.
-    public var containerPortalAsFileReference: PBXFileReference! {
-        get {
-            return containerPortalReference.getObject()
-        }
-        set {
-            containerPortalReference = newValue.reference
-        }
-    }
-
-    public var isContainerPortalFileReference: Bool {
-        return containerPortalReference.getObject() as? PBXFileReference != nil
     }
 
     /// Element proxy type.
     public var proxyType: ProxyType?
 
-    /// Element remote global ID reference.
-    var remoteGlobalIDReference: PBXObjectReference?
-
-    /// Remote global object. When referencing objects in remote .xcodeproj this will return nil, for such case use remoteGlobalIDString.
-    public var remoteGlobalID: PBXObject? {
-        get {
-            return remoteGlobalIDReference?.getObject()
-        }
-        set {
-            remoteGlobalIDReference = newValue?.reference
-        }
-    }
-
-    /// The value of remoteGlobalIDString property in pbxproj. Use this accessor if the object is in remote .xcodeproj.
-    public var remoteGlobalIDString: String? {
-        get {
-            return remoteGlobalIDReference?.value
-        }
-        set {
-            remoteGlobalIDReference = newValue.map { PBXObjectReference($0) }
-        }
-    }
+    /// Element remote global ID reference. ID of the proxied object.
+    public var remoteGlobalIDString: String?
 
     /// Element remote info.
     public var remoteInfo: String?
-
-    init(containerPortalReference: PBXObjectReference,
-         remoteGlobalIDReference: PBXObjectReference? = nil,
-         proxyType: ProxyType? = nil,
-         remoteInfo: String? = nil) {
-        self.containerPortalReference = containerPortalReference
-        self.remoteGlobalIDReference = remoteGlobalIDReference
-        self.remoteInfo = remoteInfo
-        self.proxyType = proxyType
-        super.init()
-    }
 
     /// Initializes the container item proxy with its attributes.
     /// Use this initializer if the proxy is for an object within the same .pbxproj file.
     ///
     /// - Parameters:
-    ///   - containerPortal: container portal. PBXProject object located in current .xcodeproj
-    ///   - remoteGlobalID: remote global ID.
+    ///   - containerPortal: container portal. For proxied object located in the same .xcodeproj use .project. For remote object use .fileReference with PBXFileRefence of remote .xcodeproj
+    ///   - remoteGlobalIDString: ID of the proxied object. Can be ID from remote .xcodeproj referenced if containerPortal is .fileReference
     ///   - proxyType: proxy type.
     ///   - remoteInfo: remote info.
-    public convenience init(containerPortal: PBXObject,
-                            remoteGlobalID: PBXObject? = nil,
-                            proxyType: ProxyType? = nil,
-                            remoteInfo: String? = nil) {
-        self.init(containerPortalReference: containerPortal.reference,
-                  remoteGlobalIDReference: remoteGlobalID?.reference,
-                  proxyType: proxyType,
-                  remoteInfo: remoteInfo)
-    }
-
-    /// Initializes the container item proxy with its attributes.
-    /// Use this initializer if the proxy is for an object residing in referenced .pbxproj file.
-    ///
-    /// - Parameters:
-    ///   - containerPortal: file reference to external .xcodeproj.
-    ///   - remoteGlobalID: string object ID within the remote project.
-    ///   - proxyType: proxy type.
-    ///   - remoteInfo: remote info.
-    public convenience init(containerPortal: PBXFileReference,
-                            remoteGlobalID: String? = nil,
-                            proxyType: ProxyType? = nil,
-                            remoteInfo: String? = nil) {
-        self.init(containerPortalReference: containerPortal.reference,
-                  remoteGlobalIDReference: remoteGlobalID.map { PBXObjectReference($0) },
-                  proxyType: proxyType,
-                  remoteInfo: remoteInfo)
+    public init(containerPortal: ContainerPortal,
+                remoteGlobalIDString: String? = nil,
+                proxyType: ProxyType? = nil,
+                remoteInfo: String? = nil) {
+        guard let containerPortalReference = containerPortal.reference else { fatalError("Container portal is mandatory field that has to be set to a known value instead of: \(containerPortal)") }
+        self.containerPortalReference = containerPortalReference
+        self.remoteGlobalIDString = remoteGlobalIDString
+        self.remoteInfo = remoteInfo
+        self.proxyType = proxyType
+        super.init()
     }
 
     // MARK: - Decodable
@@ -127,13 +73,9 @@ public final class PBXContainerItemProxy: PBXObject {
         let containerPortalString: String = try container.decode(.containerPortal)
         containerPortalReference = objectReferenceRepository.getOrCreate(reference: containerPortalString,
                                                                          objects: objects)
+
         proxyType = try container.decodeIntIfPresent(.proxyType).flatMap(ProxyType.init)
-        if let remoteGlobalIDString: String = try container.decodeIfPresent(.remoteGlobalIDString) {
-            remoteGlobalIDReference = objectReferenceRepository.getOrCreate(reference: remoteGlobalIDString,
-                                                                            objects: objects)
-        } else {
-            remoteGlobalIDReference = nil
-        }
+        remoteGlobalIDString = try container.decodeIfPresent(.remoteGlobalIDString)
         remoteInfo = try container.decodeIfPresent(.remoteInfo)
         try super.init(from: decoder)
     }
@@ -145,12 +87,12 @@ extension PBXContainerItemProxy: PlistSerializable {
     func plistKeyAndValue(proj _: PBXProj, reference: String) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(PBXContainerItemProxy.isa))
-        dictionary["containerPortal"] = .string(CommentedString(containerPortalReference.value, comment: isContainerPortalFileReference ? containerPortalAsFileReference.name : "Project object"))
+        dictionary["containerPortal"] = .string(CommentedString(containerPortalReference.value, comment: containerPortal.comment))
         if let proxyType = proxyType {
             dictionary["proxyType"] = .string(CommentedString("\(proxyType.rawValue)"))
         }
-        if let remoteGlobalIDReference = remoteGlobalIDReference {
-            dictionary["remoteGlobalIDString"] = .string(CommentedString(remoteGlobalIDReference.value))
+        if let remoteGlobalIDString = remoteGlobalIDString {
+            dictionary["remoteGlobalIDString"] = .string(CommentedString(remoteGlobalIDString))
         }
         if let remoteInfo = remoteInfo {
             dictionary["remoteInfo"] = .string(CommentedString(remoteInfo))
@@ -158,5 +100,38 @@ extension PBXContainerItemProxy: PlistSerializable {
         return (key: CommentedString(reference,
                                      comment: "PBXContainerItemProxy"),
                 value: .dictionary(dictionary))
+    }
+}
+
+private extension ContainerPortal {
+    init(object: PBXObject?) {
+        if let project = object as? PBXProject {
+            self = .project(project)
+        } else if let fileReference = object as? PBXFileReference {
+            self = .fileReference(fileReference)
+        } else {
+            self = .unknownObject(object)
+        }
+    }
+
+    var reference: PBXObjectReference? {
+        switch self {
+        case .project(let project):
+            return project.reference
+        case .fileReference(let fileReference):
+            return fileReference.reference
+        case .unknownObject(_):
+            return nil
+        }
+    }
+
+    var comment: String {
+        let defaultComment = "Project object"
+        switch self {
+        case .fileReference(let fileReference):
+            return fileReference.name ?? defaultComment
+        default:
+            return defaultComment
+        }
     }
 }

--- a/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
@@ -1,10 +1,5 @@
 import Foundation
 
-public enum ContainerPortal {
-    case project(PBXProject)                /// Project where the proxied object is located in
-    case fileReference(PBXFileReference)    /// File reference to .xcodeproj where the proxied object is located
-    case unknownObject(PBXObject?)          /// This is used only for reading from corrupted projects. Don't use it.
-}
 
 /// This is the element to decorate a target item.
 public final class PBXContainerItemProxy: PBXObject {
@@ -12,6 +7,12 @@ public final class PBXContainerItemProxy: PBXObject {
         case nativeTarget = 1
         case reference = 2
         case other
+    }
+
+    public enum ContainerPortal: Equatable {
+        case project(PBXProject)                /// Project where the proxied object is located in
+        case fileReference(PBXFileReference)    /// File reference to .xcodeproj where the proxied object is located
+        case unknownObject(PBXObject?)          /// This is used only for reading from corrupted projects. Don't use it.
     }
 
     /// The object is a reference to a PBXProject element if proxy is for the object located in current .xcodeproj, otherwise PBXFileReference.
@@ -103,7 +104,7 @@ extension PBXContainerItemProxy: PlistSerializable {
     }
 }
 
-private extension ContainerPortal {
+private extension PBXContainerItemProxy.ContainerPortal {
     init(object: PBXObject?) {
         if let project = object as? PBXProject {
             self = .project(project)

--- a/Sources/xcodeproj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/xcodeproj/Objects/Sourcery/Equality.generated.swift
@@ -65,7 +65,7 @@ extension PBXContainerItemProxy {
         guard let rhs = object as? PBXContainerItemProxy else { return false }
         if containerPortalReference != rhs.containerPortalReference { return false }
         if proxyType != rhs.proxyType { return false }
-        if remoteGlobalIDReference != rhs.remoteGlobalIDReference { return false }
+        if remoteGlobalIDString != rhs.remoteGlobalIDString { return false }
         if remoteInfo != rhs.remoteInfo { return false }
         return super.isEqual(to: rhs)
     }

--- a/Sources/xcodeproj/Objects/Targets/PBXNativeTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXNativeTarget.swift
@@ -72,7 +72,7 @@ extension PBXNativeTarget: PlistSerializable {
 // MARK: - Helpers
 
 public extension PBXNativeTarget {
-    /// Adds a dependency to the target.
+    /// Adds a local target dependency to the target.
     ///
     /// - Parameter target: dependency target.
     /// - Returns: target dependency reference.
@@ -82,8 +82,8 @@ public extension PBXNativeTarget {
         guard let project = objects.projects.first?.value else {
             return nil
         }
-        let proxy = PBXContainerItemProxy(containerPortal: project,
-                                          remoteGlobalID: target,
+        let proxy = PBXContainerItemProxy(containerPortal: .project(project),
+                                          remoteGlobalIDString: target.uuid,
                                           proxyType: .nativeTarget,
                                           remoteInfo: target.name)
         objects.add(object: proxy)

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -191,9 +191,9 @@ final class ReferenceGenerator: ReferenceGenerating {
         if let targetProxyReference = targetDependency.targetProxyReference,
             targetProxyReference.temporary,
             let targetProxy = targetDependency.targetProxy,
-            let remoteGlobalIDReference = targetProxy.remoteGlobalIDReference {
+            let remoteGlobalIDString = targetProxy.remoteGlobalIDString {
             var identifiers = identifiers
-            identifiers.append(remoteGlobalIDReference.value)
+            identifiers.append(remoteGlobalIDString)
             fixReference(for: targetProxy, identifiers: identifiers)
         }
 

--- a/Tests/xcodeprojTests/Objects/Targets/PBXNativeTargetTests.swift
+++ b/Tests/xcodeprojTests/Objects/Targets/PBXNativeTargetTests.swift
@@ -54,7 +54,7 @@ final class PBXNativeTargetTests: XCTestCase {
         XCTAssertEqual(targetDependency?.targetReference, dependency.reference)
         let containerItemProxy: PBXContainerItemProxy? = targetDependency?.targetProxyReference?.getObject()
         XCTAssertEqual(containerItemProxy?.containerPortalReference, project.reference)
-        XCTAssertEqual(containerItemProxy?.remoteGlobalIDReference, dependency.reference)
+        XCTAssertEqual(containerItemProxy?.remoteGlobalIDString, dependency.reference.value)
         XCTAssertEqual(containerItemProxy?.proxyType, .nativeTarget)
         XCTAssertEqual(containerItemProxy?.remoteInfo, "Dependency")
     }


### PR DESCRIPTION
### Short description 📝
PBXContainerItemProxy can reference objects defined either within the same .xcodeproj or within a remote one.

If the object is within the same _.xcodeproj_ as the proxy then **containerPortal** property contains **PBXProject** object and **remoteGlobalIDString** contains the ID of the object which _can_ be accessed through the normal object pool.
On the other hand if the referenced object is in remote _.xcodeproj_ then **containerPortal** property contains **PBXFileReference** of remote _.xcodeproj_ (where the object is located) and **remoteGlobalIDString** contains the ID of the object which _cannot_ be accessed through the normal object pool so has to accessed as a string.

Currently support for remote project is absent so I'm adding it in this pull request.

### Solution 📦
I added **containerPortalAsFileReference** and **remoteGlobalIDString** properties to be able to access the values.
Also **isContainerPortalFileReference** is introduced in order to check if **containerPortal** is a file reference or not.
Additionally I split the init method onto 2 convenience initialisers, one for local proxy and one for remote.
