### PR TITLE
Throw an error from fullPath if the path can't be resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Added `com.apple.product-type.framework.static` to `PBXProductType`. https://github.com/tuist/xcodeproj/pull/347 by @ileitch.
 - Can add a not existing file to a group https://github.com/tuist/xcodeproj/pull/418 by @llinardos.
 - **Breaking** Add `SWIFT_COMPILATION_MODE` and `CODE_SIGN_IDENTITY` build settings, remove `DEBUG` flag for Release https://github.com/tuist/xcodeproj/pull/417 @dangthaison91 
-- Added throwing an error in case group path can't be resolved by @damirdavletov  
+- **Breaking** Added throwing an error in case group path can't be resolved by @damirdavletov  
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `com.apple.product-type.framework.static` to `PBXProductType`. https://github.com/tuist/xcodeproj/pull/347 by @ileitch.
 - Can add a not existing file to a group https://github.com/tuist/xcodeproj/pull/418 by @llinardos.
 - **Breaking** Add `SWIFT_COMPILATION_MODE` and `CODE_SIGN_IDENTITY` build settings, remove `DEBUG` flag for Release https://github.com/tuist/xcodeproj/pull/417 @dangthaison91 
+- Added throwing an error in case group path can't be resolved by @damirdavletov  
 
 ### Fixed
 

--- a/Sources/xcodeproj/Errors/Errors.swift
+++ b/Sources/xcodeproj/Errors/Errors.swift
@@ -160,10 +160,13 @@ enum PBXProjEncoderError: Error, CustomStringConvertible {
 /// - notFound: the .pbxproj cannot be found at the given path.
 enum PBXProjError: Error, CustomStringConvertible {
     case notFound(path: Path)
+    case invalidGroupPath(sourceRoot: Path, elementPath: String?)
     var description: String {
         switch self {
         case let .notFound(path):
             return ".pbxproj not found at path \(path.string)"
+        case .invalidGroupPath(let sourceRoot, let elementPath):
+            return "Cannot calculate full path for file element \"\(elementPath ?? "")\" in source root: \"\(sourceRoot)\""
         }
     }
 }

--- a/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXFileElement.swift
@@ -165,7 +165,7 @@ public extension PBXFileElement {
                     return sourceRoot
                 }
                 // Fallback if parent is nil and it's not root element
-                guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { return sourceRoot }
+                guard let group = projectObjects.groups.first(where: { $0.value.childrenReferences.contains(reference) }) else { throw PBXProjError.invalidGroupPath(sourceRoot: sourceRoot, elementPath: path) }
                 groupPath = try group.value.fullPath(sourceRoot: sourceRoot)
             }
 

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -161,7 +161,7 @@ public extension PBXGroup {
         if validatePresence && !filePath.exists {
             throw XcodeprojEditingError.unexistingFile(filePath)
         }
-        let groupPath = try? fullPath(sourceRoot: sourceRoot) ?? sourceRoot
+        let groupPath = try fullPath(sourceRoot: sourceRoot)
 
         let isFileReferencePathEqual: (Dictionary<PBXObjectReference, PBXFileReference>.Element) throws -> Bool = {
             try filePath == $0.value.fullPath(sourceRoot: sourceRoot)

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -161,7 +161,7 @@ public extension PBXGroup {
         if validatePresence && !filePath.exists {
             throw XcodeprojEditingError.unexistingFile(filePath)
         }
-        let groupPath = try fullPath(sourceRoot: sourceRoot)
+        let groupPath = try? fullPath(sourceRoot: sourceRoot) ?? sourceRoot
 
         let isFileReferencePathEqual: (Dictionary<PBXObjectReference, PBXFileReference>.Element) throws -> Bool = {
             try filePath == $0.value.fullPath(sourceRoot: sourceRoot)

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -74,7 +74,8 @@ final class PBXFileElementTests: XCTestCase {
                                        path: "/a/path")
         let group = PBXGroup(children: [fileref],
                              sourceTree: .group,
-                             name: "/to/be/ignored")
+                             name: "/to/be/ignored",
+                             path: "groupPath")
 
         let objects = PBXObjects(objects: [fileref, group])
         fileref.reference.objects = objects
@@ -82,7 +83,14 @@ final class PBXFileElementTests: XCTestCase {
         // Remove parent for fallback test
         fileref.parent = nil
 
-        XCTAssertThrowsError(try fileref.fullPath(sourceRoot: sourceRoot))
+        XCTAssertThrowsError(try fileref.fullPath(sourceRoot: sourceRoot)) { (error) in
+            if case PBXProjError.invalidGroupPath(let sourceRoot, let elementPath) = error {
+                XCTAssertEqual(sourceRoot, "/")
+                XCTAssertEqual(elementPath, "groupPath")
+            } else {
+                XCTAssert(false, "fullPath should fails with PBXProjError.invalidGroupPath instaed of: \(error)")
+            }
+        }
     }
 
     func test_fullPath_with_nested_groups() throws {

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -73,8 +73,7 @@ final class PBXFileElementTests: XCTestCase {
         // Remove parent for fallback test
         fileref.parent = nil
 
-        let fullPath = try fileref.fullPath(sourceRoot: sourceRoot)
-        XCTAssertEqual(fullPath?.string, "/a/path")
+        XCTAssertThrowsError(try fileref.fullPath(sourceRoot: sourceRoot))
     }
 
     func test_fullPath_with_nested_groups() throws {

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -47,7 +47,16 @@ final class PBXFileElementTests: XCTestCase {
                              sourceTree: .group,
                              name: "/to/be/ignored")
 
-        let objects = PBXObjects(objects: [fileref, group])
+        let mainGroup = PBXGroup(children: [group],
+                                 sourceTree: .group,
+                                 name: "/to/be/ignored")
+
+        let project = PBXProject(name: "ProjectName",
+                   buildConfigurationList: XCConfigurationList(),
+                   compatibilityVersion: "0",
+                   mainGroup: mainGroup)
+
+        let objects = PBXObjects(objects: [project, mainGroup, fileref, group])
         fileref.reference.objects = objects
         group.reference.objects = objects
 
@@ -89,7 +98,12 @@ final class PBXFileElementTests: XCTestCase {
         let rootGroup = PBXGroup(children: [nestedGroup],
                                  sourceTree: .group)
 
-        let objects = PBXObjects(objects: [fileref, nestedGroup, rootGroup])
+        let project = PBXProject(name: "ProjectName",
+                                 buildConfigurationList: XCConfigurationList(),
+                                 compatibilityVersion: "0",
+                                 mainGroup: rootGroup)
+
+        let objects = PBXObjects(objects: [fileref, nestedGroup, rootGroup, project])
         fileref.reference.objects = objects
         nestedGroup.reference.objects = objects
 

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -22,6 +22,12 @@ final class PBXGroupTests: XCTestCase {
                              sourceTree: .group,
                              name: "group")
         project.add(object: group)
+        let pbxProject = PBXProject(name: "ProjectName",
+                                    buildConfigurationList: XCConfigurationList(),
+                                    compatibilityVersion: "0",
+                                    mainGroup: group)
+        project.add(object: pbxProject)
+
         let filePath = try Path.uniqueTemporary() + "file"
         try Data().write(to: filePath.url)
         let file = try? group.addFile(at: filePath, sourceRoot: sourceRoot)
@@ -103,6 +109,12 @@ final class PBXGroupTests: XCTestCase {
                              sourceTree: .group,
                              name: "group")
         project.add(object: group)
+        let pbxProject = PBXProject(name: "ProjectName",
+                                    buildConfigurationList: XCConfigurationList(),
+                                    compatibilityVersion: "0",
+                                    mainGroup: group)
+        project.add(object: pbxProject)
+
         let filePath = try Path.uniqueTemporary() + "file"
         
         // ensure it doesnt exist


### PR DESCRIPTION
### Short description 📝
ATM the following method:
```
public extension PBXFileElement {
    func fullPath(sourceRoot: Path) throws -> Path? 
}
```
returns sourceRoot value if the file element belongs to a group which doesn't have mainGroup in parent groups. 
In our setup we read an .xcodeproj then take all referenced .xcodeproj files recursively. Often when conflicts are resolved incorrectly there's duplicate entries of file elements with one being ignored by xcode as it's not part of group hierarchy.
 When we try get fullPath of such file element it returns sourceRoot and there is no way to distinguish if it is an error or correct path.

### Solution 📦
Throw and error in case fullPath can't be resolved correctly and let user handle it.

### Implementation 👩‍💻👨‍💻
Please have a look at the pull request. Thanks!
