### PR TITLE
Add support for the Swift Package Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `override` flag to `PBXGroup.addFile(at:,sourceTree:,sourceRoot:)` https://github.com/tuist/xcodeproj/pull/410 by @mrylmz
 - Rename some internal variables to have a more representative name https://github.com/tuist/xcodeproj/pull/415 by @pepibumur.
 - **Breaking** Change the UUID generation logic to generate ids with a length of 24 https://github.com/tuist/xcodeproj/pull/432 by @pepibumur.
+
 ### Added
 
 - **Breaking** Swift 5 support https://github.com/tuist/xcodeproj/pull/397 by @pepibumur.
@@ -21,6 +22,8 @@
 - **Breaking** Added throwing an error in case group path can't be resolved by @damirdavletov  
 - **Breaking** Added remote project support to PBXContainerItemProxy by @damirdavletov
 - **Breaking** Add support for `RemoteRunnable` https://github.com/tuist/xcodeproj/pull/400 by @pepibumur.
+- Support for Swift Package Manager https://github.com/tuist/xcodeproj/pull/439 by @pepibumur.
+
 ### Fixed
 
 - Carthage integration https://github.com/tuist/xcodeproj/pull/416 by @pepibumur.

--- a/Fixtures/iOS/MyLocalPackage/.gitignore
+++ b/Fixtures/iOS/MyLocalPackage/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/iOS/MyLocalPackage/Package.swift
+++ b/Fixtures/iOS/MyLocalPackage/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MyLocalPackage",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "MyLocalPackage",
+            targets: ["MyLocalPackage"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "MyLocalPackage",
+            dependencies: []),
+        .testTarget(
+            name: "MyLocalPackageTests",
+            dependencies: ["MyLocalPackage"]),
+    ]
+)

--- a/Fixtures/iOS/MyLocalPackage/Package.swift
+++ b/Fixtures/iOS/MyLocalPackage/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "MyLocalPackage",
-            targets: ["MyLocalPackage"]),
+            targets: ["MyLocalPackage"]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -20,9 +21,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "MyLocalPackage",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "MyLocalPackageTests",
-            dependencies: ["MyLocalPackage"]),
+            dependencies: ["MyLocalPackage"]
+        ),
     ]
 )

--- a/Fixtures/iOS/MyLocalPackage/README.md
+++ b/Fixtures/iOS/MyLocalPackage/README.md
@@ -1,0 +1,3 @@
+# MyLocalPackage
+
+A description of this package.

--- a/Fixtures/iOS/MyLocalPackage/Sources/MyLocalPackage/MyLocalPackage.swift
+++ b/Fixtures/iOS/MyLocalPackage/Sources/MyLocalPackage/MyLocalPackage.swift
@@ -1,0 +1,3 @@
+struct MyLocalPackage {
+    var text = "Hello, World!"
+}

--- a/Fixtures/iOS/MyLocalPackage/Tests/LinuxMain.swift
+++ b/Fixtures/iOS/MyLocalPackage/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import MyLocalPackageTests
+
+var tests = [XCTestCaseEntry]()
+tests += MyLocalPackageTests.allTests()
+XCTMain(tests)

--- a/Fixtures/iOS/MyLocalPackage/Tests/MyLocalPackageTests/MyLocalPackageTests.swift
+++ b/Fixtures/iOS/MyLocalPackage/Tests/MyLocalPackageTests/MyLocalPackageTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import MyLocalPackage
+
+final class MyLocalPackageTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(MyLocalPackage().text, "Hello, World!")
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Fixtures/iOS/MyLocalPackage/Tests/MyLocalPackageTests/XCTestManifests.swift
+++ b/Fixtures/iOS/MyLocalPackage/Tests/MyLocalPackageTests/XCTestManifests.swift
@@ -1,9 +1,9 @@
 import XCTest
 
 #if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(MyLocalPackageTests.allTests),
-    ]
-}
+    public func allTests() -> [XCTestCaseEntry] {
+        return [
+            testCase(MyLocalPackageTests.allTests),
+        ]
+    }
 #endif

--- a/Fixtures/iOS/MyLocalPackage/Tests/MyLocalPackageTests/XCTestManifests.swift
+++ b/Fixtures/iOS/MyLocalPackage/Tests/MyLocalPackageTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(MyLocalPackageTests.allTests),
+    ]
+}
+#endif

--- a/Fixtures/iOS/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/Project.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 			compilerSpec = com.apple.compilers.proxy.script;
 			filePatterns = "*.myrule";
 			fileType = pattern.proxy;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 				"$(DERIVED_FILE_DIR)/CompiledRule",
@@ -293,7 +295,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = /test;
+			shellScript = "echo \"/test\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -445,10 +447,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = iOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = es.ppinera.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -457,10 +462,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = iOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = es.ppinera.iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -470,11 +478,15 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = iOSTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = es.ppinera.iOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Project.app/Project";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS.app/iOS";
 			};
 			name = Debug;
 		};
@@ -484,11 +496,15 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = iOSTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = es.ppinera.iOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Project.app/Project";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS.app/iOS";
 			};
 			name = Release;
 		};

--- a/Fixtures/iOS/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -18,6 +18,8 @@
 		23766C201EAA3484007A9026 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 23766C1E1EAA3484007A9026 /* LaunchScreen.storyboard */; };
 		23766C2B1EAA3484007A9026 /* iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23766C2A1EAA3484007A9026 /* iOSTests.swift */; };
 		3CD1EADD205763E400DAEECB /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3CD1EADB205763E400DAEECB /* Model.xcdatamodeld */; };
+		42AA1A1A22AAF48100428760 /* MyLocalPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 42AA1A1922AAF48100428760 /* MyLocalPackage */; };
+		42AA1A1C22AAF48100428760 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 42AA1A1B22AAF48100428760 /* RxSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -69,6 +71,7 @@
 		23766C2A1EAA3484007A9026 /* iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTests.swift; sourceTree = "<group>"; };
 		23766C2C1EAA3484007A9026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3CD1EADC205763E400DAEECB /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		42AA1A1822AAF41000428760 /* MyLocalPackage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MyLocalPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,7 +79,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				42AA1A1C22AAF48100428760 /* RxSwift in Frameworks */,
 				04D5C09F1F153824008A2F98 /* CoreData.framework in Frameworks */,
+				42AA1A1A22AAF48100428760 /* MyLocalPackage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,6 +106,7 @@
 		23766C091EAA3484007A9026 = {
 			isa = PBXGroup;
 			children = (
+				42AA1A1822AAF41000428760 /* MyLocalPackage */,
 				23766C141EAA3484007A9026 /* iOS */,
 				23766C291EAA3484007A9026 /* iOSTests */,
 				23766C131EAA3484007A9026 /* Products */,
@@ -184,6 +190,10 @@
 			dependencies = (
 			);
 			name = iOS;
+			packageProductDependencies = (
+				42AA1A1922AAF48100428760 /* MyLocalPackage */,
+				42AA1A1B22AAF48100428760 /* RxSwift */,
+			);
 			productName = iOS;
 			productReference = 23766C121EAA3484007A9026 /* iOS.app */;
 			productType = "com.apple.product-type.application";
@@ -236,6 +246,9 @@
 				Base,
 			);
 			mainGroup = 23766C091EAA3484007A9026;
+			packageReferences = (
+				42AA19FF22AAF0D600428760 /* XCRemoteSwiftPackageReference "RxSwift" */,
+			);
 			productRefGroup = 23766C131EAA3484007A9026 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -510,6 +523,29 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		42AA19FF22AAF0D600428760 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		42AA1A1922AAF48100428760 /* MyLocalPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MyLocalPackage;
+		};
+		42AA1A1B22AAF48100428760 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 42AA19FF22AAF0D600428760 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		3CD1EADB205763E400DAEECB /* Model.xcdatamodeld */ = {

--- a/Fixtures/iOS/Project.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fixtures/iOS/Project.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift",
+        "state": {
+          "branch": null,
+          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
+          "version": "5.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Fixtures/iOS/iOS/AppDelegate.swift
+++ b/Fixtures/iOS/iOS/AppDelegate.swift
@@ -12,7 +12,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Sources/xcodeproj/Errors/Errors.swift
+++ b/Sources/xcodeproj/Errors/Errors.swift
@@ -165,7 +165,7 @@ enum PBXProjError: Error, CustomStringConvertible {
         switch self {
         case let .notFound(path):
             return ".pbxproj not found at path \(path.string)"
-        case .invalidGroupPath(let sourceRoot, let elementPath):
+        case let .invalidGroupPath(sourceRoot, elementPath):
             return "Cannot calculate full path for file element \"\(elementPath ?? "")\" in source root: \"\(sourceRoot)\""
         }
     }

--- a/Sources/xcodeproj/Extensions/Path+Extras.swift
+++ b/Sources/xcodeproj/Extensions/Path+Extras.swift
@@ -40,7 +40,7 @@ extension Path {
     }
 
     func relative(to path: Path) -> Path {
-        let pathComponents = self.absolute().components
+        let pathComponents = absolute().components
         let baseComponents = path.absolute().components
 
         var commonComponents = 0

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -18,7 +18,17 @@ public final class PBXBuildFile: PBXObject {
     }
     
     /// Product reference.
-    public var productReference: PBXObjectReference?
+    var productReference: PBXObjectReference?
+    
+    /// Product.
+    public var product: XCSwiftPackageProductDependency? {
+        get {
+            return productReference?.getObject()
+        }
+        set {
+            self.productReference = newValue?.reference
+        }
+    }
 
     /// Element settings
     public var settings: [String: Any]?
@@ -45,6 +55,7 @@ public final class PBXBuildFile: PBXObject {
     enum CodingKeys: String, CodingKey {
         case fileRef
         case settings
+        case productRef
     }
 
     public required init(from decoder: Decoder) throws {
@@ -53,6 +64,9 @@ public final class PBXBuildFile: PBXObject {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         if let fileRefString: String = try container.decodeIfPresent(.fileRef) {
             fileReference = objectReferenceRepository.getOrCreate(reference: fileRefString, objects: objects)
+        }
+        if let productRefString: String = try container.decodeIfPresent(.productRef) {
+            productReference = objectReferenceRepository.getOrCreate(reference: productRefString, objects: objects)
         }
         settings = try container.decodeIfPresent([String: Any].self, forKey: .settings)
         try super.init(from: decoder)
@@ -135,6 +149,9 @@ final class PBXBuildPhaseFile: PlistSerializable, Equatable {
         if let fileReference = buildFile.fileReference {
             let fileElement: PBXFileElement? = fileReference.getObject()
             dictionary["fileRef"] = .string(CommentedString(fileReference.value, comment: fileElement?.fileName()))
+        }
+        if let product = buildFile.product {
+            dictionary["productRef"] = .string(.init(product.reference.value, comment: product.productName))
         }
         if let settings = buildFile.settings {
             dictionary["settings"] = settings.plist()

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -42,10 +42,13 @@ public final class PBXBuildFile: PBXObject {
     ///
     /// - Parameters:
     ///   - file: file the build file refers to.
+    ///   - productRef: The Swift package product dependency.
     ///   - settings: build file settings.
-    public init(file: PBXFileElement,
+    public init(file: PBXFileElement? = nil,
+                product: XCSwiftPackageProductDependency? = nil,
                 settings: [String: Any]? = nil) {
-        fileReference = file.reference
+        fileReference = file?.reference
+        self.productReference = product?.reference
         self.settings = settings
         super.init()
     }

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -16,6 +16,9 @@ public final class PBXBuildFile: PBXObject {
             fileReference = newValue?.reference
         }
     }
+    
+    /// Product reference.
+    public var productReference: PBXObjectReference?
 
     /// Element settings
     public var settings: [String: Any]?

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -48,7 +48,7 @@ public final class PBXBuildFile: PBXObject {
                 product: XCSwiftPackageProductDependency? = nil,
                 settings: [String: Any]? = nil) {
         fileReference = file?.reference
-        self.productReference = product?.reference
+        productReference = product?.reference
         self.settings = settings
         super.init()
     }

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -16,17 +16,17 @@ public final class PBXBuildFile: PBXObject {
             fileReference = newValue?.reference
         }
     }
-    
+
     /// Product reference.
     var productReference: PBXObjectReference?
-    
+
     /// Product.
     public var product: XCSwiftPackageProductDependency? {
         get {
             return productReference?.getObject()
         }
         set {
-            self.productReference = newValue?.reference
+            productReference = newValue?.reference
         }
     }
 

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildFile.swift
@@ -84,8 +84,9 @@ extension PBXBuildFile {
     /// - Returns: file name.
     /// - Throws: an error if the name cannot be obtained.
     func fileName() throws -> String? {
-        guard let fileElement: PBXFileElement = fileReference?.getObject() else { return nil }
-        return fileElement.fileName()
+        if let fileElement: PBXFileElement = fileReference?.getObject(), let name = fileElement.fileName() { return name }
+        if let product: XCSwiftPackageProductDependency = productReference?.getObject() { return product.productName }
+        return nil
     }
 
     /// Returns the type of the build phase the build file belongs to.

--- a/Sources/xcodeproj/Objects/BuildPhase/PBXBuildRule.swift
+++ b/Sources/xcodeproj/Objects/BuildPhase/PBXBuildRule.swift
@@ -22,6 +22,9 @@ public final class PBXBuildRule: PBXObject {
     /// Element output files.
     public var outputFiles: [String]
 
+    /// Element input files.
+    public var inputFiles: [String]?
+
     /// Element output files compiler flags.
     public var outputFilesCompilerFlags: [String]?
 
@@ -36,6 +39,7 @@ public final class PBXBuildRule: PBXObject {
                 filePatterns: String? = nil,
                 name: String? = nil,
                 outputFiles: [String] = [],
+                inputFiles: [String]? = nil,
                 outputFilesCompilerFlags: [String]? = nil,
                 script: String? = nil) {
         self.compilerSpec = compilerSpec
@@ -44,6 +48,7 @@ public final class PBXBuildRule: PBXObject {
         self.isEditable = isEditable
         self.name = name
         self.outputFiles = outputFiles
+        self.inputFiles = inputFiles
         self.outputFilesCompilerFlags = outputFilesCompilerFlags
         self.script = script
         super.init()
@@ -58,6 +63,7 @@ public final class PBXBuildRule: PBXObject {
         case isEditable
         case name
         case outputFiles
+        case inputFiles
         case outputFilesCompilerFlags
         case script
     }
@@ -70,6 +76,7 @@ public final class PBXBuildRule: PBXObject {
         isEditable = try container.decodeIntBool(.isEditable)
         name = try container.decodeIfPresent(.name)
         outputFiles = try container.decodeIfPresent(.outputFiles) ?? []
+        inputFiles = try container.decodeIfPresent(.inputFiles)
         outputFilesCompilerFlags = try container.decodeIfPresent(.outputFilesCompilerFlags)
         script = try container.decodeIfPresent(.script)
         try super.init(from: decoder)
@@ -93,7 +100,10 @@ extension PBXBuildRule: PlistSerializable {
         if let name = name {
             dictionary["name"] = .string(CommentedString(name))
         }
-        dictionary["outputFiles"] = .array(outputFiles.map { PlistValue.string(CommentedString($0)) })
+        dictionary["outputFiles"] = .array(outputFiles.map { .string(CommentedString($0)) })
+        if let inputFiles = inputFiles {
+            dictionary["inputFiles"] = .array(inputFiles.map { .string(CommentedString($0)) })
+        }
         if let outputFilesCompilerFlags = outputFilesCompilerFlags {
             dictionary["outputFilesCompilerFlags"] = .array(outputFilesCompilerFlags.map { PlistValue.string(CommentedString($0)) })
         }

--- a/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXContainerItemProxy.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// This is the element to decorate a target item.
 public final class PBXContainerItemProxy: PBXObject {
     public enum ProxyType: UInt, Decodable {
@@ -10,9 +9,9 @@ public final class PBXContainerItemProxy: PBXObject {
     }
 
     public enum ContainerPortal: Equatable {
-        case project(PBXProject)                /// Project where the proxied object is located in
-        case fileReference(PBXFileReference)    /// File reference to .xcodeproj where the proxied object is located
-        case unknownObject(PBXObject?)          /// This is used only for reading from corrupted projects. Don't use it.
+        case project(PBXProject) /// Project where the proxied object is located in
+        case fileReference(PBXFileReference) /// File reference to .xcodeproj where the proxied object is located
+        case unknownObject(PBXObject?) /// This is used only for reading from corrupted projects. Don't use it.
     }
 
     /// The object is a reference to a PBXProject element if proxy is for the object located in current .xcodeproj, otherwise PBXFileReference.
@@ -117,11 +116,11 @@ private extension PBXContainerItemProxy.ContainerPortal {
 
     var reference: PBXObjectReference? {
         switch self {
-        case .project(let project):
+        case let .project(project):
             return project.reference
-        case .fileReference(let fileReference):
+        case let .fileReference(fileReference):
             return fileReference.reference
-        case .unknownObject(_):
+        case .unknownObject:
             return nil
         }
     }
@@ -129,7 +128,7 @@ private extension PBXContainerItemProxy.ContainerPortal {
     var comment: String {
         let defaultComment = "Project object"
         switch self {
-        case .fileReference(let fileReference):
+        case let .fileReference(fileReference):
             return fileReference.name ?? defaultComment
         default:
             return defaultComment

--- a/Sources/xcodeproj/Objects/Project/PBXObjectParser.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjectParser.swift
@@ -62,6 +62,10 @@ final class PBXObjectParser {
             return try decoder.decode(PBXRezBuildPhase.self, from: data)
         case PBXBuildRule.isa:
             return try decoder.decode(PBXBuildRule.self, from: data)
+        case XCRemoteSwiftPackageReference.isa:
+            return try decoder.decode(XCRemoteSwiftPackageReference.self, from: data)
+        case XCSwiftPackageProductDependency.isa:
+            return try decoder.decode(XCSwiftPackageProductDependency.self, from: data)
         default:
             throw PBXObjectError.unknownElement(isa)
         }

--- a/Sources/xcodeproj/Objects/Project/PBXObjects.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjects.swift
@@ -425,5 +425,7 @@ extension PBXObjects {
         headersBuildPhases.values.forEach(closure)
         sourcesBuildPhases.values.forEach(closure)
         carbonResourcesBuildPhases.values.forEach(closure)
+        remoteSwiftPackageReferences.values.forEach(closure)
+        swiftPackageProductDependencies.values.forEach(closure)
     }
 }

--- a/Sources/xcodeproj/Objects/Project/PBXObjects.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjects.swift
@@ -119,6 +119,18 @@ class PBXObjects: Equatable {
     var carbonResourcesBuildPhases: [PBXObjectReference: PBXRezBuildPhase] {
         return lock.whileLocked { _carbonResourcesBuildPhases }
     }
+    
+    private var _remoteSwiftPackageReferences: [PBXObjectReference: XCRemoteSwiftPackageReference] = [:]
+    var remoteSwiftPackageReferences: [PBXObjectReference: XCRemoteSwiftPackageReference] {
+        return lock.whileLocked { _remoteSwiftPackageReferences }
+    }
+    
+    private var _swiftPackageProductDependencies: [PBXObjectReference: XCSwiftPackageProductDependency] = [:]
+    var swiftPackageProductDependencies: [PBXObjectReference: XCSwiftPackageProductDependency] {
+        return lock.whileLocked { _swiftPackageProductDependencies }
+    }
+    
+    //XCSwiftPackageProductDependency
 
     /// Initializes the project objects container
     ///
@@ -154,7 +166,9 @@ class PBXObjects: Equatable {
             lhs.versionGroups == rhs.versionGroups &&
             lhs.referenceProxies == rhs.referenceProxies &&
             lhs.carbonResourcesBuildPhases == rhs.carbonResourcesBuildPhases &&
-            lhs.buildRules == rhs.buildRules
+            lhs.buildRules == rhs.buildRules &&
+            lhs.swiftPackageProductDependencies == rhs._swiftPackageProductDependencies &&
+            lhs.remoteSwiftPackageReferences == rhs.remoteSwiftPackageReferences
     }
 
     // MARK: - Helpers
@@ -197,6 +211,9 @@ class PBXObjects: Equatable {
         case let object as PBXReferenceProxy: _referenceProxies[objectReference] = object
         case let object as PBXRezBuildPhase: _carbonResourcesBuildPhases[objectReference] = object
         case let object as PBXBuildRule: _buildRules[objectReference] = object
+        case let object as XCRemoteSwiftPackageReference: _remoteSwiftPackageReferences[objectReference] = object
+        case let object as XCSwiftPackageProductDependency: _swiftPackageProductDependencies[objectReference] = object
+
         default: fatalError("Unhandled PBXObject type for \(object), this is likely a bug / todo")
         }
     }
@@ -252,6 +269,10 @@ class PBXObjects: Equatable {
             return _carbonResourcesBuildPhases.remove(at: index).value
         } else if let index = buildRules.index(forKey: reference) {
             return _buildRules.remove(at: index).value
+        } else if let index = remoteSwiftPackageReferences.index(forKey: reference) {
+            return _remoteSwiftPackageReferences.remove(at: index).value
+        } else if let index = swiftPackageProductDependencies.index(forKey: reference) {
+            return _swiftPackageProductDependencies.remove(at: index).value
         }
         lock.unlock()
         return nil
@@ -310,6 +331,10 @@ class PBXObjects: Equatable {
         } else if let object = carbonResourcesBuildPhases[reference] {
             return object
         } else if let object = buildRules[reference] {
+            return object
+        } else if let object = remoteSwiftPackageReferences[reference] {
+            return object
+        } else if let object = swiftPackageProductDependencies[reference] {
             return object
         } else {
             return nil

--- a/Sources/xcodeproj/Objects/Project/PBXObjects.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjects.swift
@@ -119,18 +119,18 @@ class PBXObjects: Equatable {
     var carbonResourcesBuildPhases: [PBXObjectReference: PBXRezBuildPhase] {
         return lock.whileLocked { _carbonResourcesBuildPhases }
     }
-    
+
     private var _remoteSwiftPackageReferences: [PBXObjectReference: XCRemoteSwiftPackageReference] = [:]
     var remoteSwiftPackageReferences: [PBXObjectReference: XCRemoteSwiftPackageReference] {
         return lock.whileLocked { _remoteSwiftPackageReferences }
     }
-    
+
     private var _swiftPackageProductDependencies: [PBXObjectReference: XCSwiftPackageProductDependency] = [:]
     var swiftPackageProductDependencies: [PBXObjectReference: XCSwiftPackageProductDependency] {
         return lock.whileLocked { _swiftPackageProductDependencies }
     }
-    
-    //XCSwiftPackageProductDependency
+
+    // XCSwiftPackageProductDependency
 
     /// Initializes the project objects container
     ///
@@ -396,7 +396,7 @@ extension PBXObjects {
             } ?? []
             return buildPhaseFile
         }
-        return Dictionary(values.flatMap { $0 }.map { ($0.buildFile.reference, $0) }, uniquingKeysWith: { first, _ in return first })
+        return Dictionary(values.flatMap { $0 }.map { ($0.buildFile.reference, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
     /// Runs the given closure for each of the objects that are part of the project.

--- a/Sources/xcodeproj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProjEncoder.swift
@@ -203,9 +203,9 @@ final class PBXProjEncoder {
                   outputSettings: outputSettings,
                   stateHolder: &stateHolder,
                   to: &output)
-        try write(section: "XCVersionGroup",
+        try write(section: "XCRemoteSwiftPackageReference",
                   proj: proj,
-                  objects: proj.objects.versionGroups,
+                  objects: proj.objects.remoteSwiftPackageReferences,
                   outputSettings: outputSettings,
                   stateHolder: &stateHolder,
                   to: &output)
@@ -215,12 +215,13 @@ final class PBXProjEncoder {
                   outputSettings: outputSettings,
                   stateHolder: &stateHolder,
                   to: &output)
-        try write(section: "XCRemoteSwiftPackageReference",
+        try write(section: "XCVersionGroup",
                   proj: proj,
-                  objects: proj.objects.remoteSwiftPackageReferences,
+                  objects: proj.objects.versionGroups,
                   outputSettings: outputSettings,
                   stateHolder: &stateHolder,
                   to: &output)
+
         stateHolder.decreaseIndent()
         writeIndent(stateHolder: &stateHolder, to: &output)
         write(string: "};", to: &output)

--- a/Sources/xcodeproj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProjEncoder.swift
@@ -209,6 +209,18 @@ final class PBXProjEncoder {
                   outputSettings: outputSettings,
                   stateHolder: &stateHolder,
                   to: &output)
+        try write(section: "XCSwiftPackageProductDependency",
+                  proj: proj,
+                  objects: proj.objects.swiftPackageProductDependencies,
+                  outputSettings: outputSettings,
+                  stateHolder: &stateHolder,
+                  to: &output)
+        try write(section: "XCRemoteSwiftPackageReference",
+                  proj: proj,
+                  objects: proj.objects.remoteSwiftPackageReferences,
+                  outputSettings: outputSettings,
+                  stateHolder: &stateHolder,
+                  to: &output)
         stateHolder.decreaseIndent()
         writeIndent(stateHolder: &stateHolder, to: &output)
         write(string: "};", to: &output)

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -175,11 +175,13 @@ public final class PBXProject: PBXObject {
         // Reference
         let reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRules: versionRules)
         objects.add(object: reference)
+        if packages == nil { packages = [] }
         packages?.append(reference)
 
         // Product
         let productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
         objects.add(object: productDependency)
+        if target?.packageProductDependencies == nil { target?.packageProductDependencies = [] }
         target?.packageProductDependencies?.append(productDependency)
 
         // Build file
@@ -356,7 +358,7 @@ extension PBXProject: PlistSerializable {
 
         if let packages = packages {
             dictionary["packageReferences"] = PlistValue.array(packages.map {
-                PlistValue.string(CommentedString($0.reference.value, comment: "XCRemoteSwiftPackageReference \"\($0.name)\""))
+                .string(CommentedString($0.reference.value, comment: "XCRemoteSwiftPackageReference \"\($0.name ?? "")\""))
             })
         }
 

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -185,10 +185,10 @@ public final class PBXProject: PBXObject {
         // Build file
         let buildFile = PBXBuildFile(product: productDependency)
         objects.add(object: buildFile)
-        
+
         // Link the product
         try? target?.sourcesBuildPhase()?.files?.append(buildFile)
-        
+
         return reference
     }
 

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -183,7 +183,13 @@ public final class PBXProject: PBXObject {
         target?.packageProductDependencies?.append(productDependency)
 
         // Build file
-//        let buildFile = PBXBuildFile(
+        let buildFile = PBXBuildFile(product: productDependency)
+        objects.add(object: buildFile)
+        
+        // Link the product
+        try? target?.sourcesBuildPhase()?.files?.append(buildFile)
+        
+        return reference
     }
 
     // MARK: - Init

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -123,17 +123,17 @@ public final class PBXProject: PBXObject {
             return attributes
         }
     }
-    
+
     /// Package references.
     var packageReferences: [PBXObjectReference]?
-    
+
     /// Swift packages.
     var packages: [XCRemoteSwiftPackageReference]? {
         set {
-            packageReferences = newValue?.map({ $0.reference })
+            packageReferences = newValue?.map { $0.reference }
         }
         get {
-            return self.packageReferences?.objects()
+            return packageReferences?.objects()
         }
     }
 
@@ -270,8 +270,8 @@ public final class PBXProject: PBXObject {
         self.targetReferences = targetReferences.map { referenceRepository.getOrCreate(reference: $0, objects: objects) }
 
         let packageRefeferenceStrings: [String]? = try container.decodeIfPresent(.packageReferences)
-        self.packageReferences = packageRefeferenceStrings?.map({ referenceRepository.getOrCreate(reference: $0, objects: objects) })
-        
+        packageReferences = packageRefeferenceStrings?.map { referenceRepository.getOrCreate(reference: $0, objects: objects) }
+
         var attributes = (try container.decodeIfPresent([String: Any].self, forKey: .attributes) ?? [:])
         var targetAttributeReferences: [PBXObjectReference: [String: Any]] = [:]
         if let targetAttributes = attributes[PBXProject.targetAttributesKey] as? [String: [String: Any]] {
@@ -327,11 +327,11 @@ extension PBXProject: PlistSerializable {
                 let target: PBXTarget? = targetReference.getObject()
                 return .string(CommentedString(targetReference.value, comment: target?.name))
         })
-        
+
         if let packages = packages {
-            dictionary["packageReferences"] = PlistValue.array(packages.map({
-                PlistValue.string(CommentedString.init($0.reference.value, comment: "XCRemoteSwiftPackageReference \"\($0.name)\""))
-            }))
+            dictionary["packageReferences"] = PlistValue.array(packages.map {
+                PlistValue.string(CommentedString($0.reference.value, comment: "XCRemoteSwiftPackageReference \"\($0.name)\""))
+            })
         }
 
         var plistAttributes: [String: Any] = attributes

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -166,6 +166,26 @@ public final class PBXProject: PBXObject {
         return targetAttributeReferences[target.reference]
     }
 
+    public func addSwiftPackage(repositoryURL: String,
+                                productName: String,
+                                versionRules: XCRemoteSwiftPackageReference.VersionRules,
+                                target: PBXTarget? = nil) -> XCRemoteSwiftPackageReference {
+        let objects = try! self.objects()
+
+        // Reference
+        let reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRules: versionRules)
+        objects.add(object: reference)
+        packages?.append(reference)
+
+        // Product
+        let productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
+        objects.add(object: productDependency)
+        target?.packageProductDependencies?.append(productDependency)
+
+        // Build file
+//        let buildFile = PBXBuildFile(
+    }
+
     // MARK: - Init
 
     /// Initializes the project with its attributes

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// This element is an abstract parent for specialized targets.
 public class XCRemoteSwiftPackageReference: PBXContainerItem {
-    
     /// It represents the version rules for a Swift Package.
     ///
     /// - upToNextMajorVersion: The package version can be bumped up to the next major version.
@@ -18,7 +17,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem {
         case exact(String)
         case branch(String)
         case revision(String)
-        
+
         enum CodingKeys: String, CodingKey {
             case kind
             case revision
@@ -26,7 +25,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem {
             case minimumVersion
             case maximumVersion
         }
-        
+
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             let kind: String = try container.decode(String.self, forKey: .kind)
@@ -53,110 +52,108 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem {
                 fatalError("XCRemoteSwiftPackageReference kind '\(kind)' not supported")
             }
         }
-        
-        func plistValues() throws -> [CommentedString : PlistValue] {
+
+        func plistValues() throws -> [CommentedString: PlistValue] {
             switch self {
-            case .revision(let revision):
+            case let .revision(revision):
                 return [
                     "kind": "revision",
-                    "revision": .string(.init(revision))
+                    "revision": .string(.init(revision)),
                 ]
-            case .branch(let branch):
+            case let .branch(branch):
                 return [
                     "kind": "branch",
-                    "branch": .string(.init(branch))
+                    "branch": .string(.init(branch)),
                 ]
-            case .exact(let version):
+            case let .exact(version):
                 return [
                     "kind": "exactVersion",
-                    "minimumVersion": .string(.init(version))
+                    "minimumVersion": .string(.init(version)),
                 ]
-            case .range(let from, let to):
+            case let .range(from, to):
                 return [
                     "kind": "versionRange",
                     "minimumVersion": .string(.init(from)),
                     "maximumVersion": .string(.init(to)),
                 ]
-            case .upToNextMinorVersion(let version):
+            case let .upToNextMinorVersion(version):
                 return [
                     "kind": "upToNextMinorVersion",
-                    "minimumVersion": .string(.init(version))
+                    "minimumVersion": .string(.init(version)),
                 ]
-            case .upToNextMajorVersion(let version):
+            case let .upToNextMajorVersion(version):
                 return [
                     "kind": "upToNextMajorVersion",
-                    "minimumVersion": .string(.init(version))
+                    "minimumVersion": .string(.init(version)),
                 ]
             }
         }
-        
+
         public static func == (lhs: VersionRules, rhs: VersionRules) -> Bool {
             switch (lhs, rhs) {
-            case (.revision(let lhsRevision), .revision(let rhsRevision)):
+            case let (.revision(lhsRevision), .revision(rhsRevision)):
                 return lhsRevision == rhsRevision
-            case (.branch(let lhsBranch), .branch(let rhsBranch)):
+            case let (.branch(lhsBranch), .branch(rhsBranch)):
                 return lhsBranch == rhsBranch
-            case (.exact(let lhsVersion), .exact(let rhsVersion)):
+            case let (.exact(lhsVersion), .exact(rhsVersion)):
                 return lhsVersion == rhsVersion
-            case (.range(let lhsFrom, let lhsTo), .range(let rhsFrom, let rhsTo)):
+            case let (.range(lhsFrom, lhsTo), .range(rhsFrom, rhsTo)):
                 return lhsFrom == rhsFrom && lhsTo == rhsTo
-            case (.upToNextMinorVersion(let lhsVersion), .upToNextMinorVersion(let rhsVersion)):
+            case let (.upToNextMinorVersion(lhsVersion), .upToNextMinorVersion(rhsVersion)):
                 return lhsVersion == rhsVersion
-            case (.upToNextMajorVersion(let lhsVersion), .upToNextMajorVersion(let rhsVersion)):
+            case let (.upToNextMajorVersion(lhsVersion), .upToNextMajorVersion(rhsVersion)):
                 return lhsVersion == rhsVersion
             default:
                 return false
             }
         }
     }
-    
+
     /// Repository url.
     var repositoryURL: String?
-    
+
     /// Version rules.
     var versionRules: VersionRules?
-    
+
     /// Initializes the remote swift package reference with its attributes.
     ///
     /// - Parameters:
     ///   - repositoryURL: Package repository url.
     ///   - versionRules: Package version rules.
     init(repositoryURL: String,
-                versionRules: VersionRules? = nil) {
+         versionRules: VersionRules? = nil) {
         self.repositoryURL = repositoryURL
         self.versionRules = versionRules
         super.init()
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case requirement
         case repositoryURL
     }
-    
+
     public required init(from decoder: Decoder) throws {
         let objects = decoder.context.objects
         let repository = decoder.context.objectReferenceRepository
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        
-        
+
         try super.init(from: decoder)
     }
-    
+
     var name: String {
         return "TODO"
     }
-    
-    override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString : PlistValue] {
+
+    override func plistValues(proj _: PBXProj, reference _: String) throws -> [CommentedString: PlistValue] {
         return [:]
     }
-    
+
     // MARK: - Equatable
-    
+
     @objc public override func isEqual(to object: Any?) -> Bool {
         guard let rhs = object as? XCRemoteSwiftPackageReference else { return false }
         if repositoryURL != rhs.repositoryURL { return false }
         if versionRules != rhs.versionRules { return false }
         return super.isEqual(to: rhs)
     }
-
 }

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -3,84 +3,160 @@ import Foundation
 /// This element is an abstract parent for specialized targets.
 public class XCRemoteSwiftPackageReference: PBXContainerItem {
     
-    /// Repository url.
-    var repositoryURL: String
+    /// It represents the version rules for a Swift Package.
+    ///
+    /// - upToNextMajorVersion: The package version can be bumped up to the next major version.
+    /// - upToNextMinorVersion: The package version can be bumped up to the next minor version.
+    /// - range: The package version needs to be in the given range.
+    /// - exact: The package version needs to be the given version.
+    /// - branch: To use a specific branch of the git repository.
+    /// - revision: To use an specific revision of the git repository.
+    public enum VersionRules: Decodable, Equatable {
+        case upToNextMajorVersion(String)
+        case upToNextMinorVersion(String)
+        case range(from: String, to: String)
+        case exact(String)
+        case branch(String)
+        case revision(String)
+        
+        enum CodingKeys: String, CodingKey {
+            case kind
+            case revision
+            case branch
+            case minimumVersion
+            case maximumVersion
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let kind: String = try container.decode(String.self, forKey: .kind)
+            if kind == "revision" {
+                let revision = try container.decode(String.self, forKey: .revision)
+                self = .revision(revision)
+            } else if kind == "branch" {
+                let branch = try container.decode(String.self, forKey: .branch)
+                self = .branch(branch)
+            } else if kind == "exactVersion" {
+                let version = try container.decode(String.self, forKey: .minimumVersion)
+                self = .exact(version)
+            } else if kind == "versionRange" {
+                let minimumVersion = try container.decode(String.self, forKey: .minimumVersion)
+                let maximumVersion = try container.decode(String.self, forKey: .maximumVersion)
+                self = .range(from: minimumVersion, to: maximumVersion)
+            } else if kind == "upToNextMinorVersion" {
+                let version = try container.decode(String.self, forKey: .minimumVersion)
+                self = .upToNextMinorVersion(version)
+            } else if kind == "upToNextMajorVersion" {
+                let version = try container.decode(String.self, forKey: .minimumVersion)
+                self = .upToNextMajorVersion(version)
+            } else {
+                fatalError("XCRemoteSwiftPackageReference kind '\(kind)' not supported")
+            }
+        }
+        
+        func plistValues() throws -> [CommentedString : PlistValue] {
+            switch self {
+            case .revision(let revision):
+                return [
+                    "kind": "revision",
+                    "revision": .string(.init(revision))
+                ]
+            case .branch(let branch):
+                return [
+                    "kind": "branch",
+                    "branch": .string(.init(branch))
+                ]
+            case .exact(let version):
+                return [
+                    "kind": "exactVersion",
+                    "minimumVersion": .string(.init(version))
+                ]
+            case .range(let from, let to):
+                return [
+                    "kind": "versionRange",
+                    "minimumVersion": .string(.init(from)),
+                    "maximumVersion": .string(.init(to)),
+                ]
+            case .upToNextMinorVersion(let version):
+                return [
+                    "kind": "upToNextMinorVersion",
+                    "minimumVersion": .string(.init(version))
+                ]
+            case .upToNextMajorVersion(let version):
+                return [
+                    "kind": "upToNextMajorVersion",
+                    "minimumVersion": .string(.init(version))
+                ]
+            }
+        }
+        
+        public static func == (lhs: VersionRules, rhs: VersionRules) -> Bool {
+            switch (lhs, rhs) {
+            case (.revision(let lhsRevision), .revision(let rhsRevision)):
+                return lhsRevision == rhsRevision
+            case (.branch(let lhsBranch), .branch(let rhsBranch)):
+                return lhsBranch == rhsBranch
+            case (.exact(let lhsVersion), .exact(let rhsVersion)):
+                return lhsVersion == rhsVersion
+            case (.range(let lhsFrom, let lhsTo), .range(let rhsFrom, let rhsTo)):
+                return lhsFrom == rhsFrom && lhsTo == rhsTo
+            case (.upToNextMinorVersion(let lhsVersion), .upToNextMinorVersion(let rhsVersion)):
+                return lhsVersion == rhsVersion
+            case (.upToNextMajorVersion(let lhsVersion), .upToNextMajorVersion(let rhsVersion)):
+                return lhsVersion == rhsVersion
+            default:
+                return false
+            }
+        }
+    }
     
-
-    public init(repositoryURL: String) {
+    /// Repository url.
+    var repositoryURL: String?
+    
+    /// Version rules.
+    var versionRules: VersionRules?
+    
+    /// Initializes the remote swift package reference with its attributes.
+    ///
+    /// - Parameters:
+    ///   - repositoryURL: Package repository url.
+    ///   - versionRules: Package version rules.
+    init(repositoryURL: String,
+                versionRules: VersionRules? = nil) {
         self.repositoryURL = repositoryURL
+        self.versionRules = versionRules
         super.init()
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case requirement
+        case repositoryURL
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let objects = decoder.context.objects
+        let repository = decoder.context.objectReferenceRepository
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        
+        try super.init(from: decoder)
     }
     
     var name: String {
         return "TODO"
     }
     
-    // MARK: - Decodable
+    override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString : PlistValue] {
+        return [:]
+    }
     
-//    fileprivate enum CodingKeys: String, CodingKey {
+    // MARK: - Equatable
+    
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? XCRemoteSwiftPackageReference else { return false }
+        if repositoryURL != rhs.repositoryURL { return false }
+        if versionRules != rhs.versionRules { return false }
+        return super.isEqual(to: rhs)
+    }
 
-//    }
-    
-    public required init(from decoder: Decoder) throws {
-//        let objectReferenceRepository = decoder.context.objectReferenceRepository
-//        let objects = decoder.context.objects
-//        let container = try decoder.container(keyedBy: CodingKeys.self)
-//
-//        name = try container.decode(.name)
-//        if let buildConfigurationListReference: String = try container.decodeIfPresent(.buildConfigurationList) {
-//            self.buildConfigurationListReference = objectReferenceRepository.getOrCreate(reference: buildConfigurationListReference, objects: objects)
-//        } else {
-//            buildConfigurationListReference = nil
-//        }
-//        let buildPhaseReferences: [String] = try container.decodeIfPresent(.buildPhases) ?? []
-//        self.buildPhaseReferences = buildPhaseReferences.map { objectReferenceRepository.getOrCreate(reference: $0, objects: objects) }
-//        let buildRuleReferences: [String] = try container.decodeIfPresent(.buildRules) ?? []
-//        self.buildRuleReferences = buildRuleReferences.map { objectReferenceRepository.getOrCreate(reference: $0, objects: objects) }
-//        let dependencyReferences: [String] = try container.decodeIfPresent(.dependencies) ?? []
-//        self.dependencyReferences = dependencyReferences.map { objectReferenceRepository.getOrCreate(reference: $0, objects: objects) }
-//        productName = try container.decodeIfPresent(.productName)
-//        if let productReferenceString: String = try container.decodeIfPresent(.productReference) {
-//            productReference = objectReferenceRepository.getOrCreate(reference: productReferenceString, objects: objects)
-//        } else {
-//            productReference = nil
-//        }
-//        productType = try container.decodeIfPresent(.productType)
-        try super.init(from: decoder)
-    }
-    
-    func plistValues(proj: PBXProj, isa: String, reference: String) throws -> (key: CommentedString, value: PlistValue) {
-//        var dictionary = try super.plistValues(proj: proj, reference: reference)
-//        dictionary["isa"] = .string(CommentedString(isa))
-//        let buildConfigurationListComment = "Build configuration list for \(isa) \"\(name)\""
-//        if let buildConfigurationListReference = buildConfigurationListReference {
-//            dictionary["buildConfigurationList"] = .string(CommentedString(buildConfigurationListReference.value,
-//                                                                           comment: buildConfigurationListComment))
-//        }
-//        dictionary["buildPhases"] = .array(buildPhaseReferences
-//            .map { (buildPhaseReference: PBXObjectReference) in
-//                let buildPhase: PBXBuildPhase? = buildPhaseReference.getObject()
-//                return .string(CommentedString(buildPhaseReference.value, comment: buildPhase?.name()))
-//        })
-//
-//        // Xcode doesn't write PBXAggregateTarget buildRules or empty PBXLegacyTarget buildRules
-//        if !(self is PBXAggregateTarget), !(self is PBXLegacyTarget) || !buildRuleReferences.isEmpty {
-//            dictionary["buildRules"] = .array(buildRuleReferences.map { .string(CommentedString($0.value, comment: PBXBuildRule.isa)) })
-//        }
-//
-//        dictionary["dependencies"] = .array(dependencyReferences.map { .string(CommentedString($0.value, comment: PBXTargetDependency.isa)) })
-//        dictionary["name"] = .string(CommentedString(name))
-//        if let productName = productName {
-//            dictionary["productName"] = .string(CommentedString(productName))
-//        }
-//        if let productType = productType {
-//            dictionary["productType"] = .string(CommentedString(productType.rawValue))
-//        }
-//        if let productReference = productReference {
-//            let fileElement: PBXFileElement? = productReference.getObject()
-//            dictionary["productReference"] = .string(CommentedString(productReference.value, comment: fileElement?.fileName()))
-//        }
-//        return (key: CommentedString(reference, comment: name),
-//                value: .dictionary(dictionary))
-    }
 }

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element is an abstract parent for specialized targets.
-public class XCRemoteSwiftPackageReference: PBXContainerItem {
+public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable {
     /// It represents the version rules for a Swift Package.
     ///
     /// - upToNextMajorVersion: The package version can be bumped up to the next major version.
@@ -143,10 +143,10 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem {
 
     /// It returns the name of the package reference.
     var name: String? {
-        return self.repositoryURL?.split(separator: "/").last?.replacingOccurrences(of: ".git", with: "")
+        return repositoryURL?.split(separator: "/").last?.replacingOccurrences(of: ".git", with: "")
     }
 
-    override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString: PlistValue] {
+    func plistKeyAndValue(proj: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary = try super.plistValues(proj: proj, reference: reference)
         if let repositoryURL = repositoryURL {
             dictionary["repositoryURL"] = .string(.init(repositoryURL))
@@ -154,7 +154,8 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem {
         if let versionRules = versionRules {
             dictionary["requirement"] = PlistValue.dictionary(versionRules.plistValues())
         }
-        return dictionary
+        return (key: CommentedString(reference),
+                value: .dictionary(dictionary))
     }
 
     // MARK: - Equatable

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// This element is an abstract parent for specialized targets.
+public class XCRemoteSwiftPackageReference: PBXContainerItem {
+    
+    /// Repository url.
+    var repositoryURL: String
+    
+
+    public init(repositoryURL: String) {
+        self.repositoryURL = repositoryURL
+        super.init()
+    }
+    
+    var name: String {
+        return "TODO"
+    }
+    
+    // MARK: - Decodable
+    
+//    fileprivate enum CodingKeys: String, CodingKey {
+
+//    }
+    
+    public required init(from decoder: Decoder) throws {
+//        let objectReferenceRepository = decoder.context.objectReferenceRepository
+//        let objects = decoder.context.objects
+//        let container = try decoder.container(keyedBy: CodingKeys.self)
+//
+//        name = try container.decode(.name)
+//        if let buildConfigurationListReference: String = try container.decodeIfPresent(.buildConfigurationList) {
+//            self.buildConfigurationListReference = objectReferenceRepository.getOrCreate(reference: buildConfigurationListReference, objects: objects)
+//        } else {
+//            buildConfigurationListReference = nil
+//        }
+//        let buildPhaseReferences: [String] = try container.decodeIfPresent(.buildPhases) ?? []
+//        self.buildPhaseReferences = buildPhaseReferences.map { objectReferenceRepository.getOrCreate(reference: $0, objects: objects) }
+//        let buildRuleReferences: [String] = try container.decodeIfPresent(.buildRules) ?? []
+//        self.buildRuleReferences = buildRuleReferences.map { objectReferenceRepository.getOrCreate(reference: $0, objects: objects) }
+//        let dependencyReferences: [String] = try container.decodeIfPresent(.dependencies) ?? []
+//        self.dependencyReferences = dependencyReferences.map { objectReferenceRepository.getOrCreate(reference: $0, objects: objects) }
+//        productName = try container.decodeIfPresent(.productName)
+//        if let productReferenceString: String = try container.decodeIfPresent(.productReference) {
+//            productReference = objectReferenceRepository.getOrCreate(reference: productReferenceString, objects: objects)
+//        } else {
+//            productReference = nil
+//        }
+//        productType = try container.decodeIfPresent(.productType)
+        try super.init(from: decoder)
+    }
+    
+    func plistValues(proj: PBXProj, isa: String, reference: String) throws -> (key: CommentedString, value: PlistValue) {
+//        var dictionary = try super.plistValues(proj: proj, reference: reference)
+//        dictionary["isa"] = .string(CommentedString(isa))
+//        let buildConfigurationListComment = "Build configuration list for \(isa) \"\(name)\""
+//        if let buildConfigurationListReference = buildConfigurationListReference {
+//            dictionary["buildConfigurationList"] = .string(CommentedString(buildConfigurationListReference.value,
+//                                                                           comment: buildConfigurationListComment))
+//        }
+//        dictionary["buildPhases"] = .array(buildPhaseReferences
+//            .map { (buildPhaseReference: PBXObjectReference) in
+//                let buildPhase: PBXBuildPhase? = buildPhaseReference.getObject()
+//                return .string(CommentedString(buildPhaseReference.value, comment: buildPhase?.name()))
+//        })
+//
+//        // Xcode doesn't write PBXAggregateTarget buildRules or empty PBXLegacyTarget buildRules
+//        if !(self is PBXAggregateTarget), !(self is PBXLegacyTarget) || !buildRuleReferences.isEmpty {
+//            dictionary["buildRules"] = .array(buildRuleReferences.map { .string(CommentedString($0.value, comment: PBXBuildRule.isa)) })
+//        }
+//
+//        dictionary["dependencies"] = .array(dependencyReferences.map { .string(CommentedString($0.value, comment: PBXTargetDependency.isa)) })
+//        dictionary["name"] = .string(CommentedString(name))
+//        if let productName = productName {
+//            dictionary["productName"] = .string(CommentedString(productName))
+//        }
+//        if let productType = productType {
+//            dictionary["productType"] = .string(CommentedString(productType.rawValue))
+//        }
+//        if let productReference = productReference {
+//            let fileElement: PBXFileElement? = productReference.getObject()
+//            dictionary["productReference"] = .string(CommentedString(productReference.value, comment: fileElement?.fileName()))
+//        }
+//        return (key: CommentedString(reference, comment: name),
+//                value: .dictionary(dictionary))
+    }
+}

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -24,6 +24,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
             case branch
             case minimumVersion
             case maximumVersion
+            case version
         }
 
         public init(from decoder: Decoder) throws {
@@ -36,7 +37,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
                 let branch = try container.decode(String.self, forKey: .branch)
                 self = .branch(branch)
             } else if kind == "exactVersion" {
-                let version = try container.decode(String.self, forKey: .minimumVersion)
+                let version = try container.decode(String.self, forKey: .version)
                 self = .exact(version)
             } else if kind == "versionRange" {
                 let minimumVersion = try container.decode(String.self, forKey: .minimumVersion)
@@ -68,7 +69,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
             case let .exact(version):
                 return [
                     "kind": "exactVersion",
-                    "minimumVersion": .string(.init(version)),
+                    "version": .string(.init(version)),
                 ]
             case let .range(from, to):
                 return [

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -156,7 +156,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
         if let versionRules = versionRules {
             dictionary["requirement"] = PlistValue.dictionary(versionRules.plistValues())
         }
-        return (key: CommentedString(reference),
+        return (key: CommentedString(reference, comment: "XCRemoteSwiftPackageReference \"\(name ?? "")\""),
                 value: .dictionary(dictionary))
     }
 

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -148,6 +148,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
 
     func plistKeyAndValue(proj: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary = try super.plistValues(proj: proj, reference: reference)
+        dictionary["isa"] = .string(CommentedString(XCRemoteSwiftPackageReference.isa))
         if let repositoryURL = repositoryURL {
             dictionary["repositoryURL"] = .string(.init(repositoryURL))
         }

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -3,5 +3,67 @@ import Foundation
 /// This element is an abstract parent for specialized targets.
 public class XCSwiftPackageProductDependency: PBXContainerItem {
 
-    var productName: String = ""
+    /// Product name.
+    public var productName: String
+    
+    /// Package reference.
+    var packageReference: PBXObjectReference?
+    
+    /// Package the product dependency refers to.
+    var package: XCRemoteSwiftPackageReference?  {
+        get {
+            return self.packageReference?.getObject()
+        }
+        set {
+            self.packageReference = newValue?.reference
+        }
+    }
+    
+    // MARK: - Init
+    
+    init(productName: String,
+         package: XCRemoteSwiftPackageReference? = nil) {
+        self.productName = productName
+        self.packageReference = package?.reference
+        super.init()
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let objects = decoder.context.objects
+        let repository = decoder.context.objectReferenceRepository
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.productName = try container.decode(String.self, forKey: .productName)
+        if let packageString: String = try container.decodeIfPresent(.package) {
+            self.packageReference = repository.getOrCreate(reference: packageString, objects: objects)
+        } else {
+            self.packageReference = nil
+        }
+        try super.init(from: decoder)
+    }
+    
+    override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString : PlistValue] {
+        var dictionary = try super.plistValues(proj: proj, reference: reference)
+        if let package = package {
+            dictionary["package"] = PlistValue.string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name)\""))
+        }
+        dictionary["productName"] = .string(.init(productName))
+        return dictionary
+    }
+    
+    // MARK: - Codable
+    
+    fileprivate enum CodingKeys: String, CodingKey {
+        case productName
+        case package
+    }
+    
+    // MARK: - Equatable
+    
+    @objc public override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? XCSwiftPackageProductDependency else { return false }
+        if packageReference != rhs.packageReference { return false }
+        if productName != rhs.productName { return false }
+        return super.isEqual(to: rhs)
+    }
+    
 }

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// This element is an abstract parent for specialized targets.
+public class XCSwiftPackageProductDependency: PBXContainerItem {
+
+    var productName: String = ""
+}

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -48,7 +48,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
         }
         dictionary["productName"] = .string(.init(productName))
 
-        return (key: CommentedString(reference),
+        return (key: CommentedString(reference, comment: productName),
                 value: .dictionary(dictionary))
     }
 

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -42,6 +42,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
 
     func plistKeyAndValue(proj: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary = try super.plistValues(proj: proj, reference: reference)
+        dictionary["isa"] = .string(CommentedString(XCSwiftPackageProductDependency.isa))
         if let package = package {
             dictionary["package"] = .string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name ?? "")\""))
         }

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -43,7 +43,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem {
     override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString: PlistValue] {
         var dictionary = try super.plistValues(proj: proj, reference: reference)
         if let package = package {
-            dictionary["package"] = PlistValue.string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name)\""))
+            dictionary["package"] = .string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name ?? "")\""))
         }
         dictionary["productName"] = .string(.init(productName))
         return dictionary

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -2,46 +2,45 @@ import Foundation
 
 /// This element is an abstract parent for specialized targets.
 public class XCSwiftPackageProductDependency: PBXContainerItem {
-
     /// Product name.
     public var productName: String
-    
+
     /// Package reference.
     var packageReference: PBXObjectReference?
-    
+
     /// Package the product dependency refers to.
-    var package: XCRemoteSwiftPackageReference?  {
+    var package: XCRemoteSwiftPackageReference? {
         get {
-            return self.packageReference?.getObject()
+            return packageReference?.getObject()
         }
         set {
-            self.packageReference = newValue?.reference
+            packageReference = newValue?.reference
         }
     }
-    
+
     // MARK: - Init
-    
+
     init(productName: String,
          package: XCRemoteSwiftPackageReference? = nil) {
         self.productName = productName
-        self.packageReference = package?.reference
+        packageReference = package?.reference
         super.init()
     }
-    
+
     public required init(from decoder: Decoder) throws {
         let objects = decoder.context.objects
         let repository = decoder.context.objectReferenceRepository
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.productName = try container.decode(String.self, forKey: .productName)
+        productName = try container.decode(String.self, forKey: .productName)
         if let packageString: String = try container.decodeIfPresent(.package) {
-            self.packageReference = repository.getOrCreate(reference: packageString, objects: objects)
+            packageReference = repository.getOrCreate(reference: packageString, objects: objects)
         } else {
-            self.packageReference = nil
+            packageReference = nil
         }
         try super.init(from: decoder)
     }
-    
-    override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString : PlistValue] {
+
+    override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString: PlistValue] {
         var dictionary = try super.plistValues(proj: proj, reference: reference)
         if let package = package {
             dictionary["package"] = PlistValue.string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name)\""))
@@ -49,21 +48,20 @@ public class XCSwiftPackageProductDependency: PBXContainerItem {
         dictionary["productName"] = .string(.init(productName))
         return dictionary
     }
-    
+
     // MARK: - Codable
-    
+
     fileprivate enum CodingKeys: String, CodingKey {
         case productName
         case package
     }
-    
+
     // MARK: - Equatable
-    
+
     @objc public override func isEqual(to object: Any?) -> Bool {
         guard let rhs = object as? XCSwiftPackageProductDependency else { return false }
         if packageReference != rhs.packageReference { return false }
         if productName != rhs.productName { return false }
         return super.isEqual(to: rhs)
     }
-    
 }

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element is an abstract parent for specialized targets.
-public class XCSwiftPackageProductDependency: PBXContainerItem {
+public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializable {
     /// Product name.
     public var productName: String
 
@@ -40,13 +40,15 @@ public class XCSwiftPackageProductDependency: PBXContainerItem {
         try super.init(from: decoder)
     }
 
-    override func plistValues(proj: PBXProj, reference: String) throws -> [CommentedString: PlistValue] {
+    func plistKeyAndValue(proj: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary = try super.plistValues(proj: proj, reference: reference)
         if let package = package {
             dictionary["package"] = .string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name ?? "")\""))
         }
         dictionary["productName"] = .string(.init(productName))
-        return dictionary
+
+        return (key: CommentedString(reference),
+                value: .dictionary(dictionary))
     }
 
     // MARK: - Codable

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -72,17 +72,17 @@ public class PBXTarget: PBXContainerItem {
             productReference = newValue?.reference
         }
     }
-    
+
     /// Swift package product references.
     var packageProductDependencyReferences: [PBXObjectReference]?
-    
+
     /// Swift packages products.
     var packageProductDependencies: [XCSwiftPackageProductDependency]? {
         set {
-            packageProductDependencyReferences = newValue?.map({ $0.reference })
+            packageProductDependencyReferences = newValue?.map { $0.reference }
         }
         get {
-            return self.packageProductDependencyReferences?.objects()
+            return packageProductDependencyReferences?.objects()
         }
     }
 
@@ -156,10 +156,10 @@ public class PBXTarget: PBXContainerItem {
         } else {
             productReference = nil
         }
-        
+
         let packageProductDependencyReferenceStrings: [String]? = try container.decodeIfPresent(.packageProductDependencies)
-        self.packageProductDependencyReferences = packageProductDependencyReferenceStrings?.map({ objectReferenceRepository.getOrCreate(reference: $0, objects: objects) })
-        
+        packageProductDependencyReferences = packageProductDependencyReferenceStrings?.map { objectReferenceRepository.getOrCreate(reference: $0, objects: objects) }
+
         productType = try container.decodeIfPresent(.productType)
         try super.init(from: decoder)
     }
@@ -196,9 +196,9 @@ public class PBXTarget: PBXContainerItem {
             dictionary["productReference"] = .string(CommentedString(productReference.value, comment: fileElement?.fileName()))
         }
         if let packageProductDependencies = packageProductDependencies {
-            dictionary["packageProductDependency"] = PlistValue.array(packageProductDependencies.map({
+            dictionary["packageProductDependency"] = PlistValue.array(packageProductDependencies.map {
                 PlistValue.string(.init($0.reference.value, comment: $0.productName))
-            }))
+            })
         }
         return (key: CommentedString(reference, comment: name),
                 value: .dictionary(dictionary))

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -196,7 +196,7 @@ public class PBXTarget: PBXContainerItem {
             dictionary["productReference"] = .string(CommentedString(productReference.value, comment: fileElement?.fileName()))
         }
         if let packageProductDependencies = packageProductDependencies {
-            dictionary["packageProductDependency"] = PlistValue.array(packageProductDependencies.map {
+            dictionary["packageProductDependencies"] = .array(packageProductDependencies.map {
                 PlistValue.string(.init($0.reference.value, comment: $0.productName))
             })
         }

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -228,7 +228,7 @@ public extension PBXTarget {
             .compactMap { $0 as? PBXSourcesBuildPhase }
             .first
     }
-    
+
     /// Returns the frameworks build phase.
     ///
     /// - Returns: sources build phase.

--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -228,6 +228,18 @@ public extension PBXTarget {
             .compactMap { $0 as? PBXSourcesBuildPhase }
             .first
     }
+    
+    /// Returns the frameworks build phase.
+    ///
+    /// - Returns: sources build phase.
+    /// - Throws: an error if the build phase cannot be obtained.
+    func frameworksBuildPhase() throws -> PBXFrameworksBuildPhase? {
+        return try buildPhaseReferences
+            .compactMap { try $0.getThrowingObject() as? PBXBuildPhase }
+            .filter { $0.buildPhase == .frameworks }
+            .compactMap { $0 as? PBXFrameworksBuildPhase }
+            .first
+    }
 
     /// Returns the resources build phase.
     ///

--- a/Sources/xcodeproj/Project/Xcode.swift
+++ b/Sources/xcodeproj/Project/Xcode.swift
@@ -38,7 +38,7 @@ public struct Xcode {
     /// Default values.
     public struct Default {
         /// The default object version for Xcodeproj.
-        public static let objectVersion: UInt = 50
+        public static let objectVersion: UInt = 52 // Xcode 11
 
         /// Default compatibility version.
         public static let compatibilityVersion: String = "Xcode 9.3"

--- a/Sources/xcodeproj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/xcodeproj/Scheme/XCScheme+LaunchAction.swift
@@ -5,7 +5,6 @@ import PathKit
 extension XCScheme {
     // swiftlint:disable:next type_body_length
     public final class LaunchAction: SerialAction {
-        
         public enum Style: String {
             case auto = "0"
             case wait = "1"
@@ -138,7 +137,6 @@ extension XCScheme {
             debugServiceExtension = element.attributes["debugServiceExtension"] ?? LaunchAction.defaultDebugServiceExtension
             allowLocationSimulation = element.attributes["allowLocationSimulation"].map { $0 == "YES" } ?? true
 
-        
             // Runnable
             let buildableProductRunnableElement = element["BuildableProductRunnable"]
             let remoteRunnableElement = element["RemoteRunnable"]
@@ -147,7 +145,7 @@ extension XCScheme {
             } else if remoteRunnableElement.error == nil {
                 runnable = try RemoteRunnable(element: remoteRunnableElement)
             }
-            
+
             let buildableReferenceElement = element["MacroExpansion"]["BuildableReference"]
             if buildableReferenceElement.error == nil {
                 macroExpansion = try BuildableReference(element: buildableReferenceElement)

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -76,12 +76,26 @@ final class ReferenceGenerator: ReferenceGenerating {
         // Project
         fixReference(for: project, identifiers: identifiers)
 
+        // Packages
+        project.packages?.forEach {
+            var identifiers = identifiers
+            identifiers.append($0.name)
+            fixReference(for: $0, identifiers: identifiers)
+        }
+
         // Targets
         let targets: [PBXTarget] = project.targetReferences.objects()
         targets.forEach { target in
 
             var identifiers = identifiers
             identifiers.append(target.name)
+
+            // Packages
+            target.packageProductDependencies?.forEach {
+                var identifiers = identifiers
+                identifiers.append($0.productName)
+                fixReference(for: $0, identifiers: identifiers)
+            }
 
             fixReference(for: target, identifiers: identifiers)
         }

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -79,7 +79,7 @@ final class ReferenceGenerator: ReferenceGenerating {
         // Packages
         project.packages?.forEach {
             var identifiers = identifiers
-            identifiers.append($0.name)
+            identifiers.append($0.repositoryURL ?? $0.name ?? "")
             fixReference(for: $0, identifiers: identifiers)
         }
 

--- a/Tests/xcodeprojTests/Extensions/PathExtrasTests.swift
+++ b/Tests/xcodeprojTests/Extensions/PathExtrasTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import PathKit
+import XCTest
 @testable import XcodeProj
 
 final class PathExtrasTests: XCTestCase {

--- a/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXFileElementTests.swift
@@ -52,9 +52,9 @@ final class PBXFileElementTests: XCTestCase {
                                  name: "/to/be/ignored")
 
         let project = PBXProject(name: "ProjectName",
-                   buildConfigurationList: XCConfigurationList(),
-                   compatibilityVersion: "0",
-                   mainGroup: mainGroup)
+                                 buildConfigurationList: XCConfigurationList(),
+                                 compatibilityVersion: "0",
+                                 mainGroup: mainGroup)
 
         let objects = PBXObjects(objects: [project, mainGroup, fileref, group])
         fileref.reference.objects = objects
@@ -83,8 +83,8 @@ final class PBXFileElementTests: XCTestCase {
         // Remove parent for fallback test
         fileref.parent = nil
 
-        XCTAssertThrowsError(try fileref.fullPath(sourceRoot: sourceRoot)) { (error) in
-            if case PBXProjError.invalidGroupPath(let sourceRoot, let elementPath) = error {
+        XCTAssertThrowsError(try fileref.fullPath(sourceRoot: sourceRoot)) { error in
+            if case let PBXProjError.invalidGroupPath(sourceRoot, elementPath) = error {
                 XCTAssertEqual(sourceRoot, "/")
                 XCTAssertEqual(elementPath, "groupPath")
             } else {

--- a/Tests/xcodeprojTests/Objects/Project/PBXOutputSettingsTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXOutputSettingsTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 @testable import XcodeProj
 
-class PBXOutputSettingsTsts: XCTestCase {
+class PBXOutputSettingsTests: XCTestCase {
     var proj: PBXProj!
     var buildFileAssets: PBXBuildFile!
     var buildFileMain: PBXBuildFile!
@@ -32,10 +32,10 @@ class PBXOutputSettingsTsts: XCTestCase {
         do {
             proj = try PBXProj(jsonDictionary: dic.1)
         } catch {
-            XCTFail("Failed to load project from file \(error)")
+            XCTFail("Failed to load project from file: \(error)")
         }
 
-        proj.buildFiles.forEach { print("\(type(of: $0.file!)) \($0.file!.fileName()!)") }
+//        proj.buildFiles.forEach { print("\(type(of: $0.file!)) \($0.file!.fileName()!)") }
         buildFileAssets = proj.buildFiles.first { $0.file?.fileName() == "Assets.xcassets" }!
         buildFileMain = proj.buildFiles.first { $0.file?.fileName() == "Main.storyboard" }!
 

--- a/Tests/xcodeprojTests/Objects/Project/PBXProjEncoderTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProjEncoderTests.swift
@@ -20,7 +20,7 @@ class PBXProjEncoderTests: XCTestCase {
 
     func test_writeHeaders() throws {
         let lines = self.lines(fromFile: encodeProject())
-        XCTAssertEqual(529, lines.count)
+        XCTAssertEqual(581, lines.count)
         XCTAssertEqual("// !$*UTF8*$!", lines[0])
     }
 
@@ -40,6 +40,8 @@ class PBXProjEncoderTests: XCTestCase {
         line = lines.validate(lineContaining: "23766C201EAA3484007A9026 /* LaunchScreen.storyboard in Resources */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C2B1EAA3484007A9026 /* iOSTests.swift in Sources */", onLineAfter: line)
         line = lines.validate(lineContaining: "3CD1EADD205763E400DAEECB /* Model.xcdatamodeld in Sources */", onLineAfter: line)
+        line = lines.validate(lineContaining: "42AA1A1A22AAF48100428760 /* MyLocalPackage in Frameworks */", onLineAfter: line)
+        line = lines.validate(lineContaining: "42AA1A1C22AAF48100428760 /* RxSwift in Frameworks */", onLineAfter: line)
         lines.validate(line: "/* End PBXBuildFile section */", onLineAfter: line)
     }
 
@@ -58,6 +60,8 @@ class PBXProjEncoderTests: XCTestCase {
         line = lines.validate(lineContaining: "04D5C0A31F153924008A2F98 /* Public.h in Headers */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C181EAA3484007A9026 /* ViewController.swift in Sources */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C2B1EAA3484007A9026 /* iOSTests.swift in Sources */", onLineAfter: line)
+        line = lines.validate(lineContaining: "42AA1A1A22AAF48100428760 /* MyLocalPackage in Frameworks */", onLineAfter: line)
+        line = lines.validate(lineContaining: "42AA1A1C22AAF48100428760 /* RxSwift in Frameworks */", onLineAfter: line)
         lines.validate(line: "/* End PBXBuildFile section */", onLineAfter: line)
     }
 
@@ -79,6 +83,7 @@ class PBXProjEncoderTests: XCTestCase {
         line = lines.validate(lineContaining: "23766C2A1EAA3484007A9026 /* iOSTests.swift */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C2C1EAA3484007A9026 /* Info.plist */", onLineAfter: line)
         line = lines.validate(lineContaining: "3CD1EADC205763E400DAEECB /* Model.xcdatamodel */", onLineAfter: line)
+        line = lines.validate(lineContaining: "42AA1A1822AAF41000428760 /* MyLocalPackage */", onLineAfter: line)
         lines.validate(line: "/* End PBXFileReference section */", onLineAfter: line)
     }
 
@@ -94,6 +99,7 @@ class PBXProjEncoderTests: XCTestCase {
         line = lines.validate(lineContaining: "23766C211EAA3484007A9026 /* Info.plist */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C2C1EAA3484007A9026 /* Info.plist */", onLineAfter: line)
         line = lines.validate(lineContaining: "3CD1EADC205763E400DAEECB /* Model.xcdatamodel */", onLineAfter: line)
+        line = lines.validate(lineContaining: "42AA1A1822AAF41000428760 /* MyLocalPackage */", onLineAfter: line)
         line = lines.validate(lineContaining: "04D5C0A21F153921008A2F98 /* Private.h */", onLineAfter: line)
         line = lines.validate(lineContaining: "04D5C0A11F15391B008A2F98 /* Protected.h */", onLineAfter: line)
         line = lines.validate(lineContaining: "04D5C0A01F153915008A2F98 /* Public.h */", onLineAfter: line)

--- a/Tests/xcodeprojTests/Objects/Project/PBXProjIntegrationTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProjIntegrationTests.swift
@@ -85,5 +85,7 @@ final class PBXProjIntegrationTests: XCTestCase {
         XCTAssertEqual(proj.objects.buildRules.count, 1)
         XCTAssertEqual(proj.objects.versionGroups.count, 1)
         XCTAssertEqual(proj.objects.projects.count, 1)
+        XCTAssertEqual(proj.objects.swiftPackageProductDependencies.count, 2)
+        XCTAssertEqual(proj.objects.remoteSwiftPackageReferences.count, 1)
     }
 }

--- a/Tests/xcodeprojTests/Objects/Project/PBXProjIntegrationTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProjIntegrationTests.swift
@@ -64,9 +64,9 @@ final class PBXProjIntegrationTests: XCTestCase {
 
     private func assert(proj: PBXProj) {
         XCTAssertEqual(proj.archiveVersion, 1)
-        XCTAssertEqual(proj.objectVersion, 46)
+        XCTAssertEqual(proj.objectVersion, 52)
         XCTAssertEqual(proj.classes.count, 0)
-        XCTAssertEqual(proj.objects.buildFiles.count, 11)
+        XCTAssertEqual(proj.objects.buildFiles.count, 13)
         XCTAssertEqual(proj.objects.aggregateTargets.count, 0)
         XCTAssertEqual(proj.objects.containerItemProxies.count, 1)
         XCTAssertEqual(proj.objects.copyFilesBuildPhases.count, 1)
@@ -81,7 +81,7 @@ final class PBXProjIntegrationTests: XCTestCase {
         XCTAssertEqual(proj.objects.frameworksBuildPhases.count, 2)
         XCTAssertEqual(proj.objects.headersBuildPhases.count, 1)
         XCTAssertEqual(proj.objects.nativeTargets.count, 2)
-        XCTAssertEqual(proj.objects.fileReferences.count, 15)
+        XCTAssertEqual(proj.objects.fileReferences.count, 16)
         XCTAssertEqual(proj.objects.buildRules.count, 1)
         XCTAssertEqual(proj.objects.versionGroups.count, 1)
         XCTAssertEqual(proj.objects.projects.count, 1)

--- a/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
+++ b/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import XCTest
+
+@testable import XcodeProj
+
+final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
+    
+    func test_versionRules_returnsTheRightPlistValues_when_revision() throws {
+        // When
+        let subject = XCRemoteSwiftPackageReference.VersionRules.revision("sha")
+        
+        // Given
+        let got = try subject.plistValues()
+        
+        // Then
+        XCTAssertEqual(got, [
+            "kind": "revision",
+            "revision": .string(.init("sha"))
+            ])
+    }
+    func test_versionRules_returnsTheRightPlistValues_when_branch() throws {
+        // When
+        let subject = XCRemoteSwiftPackageReference.VersionRules.branch("master")
+        
+        // Given
+        let got = try subject.plistValues()
+        
+        // Then
+        XCTAssertEqual(got, [
+            "kind": "branch",
+            "branch": .string(.init("master"))
+            ])
+    }
+    
+    func test_versionRules_returnsTheRightPlistValues_when_exact() throws {
+        // When
+        let subject = XCRemoteSwiftPackageReference.VersionRules.exact("3.2.1")
+        
+        // Given
+        let got = try subject.plistValues()
+        
+        // Then
+        XCTAssertEqual(got, [
+            "kind": "exactVersion",
+            "minimumVersion": .string(.init("3.2.1"))
+            ])
+    }
+    
+    func test_versionRules_returnsTheRightPlistValues_when_upToNextMajorVersion() throws {
+        // When
+        let subject = XCRemoteSwiftPackageReference.VersionRules.upToNextMajorVersion("3.2.1")
+        
+        // Given
+        let got = try subject.plistValues()
+        
+        // Then
+        XCTAssertEqual(got, [
+            "kind": "upToNextMajorVersion",
+            "minimumVersion": .string(.init("3.2.1"))
+            ])
+    }
+    
+    func test_versionRules_returnsTheRightPlistValues_when_range() throws {
+        // When
+        let subject = XCRemoteSwiftPackageReference.VersionRules.range(from: "3.2.1", to: "4.0.0")
+        
+        // Given
+        let got = try subject.plistValues()
+        
+        // Then
+        XCTAssertEqual(got, [
+            "kind": "versionRange",
+            "minimumVersion": .string(.init("3.2.1")),
+            "maximumVersion": .string(.init("4.0.0")),
+            ])
+    }
+    
+    func test_versionRules_returnsTheRightPlistValues_when_upToNextMinorVersion() throws {
+        // When
+        let subject = XCRemoteSwiftPackageReference.VersionRules.upToNextMinorVersion("3.2.1")
+        
+        // Given
+        let got = try subject.plistValues()
+        
+        // Then
+        XCTAssertEqual(got, [
+            "kind": "upToNextMinorVersion",
+            "minimumVersion": .string(.init("3.2.1"))
+            ])
+    }
+}

--- a/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
+++ b/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
@@ -4,88 +4,88 @@ import XCTest
 @testable import XcodeProj
 
 final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
-    
     func test_versionRules_returnsTheRightPlistValues_when_revision() throws {
         // When
         let subject = XCRemoteSwiftPackageReference.VersionRules.revision("sha")
-        
+
         // Given
         let got = try subject.plistValues()
-        
+
         // Then
         XCTAssertEqual(got, [
             "kind": "revision",
-            "revision": .string(.init("sha"))
-            ])
+            "revision": .string(.init("sha")),
+        ])
     }
+
     func test_versionRules_returnsTheRightPlistValues_when_branch() throws {
         // When
         let subject = XCRemoteSwiftPackageReference.VersionRules.branch("master")
-        
+
         // Given
         let got = try subject.plistValues()
-        
+
         // Then
         XCTAssertEqual(got, [
             "kind": "branch",
-            "branch": .string(.init("master"))
-            ])
+            "branch": .string(.init("master")),
+        ])
     }
-    
+
     func test_versionRules_returnsTheRightPlistValues_when_exact() throws {
         // When
         let subject = XCRemoteSwiftPackageReference.VersionRules.exact("3.2.1")
-        
+
         // Given
         let got = try subject.plistValues()
-        
+
         // Then
         XCTAssertEqual(got, [
             "kind": "exactVersion",
-            "minimumVersion": .string(.init("3.2.1"))
-            ])
+            "minimumVersion": .string(.init("3.2.1")),
+        ])
     }
-    
+
     func test_versionRules_returnsTheRightPlistValues_when_upToNextMajorVersion() throws {
         // When
         let subject = XCRemoteSwiftPackageReference.VersionRules.upToNextMajorVersion("3.2.1")
-        
+
         // Given
         let got = try subject.plistValues()
-        
+
         // Then
         XCTAssertEqual(got, [
             "kind": "upToNextMajorVersion",
-            "minimumVersion": .string(.init("3.2.1"))
-            ])
+            "minimumVersion": .string(.init("3.2.1")),
+        ])
     }
-    
+
     func test_versionRules_returnsTheRightPlistValues_when_range() throws {
         // When
         let subject = XCRemoteSwiftPackageReference.VersionRules.range(from: "3.2.1", to: "4.0.0")
-        
+
         // Given
         let got = try subject.plistValues()
-        
+
         // Then
         XCTAssertEqual(got, [
             "kind": "versionRange",
             "minimumVersion": .string(.init("3.2.1")),
             "maximumVersion": .string(.init("4.0.0")),
-            ])
+        ])
     }
-    
+
     func test_versionRules_returnsTheRightPlistValues_when_upToNextMinorVersion() throws {
         // When
         let subject = XCRemoteSwiftPackageReference.VersionRules.upToNextMinorVersion("3.2.1")
-        
+
         // Given
         let got = try subject.plistValues()
-        
+
         // Then
         XCTAssertEqual(got, [
             "kind": "upToNextMinorVersion",
-            "minimumVersion": .string(.init("3.2.1"))
-            ])
+            "minimumVersion": .string(.init("3.2.1")),
+        ])
     }
 }

--- a/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
+++ b/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
@@ -62,7 +62,7 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         // Then
         XCTAssertEqual(got, [
             "kind": "exactVersion",
-            "minimumVersion": .string(.init("3.2.1")),
+            "version": .string(.init("3.2.1")),
         ])
     }
 
@@ -116,16 +116,17 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
                                                     versionRules: .exact("1.2.3"))
 
         // Given
-        let got = try subject.plistValues(proj: proj, reference: "ref")
+        let got = try subject.plistKeyAndValue(proj: proj, reference: "ref")
 
         // Then
-        XCTAssertEqual(got, [
+        XCTAssertEqual(got.value, .dictionary([
+            "isa": "XCRemoteSwiftPackageReference",
             "repositoryURL": "repository",
             "requirement": .dictionary([
                 "kind": "exactVersion",
-                "minimumVersion": "1.2.3",
+                "version": "1.2.3",
             ]),
-        ])
+        ]))
     }
 
     func test_equal() {

--- a/Tests/xcodeprojTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
+++ b/Tests/xcodeprojTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
@@ -29,13 +29,14 @@ final class XCSwiftPackageProductDependencyTests: XCTestCase {
                                                       package: package)
 
         // When
-        let got = try subject.plistValues(proj: proj, reference: "reference")
+        let got = try subject.plistKeyAndValue(proj: proj, reference: "reference")
 
         // Then
-        XCTAssertEqual(got, [
+        XCTAssertEqual(got.value, .dictionary([
+            "isa": "XCSwiftPackageProductDependency",
             "productName": "product",
             "package": .string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name ?? "")\"")),
-        ])
+        ]))
     }
 
     func test_equal() {

--- a/Tests/xcodeprojTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
+++ b/Tests/xcodeprojTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+
+@testable import XcodeProj
+
+final class XCSwiftPackageProductDependencyTests: XCTestCase {
+    func test_init() throws {
+        // Given
+        let decoder = XcodeprojPropertyListDecoder()
+        let encoder = PropertyListEncoder()
+        let plist = ["reference": "reference",
+                     "productName": "xcodeproj",
+                     "package": "packageReference"]
+        let data = try encoder.encode(plist)
+
+        // When
+        let got = try decoder.decode(XCSwiftPackageProductDependency.self, from: data)
+
+        // Then
+        XCTAssertEqual(got.productName, "xcodeproj")
+        XCTAssertEqual(got.packageReference?.value, "packageReference")
+    }
+
+    func test_plistValues() throws {
+        // Given
+        let proj = PBXProj()
+        let package = XCRemoteSwiftPackageReference(repositoryURL: "repository")
+        let subject = XCSwiftPackageProductDependency(productName: "product",
+                                                      package: package)
+
+        // When
+        let got = try subject.plistValues(proj: proj, reference: "reference")
+
+        // Then
+        XCTAssertEqual(got, [
+            "productName": "product",
+            "package": .string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name ?? "")\"")),
+        ])
+    }
+
+    func test_equal() {
+        // Given
+        let package = XCRemoteSwiftPackageReference(repositoryURL: "repository")
+        let first = XCSwiftPackageProductDependency(productName: "product",
+                                                    package: package)
+        let second = XCSwiftPackageProductDependency(productName: "product",
+                                                     package: package)
+
+        // Then
+        XCTAssertEqual(first, second)
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/438

### Short description 📝
With the introduction of Swift Package Manager support to Xcode projects, Apple has added new objects and attributes to existing models.

### Solution 📦
Add support for those changes from XcodeProj.

### Implementation 👩‍💻👨‍💻
- [x] Add `PBXProject.packages` attribute.
- [x] Add `PBXNativeTarget. packageProductDependencies` attribute.
- [x] Define `XCRemoteSwiftPackageReference` model.
- [x] Define `XCSwiftPackageProductDependency` model.
- [x] Add `PBXBuildFile.productRef` attribute.
- [x] Verify the optionality of the attributes.
- [x] Update the `ReferenceGenerator` logic to generate the reference for the new objects.
- [x] Add tests.
- [x] Add method to `PBXProject` to add a new Swift package to the project.