### PR TITLE
Added Product Type for WatchKit2AppContainer (i.e Independent Watch Apps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Breaking** Change the UUID generation logic to generate ids with a length of 24 https://github.com/tuist/xcodeproj/pull/432 by @pepibumur.
 ### Added
 
+- Added `com.apple.product-type.application.watchapp2-container` to `PBXProductType`. https://github.com/tuist/xcodeproj/pull/441 by @leogdion.
 - Add BatchUpdater to quickly add files to the group https://github.com/tuist/xcodeproj/pull/388 by @CognitiveDisson.
 - **Breaking** Swift 5 support https://github.com/tuist/xcodeproj/pull/397 by @pepibumur.
 - `WorkspaceSettings.autoCreateSchemes` attribute https://github.com/tuist/xcodeproj/pull/399 by @pepibumur

--- a/Sources/xcodeproj/Objects/Targets/PBXProductType.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXProductType.swift
@@ -14,6 +14,7 @@ public enum PBXProductType: String, Decodable {
     case commandLineTool = "com.apple.product-type.tool"
     case watchApp = "com.apple.product-type.application.watchapp"
     case watch2App = "com.apple.product-type.application.watchapp2"
+    case watch2AppContainer = "com.apple.product-type.application.watchapp2-container"
     case watchExtension = "com.apple.product-type.watchkit-extension"
     case watch2Extension = "com.apple.product-type.watchkit2-extension"
     case tvExtension = "com.apple.product-type.tv-app-extension"
@@ -29,7 +30,7 @@ public enum PBXProductType: String, Decodable {
     /// Returns the file extension for the given product type.
     public var fileExtension: String? {
         switch self {
-        case .application, .watchApp, .watch2App, .messagesApplication:
+        case .application, .watchApp, .watch2App, .watch2AppContainer, .messagesApplication:
             return "app"
         case .framework, .staticFramework:
             return "framework"


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/438

### Short description 📝
> The resolves the missing product type for the new Independent Watch App containers.

### Solution 📦
> I added the PBXProductType enum case of `com.apple.product-type.application.watchapp2-container`. These act similar to how the iOS app acts except without being an iOS app. 

### Implementation 👩‍💻👨‍💻
- [ ] Added the Enum Case under PBXProductType
- [ ] Added the file extension for the Product Type