### PR TITLE
Fix compile error

### DIFF
--- a/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXTarget.swift
@@ -241,18 +241,6 @@ public extension PBXTarget {
             .first
     }
 
-    /// Returns the frameworks build phase.
-    ///
-    /// - Returns: sources build phase.
-    /// - Throws: an error if the build phase cannot be obtained.
-    func frameworksBuildPhase() throws -> PBXFrameworksBuildPhase? {
-        return try buildPhaseReferences
-            .compactMap { try $0.getThrowingObject() as? PBXBuildPhase }
-            .filter { $0.buildPhase == .frameworks }
-            .compactMap { $0 as? PBXFrameworksBuildPhase }
-            .first
-    }
-
     /// Returns the resources build phase.
     ///
     /// - Returns: sources build phase.


### PR DESCRIPTION
There was a duplicate function due to 2 different PR’s landing at the same time, causing a compile error. This is now fixed