### PR TITLE
Swift Package fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 /.build
 /Packages
-
+.swiftpm
 # Created by https://www.gitignore.io/api/macos,swift,xcode,appcode,swiftpm
 
 ### AppCode ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - **Breaking** Added throwing an error in case group path can't be resolved by @damirdavletov  
 - **Breaking** Added remote project support to PBXContainerItemProxy by @damirdavletov
 - **Breaking** Add support for `RemoteRunnable` https://github.com/tuist/xcodeproj/pull/400 by @pepibumur.
-- Support for Swift Package Manager https://github.com/tuist/xcodeproj/pull/439 by @pepibumur.
+- Support for Swift PM Packages https://github.com/tuist/xcodeproj/pull/439 https://github.com/tuist/xcodeproj/pull/444 by @pepibumur @yonaskolb.
 
 ### Fixed
 

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -125,15 +125,15 @@ public final class PBXProject: PBXObject {
     }
 
     /// Package references.
-    var packageReferences: [PBXObjectReference]?
+    var packageReferences: [PBXObjectReference]
 
     /// Swift packages.
-    var packages: [XCRemoteSwiftPackageReference]? {
+    public var packages: [XCRemoteSwiftPackageReference] {
         set {
-            packageReferences = newValue?.map { $0.reference }
+            packageReferences = newValue.references()
         }
         get {
-            return packageReferences?.objects()
+            return packageReferences.objects()
         }
     }
 
@@ -175,8 +175,7 @@ public final class PBXProject: PBXObject {
         // Reference
         let reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRules: versionRules)
         objects.add(object: reference)
-        if packages == nil { packages = [] }
-        packages?.append(reference)
+        packages.append(reference)
 
         // Product
         let productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
@@ -223,6 +222,7 @@ public final class PBXProject: PBXObject {
                 projects: [[String: PBXFileElement]] = [],
                 projectRoots: [String] = [],
                 targets: [PBXTarget] = [],
+                packages: [XCRemoteSwiftPackageReference] = [],
                 attributes: [String: Any] = [:],
                 targetAttributes: [PBXTarget: [String: Any]] = [:]) {
         self.name = name
@@ -237,6 +237,7 @@ public final class PBXProject: PBXObject {
         projectReferences = projects.map { project in project.mapValues { $0.reference } }
         self.projectRoots = projectRoots
         targetReferences = targets.references()
+        packageReferences = packages.references()
         self.attributes = attributes
         targetAttributeReferences = [:]
         super.init()
@@ -297,8 +298,8 @@ public final class PBXProject: PBXObject {
         let targetReferences: [String] = (try container.decodeIfPresent(.targets)) ?? []
         self.targetReferences = targetReferences.map { referenceRepository.getOrCreate(reference: $0, objects: objects) }
 
-        let packageRefeferenceStrings: [String]? = try container.decodeIfPresent(.packageReferences)
-        packageReferences = packageRefeferenceStrings?.map { referenceRepository.getOrCreate(reference: $0, objects: objects) }
+        let packageRefeferenceStrings: [String] = try container.decodeIfPresent(.packageReferences) ?? []
+        packageReferences = packageRefeferenceStrings.map { referenceRepository.getOrCreate(reference: $0, objects: objects) }
 
         var attributes = (try container.decodeIfPresent([String: Any].self, forKey: .attributes) ?? [:])
         var targetAttributeReferences: [PBXObjectReference: [String: Any]] = [:]
@@ -356,7 +357,7 @@ extension PBXProject: PlistSerializable {
                 return .string(CommentedString(targetReference.value, comment: target?.name))
         })
 
-        if let packages = packages {
+        if !packages.isEmpty {
             dictionary["packageReferences"] = PlistValue.array(packages.map {
                 .string(CommentedString($0.reference.value, comment: "XCRemoteSwiftPackageReference \"\($0.name ?? "")\""))
             })

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -180,8 +180,7 @@ public final class PBXProject: PBXObject {
         // Product
         let productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
         objects.add(object: productDependency)
-        if target?.packageProductDependencies == nil { target?.packageProductDependencies = [] }
-        target?.packageProductDependencies?.append(productDependency)
+        target?.packageProductDependencies.append(productDependency)
 
         // Build file
         let buildFile = PBXBuildFile(product: productDependency)

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -125,7 +125,7 @@ public final class PBXProject: PBXObject {
     }
 
     /// Package references.
-    var packageReferences: [PBXObjectReference]
+    var packageReferences: [PBXObjectReference]?
 
     /// Swift packages.
     public var packages: [XCRemoteSwiftPackageReference] {
@@ -133,7 +133,7 @@ public final class PBXProject: PBXObject {
             packageReferences = newValue.references()
         }
         get {
-            return packageReferences.objects()
+            return packageReferences?.objects() ?? []
         }
     }
 

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -111,17 +111,17 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
     }
 
     /// Repository url.
-    var repositoryURL: String?
+    public var repositoryURL: String?
 
     /// Version rules.
-    var versionRules: VersionRules?
+    public var versionRules: VersionRules?
 
     /// Initializes the remote swift package reference with its attributes.
     ///
     /// - Parameters:
     ///   - repositoryURL: Package repository url.
     ///   - versionRules: Package version rules.
-    init(repositoryURL: String,
+    public init(repositoryURL: String,
          versionRules: VersionRules? = nil) {
         self.repositoryURL = repositoryURL
         self.versionRules = versionRules
@@ -143,7 +143,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
     }
 
     /// It returns the name of the package reference.
-    var name: String? {
+    public var name: String? {
         return repositoryURL?.split(separator: "/").last?.replacingOccurrences(of: ".git", with: "")
     }
 

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -9,7 +9,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
     var packageReference: PBXObjectReference?
 
     /// Package the product dependency refers to.
-    var package: XCRemoteSwiftPackageReference? {
+    public var package: XCRemoteSwiftPackageReference? {
         get {
             return packageReference?.getObject()
         }
@@ -20,7 +20,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
 
     // MARK: - Init
 
-    init(productName: String,
+    public init(productName: String,
          package: XCRemoteSwiftPackageReference? = nil) {
         self.productName = productName
         packageReference = package?.reference

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -77,7 +77,7 @@ final class ReferenceGenerator: ReferenceGenerating {
         fixReference(for: project, identifiers: identifiers)
 
         // Packages
-        project.packages?.forEach {
+        project.packages.forEach {
             var identifiers = identifiers
             identifiers.append($0.repositoryURL ?? $0.name ?? "")
             fixReference(for: $0, identifiers: identifiers)

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -91,7 +91,7 @@ final class ReferenceGenerator: ReferenceGenerating {
             identifiers.append(target.name)
 
             // Packages
-            target.packageProductDependencies?.forEach {
+            target.packageProductDependencies.forEach {
                 var identifiers = identifiers
                 identifiers.append($0.productName)
                 fixReference(for: $0, identifiers: identifiers)


### PR DESCRIPTION
- makes some properties in the new swift package classes public and in the inits so they can be used in other tools
- adds the `.swiftpm` directory to `.gitignore` for when opening the `Package.swift` in Xcode 11
- make `PBXProject.packages` and `PBXTarget.packageProductDependencies`
  - public
  - non optional
  - available in init