### PR TITLE
Fix PBXContainerItemProxy.remoteGlobalID

### DIFF
--- a/Sources/xcodeproj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/xcodeproj/Objects/Sourcery/Equality.generated.swift
@@ -65,7 +65,7 @@ extension PBXContainerItemProxy {
         guard let rhs = object as? PBXContainerItemProxy else { return false }
         if containerPortalReference != rhs.containerPortalReference { return false }
         if proxyType != rhs.proxyType { return false }
-        if remoteGlobalIDString != rhs.remoteGlobalIDString { return false }
+        if remoteGlobalIDReference != rhs.remoteGlobalIDReference { return false }
         if remoteInfo != rhs.remoteInfo { return false }
         return super.isEqual(to: rhs)
     }

--- a/Sources/xcodeproj/Objects/Targets/PBXNativeTarget.swift
+++ b/Sources/xcodeproj/Objects/Targets/PBXNativeTarget.swift
@@ -83,7 +83,7 @@ public extension PBXNativeTarget {
             return nil
         }
         let proxy = PBXContainerItemProxy(containerPortal: .project(project),
-                                          remoteGlobalIDString: target.uuid,
+                                          remoteGlobalID: .object(target),
                                           proxyType: .nativeTarget,
                                           remoteInfo: target.name)
         objects.add(object: proxy)

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -205,7 +205,7 @@ final class ReferenceGenerator: ReferenceGenerating {
         if let targetProxyReference = targetDependency.targetProxyReference,
             targetProxyReference.temporary,
             let targetProxy = targetDependency.targetProxy,
-            let remoteGlobalIDString = targetProxy.remoteGlobalIDString {
+            let remoteGlobalIDString = targetProxy.remoteGlobalID?.uuid {
             var identifiers = identifiers
             identifiers.append(remoteGlobalIDString)
             fixReference(for: targetProxy, identifiers: identifiers)

--- a/Tests/xcodeprojTests/Objects/Files/PBXContainerItemProxyTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXContainerItemProxyTests.swift
@@ -18,6 +18,14 @@ final class PBXContainerItemProxyTests: XCTestCase {
         } catch {}
     }
 
+    func test_maintains_remoteID() {
+        let target = PBXNativeTarget(name: "")
+        let project = PBXProject(name: "", buildConfigurationList: XCConfigurationList(), compatibilityVersion: "", mainGroup: PBXGroup())
+        let containerProxy = PBXContainerItemProxy(containerPortal: .project(project), remoteGlobalID: .object(target))
+
+        XCTAssertEqual(target.uuid, containerProxy.remoteGlobalID?.uuid)
+    }
+
     private func testDictionary() -> [String: Any] {
         return [
             "containerPortal": "containerPortal",

--- a/Tests/xcodeprojTests/Objects/Targets/PBXNativeTargetTests.swift
+++ b/Tests/xcodeprojTests/Objects/Targets/PBXNativeTargetTests.swift
@@ -54,7 +54,7 @@ final class PBXNativeTargetTests: XCTestCase {
         XCTAssertEqual(targetDependency?.targetReference, dependency.reference)
         let containerItemProxy: PBXContainerItemProxy? = targetDependency?.targetProxyReference?.getObject()
         XCTAssertEqual(containerItemProxy?.containerPortalReference, project.reference)
-        XCTAssertEqual(containerItemProxy?.remoteGlobalIDString, dependency.reference.value)
+        XCTAssertEqual(containerItemProxy?.remoteGlobalID?.uuid, dependency.reference.value)
         XCTAssertEqual(containerItemProxy?.proxyType, .nativeTarget)
         XCTAssertEqual(containerItemProxy?.remoteInfo, "Dependency")
     }


### PR DESCRIPTION
### Short description 📝
https://github.com/tuist/xcodeproj/pull/425 changed `PBXContainerItemProxy.remoteGlobalID` into a string to support references outside of the project. This created a problem because if setting the id from a PBXObject.uuid, this would changed upon reference resolution. Outsider users of xcodeproj also don't have access to the PBXReference

### Solution 📦
Create an enum that allows for setting an `.object` as before or a `.string` for remote projects
