### PR TITLE
Rename version requirement

### DIFF
--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -168,12 +168,12 @@ public final class PBXProject: PBXObject {
 
     public func addSwiftPackage(repositoryURL: String,
                                 productName: String,
-                                versionRules: XCRemoteSwiftPackageReference.VersionRules,
+                                versionRequirement: XCRemoteSwiftPackageReference.VersionRequirement,
                                 target: PBXTarget? = nil) -> XCRemoteSwiftPackageReference {
         let objects = try! self.objects()
 
         // Reference
-        let reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRules: versionRules)
+        let reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRequirement: versionRequirement)
         objects.add(object: reference)
         packages.append(reference)
 

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -10,7 +10,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
     /// - exact: The package version needs to be the given version.
     /// - branch: To use a specific branch of the git repository.
     /// - revision: To use an specific revision of the git repository.
-    public enum VersionRules: Decodable, Equatable {
+    public enum VersionRequirement: Decodable, Equatable {
         case upToNextMajorVersion(String)
         case upToNextMinorVersion(String)
         case range(from: String, to: String)
@@ -118,7 +118,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         repositoryURL = try container.decodeIfPresent(String.self, forKey: .repositoryURL)
-        versionRules = try container.decodeIfPresent(VersionRules.self, forKey: .requirement)
+        versionRequirement = try container.decodeIfPresent(VersionRequirement.self, forKey: .requirement)
 
         try super.init(from: decoder)
     }
@@ -134,8 +134,8 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
         if let repositoryURL = repositoryURL {
             dictionary["repositoryURL"] = .string(.init(repositoryURL))
         }
-        if let versionRules = versionRules {
-            dictionary["requirement"] = PlistValue.dictionary(versionRules.plistValues())
+        if let versionRequirement = versionRequirement {
+            dictionary["requirement"] = PlistValue.dictionary(versionRequirement.plistValues())
         }
         return (key: CommentedString(reference, comment: "XCRemoteSwiftPackageReference \"\(name ?? "")\""),
                 value: .dictionary(dictionary))
@@ -146,7 +146,7 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
     @objc public override func isEqual(to object: Any?) -> Bool {
         guard let rhs = object as? XCRemoteSwiftPackageReference else { return false }
         if repositoryURL != rhs.repositoryURL { return false }
-        if versionRules != rhs.versionRules { return false }
+        if versionRequirement != rhs.versionRequirement { return false }
         return super.isEqual(to: rhs)
     }
 }

--- a/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
+++ b/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift
@@ -89,42 +89,23 @@ public class XCRemoteSwiftPackageReference: PBXContainerItem, PlistSerializable 
                 ]
             }
         }
-
-        public static func == (lhs: VersionRules, rhs: VersionRules) -> Bool {
-            switch (lhs, rhs) {
-            case let (.revision(lhsRevision), .revision(rhsRevision)):
-                return lhsRevision == rhsRevision
-            case let (.branch(lhsBranch), .branch(rhsBranch)):
-                return lhsBranch == rhsBranch
-            case let (.exact(lhsVersion), .exact(rhsVersion)):
-                return lhsVersion == rhsVersion
-            case let (.range(lhsFrom, lhsTo), .range(rhsFrom, rhsTo)):
-                return lhsFrom == rhsFrom && lhsTo == rhsTo
-            case let (.upToNextMinorVersion(lhsVersion), .upToNextMinorVersion(rhsVersion)):
-                return lhsVersion == rhsVersion
-            case let (.upToNextMajorVersion(lhsVersion), .upToNextMajorVersion(rhsVersion)):
-                return lhsVersion == rhsVersion
-            default:
-                return false
-            }
-        }
     }
 
     /// Repository url.
     public var repositoryURL: String?
 
     /// Version rules.
-    public var versionRules: VersionRules?
+    public var versionRequirement: VersionRequirement?
 
     /// Initializes the remote swift package reference with its attributes.
     ///
     /// - Parameters:
     ///   - repositoryURL: Package repository url.
-    ///   - versionRules: Package version rules.
+    ///   - versionRequirement: Package version rules.
     public init(repositoryURL: String,
-         versionRules: VersionRules? = nil) {
+         versionRequirement: VersionRequirement? = nil) {
         self.repositoryURL = repositoryURL
-        self.versionRules = versionRules
+        self.versionRequirement = versionRequirement
         super.init()
     }
 

--- a/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
+++ b/Tests/xcodeprojTests/Objects/SwiftPackage/XCRemoteSwiftPackageReferenceTests.swift
@@ -21,12 +21,12 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         // Then
         XCTAssertEqual(got.reference.value, "ref")
         XCTAssertEqual(got.repositoryURL, "url")
-        XCTAssertEqual(got.versionRules, XCRemoteSwiftPackageReference.VersionRules.revision("abc"))
+        XCTAssertEqual(got.versionRequirement, XCRemoteSwiftPackageReference.VersionRequirement.revision("abc"))
     }
 
-    func test_versionRules_returnsTheRightPlistValues_when_revision() throws {
+    func test_versionRequirement_returnsTheRightPlistValues_when_revision() throws {
         // When
-        let subject = XCRemoteSwiftPackageReference.VersionRules.revision("sha")
+        let subject = XCRemoteSwiftPackageReference.VersionRequirement.revision("sha")
 
         // Given
         let got = subject.plistValues()
@@ -38,9 +38,9 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         ])
     }
 
-    func test_versionRules_returnsTheRightPlistValues_when_branch() throws {
+    func test_versionRequirement_returnsTheRightPlistValues_when_branch() throws {
         // When
-        let subject = XCRemoteSwiftPackageReference.VersionRules.branch("master")
+        let subject = XCRemoteSwiftPackageReference.VersionRequirement.branch("master")
 
         // Given
         let got = subject.plistValues()
@@ -52,9 +52,9 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         ])
     }
 
-    func test_versionRules_returnsTheRightPlistValues_when_exact() throws {
+    func test_versionRequirement_returnsTheRightPlistValues_when_exact() throws {
         // When
-        let subject = XCRemoteSwiftPackageReference.VersionRules.exact("3.2.1")
+        let subject = XCRemoteSwiftPackageReference.VersionRequirement.exact("3.2.1")
 
         // Given
         let got = subject.plistValues()
@@ -66,9 +66,9 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         ])
     }
 
-    func test_versionRules_returnsTheRightPlistValues_when_upToNextMajorVersion() throws {
+    func test_versionRequirement_returnsTheRightPlistValues_when_upToNextMajorVersion() throws {
         // When
-        let subject = XCRemoteSwiftPackageReference.VersionRules.upToNextMajorVersion("3.2.1")
+        let subject = XCRemoteSwiftPackageReference.VersionRequirement.upToNextMajorVersion("3.2.1")
 
         // Given
         let got = subject.plistValues()
@@ -80,9 +80,9 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         ])
     }
 
-    func test_versionRules_returnsTheRightPlistValues_when_range() throws {
+    func test_versionRequirement_returnsTheRightPlistValues_when_range() throws {
         // When
-        let subject = XCRemoteSwiftPackageReference.VersionRules.range(from: "3.2.1", to: "4.0.0")
+        let subject = XCRemoteSwiftPackageReference.VersionRequirement.range(from: "3.2.1", to: "4.0.0")
 
         // Given
         let got = subject.plistValues()
@@ -95,9 +95,9 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         ])
     }
 
-    func test_versionRules_returnsTheRightPlistValues_when_upToNextMinorVersion() throws {
+    func test_versionRequirement_returnsTheRightPlistValues_when_upToNextMinorVersion() throws {
         // When
-        let subject = XCRemoteSwiftPackageReference.VersionRules.upToNextMinorVersion("3.2.1")
+        let subject = XCRemoteSwiftPackageReference.VersionRequirement.upToNextMinorVersion("3.2.1")
 
         // Given
         let got = subject.plistValues()
@@ -113,7 +113,7 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
         // When
         let proj = PBXProj()
         let subject = XCRemoteSwiftPackageReference(repositoryURL: "repository",
-                                                    versionRules: .exact("1.2.3"))
+                                                    versionRequirement: .exact("1.2.3"))
 
         // Given
         let got = try subject.plistKeyAndValue(proj: proj, reference: "ref")
@@ -132,9 +132,9 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
     func test_equal() {
         // When
         let first = XCRemoteSwiftPackageReference(repositoryURL: "repository",
-                                                  versionRules: .exact("1.2.3"))
+                                                  versionRequirement: .exact("1.2.3"))
         let second = XCRemoteSwiftPackageReference(repositoryURL: "repository",
-                                                   versionRules: .exact("1.2.3"))
+                                                   versionRequirement: .exact("1.2.3"))
 
         // Then
         XCTAssertEqual(first, second)
@@ -142,7 +142,7 @@ final class XCRemoteSwiftPackageReferenceTests: XCTestCase {
 
     func test_name() {
         // When
-        let subject = XCRemoteSwiftPackageReference(repositoryURL: "https://github.com/tuist/xcodeproj", versionRules: nil)
+        let subject = XCRemoteSwiftPackageReference(repositoryURL: "https://github.com/tuist/xcodeproj", versionRequirement: nil)
 
         // Then
         XCTAssertEqual(subject.name, "xcodeproj")


### PR DESCRIPTION
Renames `VersionRules` to `VersionRequirement` to match the pbxobject name