### PR TITLE
Fix deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Relative path is wrong when referencing file outside of project folder https://github.com/tuist/xcodeproj/issues/423 by @damirdavletov
 - [crash] Fatal error: Duplicate values for key https://github.com/tuist/xcodeproj/issues/426 by @toshi0383
 - Change PBXContainerItemProxy.remoteGlobalID attribute to support object references https://github.com/tuist/xcodeproj/pull/445 by @yonaskolb
-
+- Dead lock in the `PBXObjects.delete` method https://github.com/tuist/xcodeproj/pull/449 by @pepibumur
 ## 6.7.0
 
 ### Changed

--- a/Sources/xcodeproj/Objects/Project/PBXObjects.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXObjects.swift
@@ -225,6 +225,7 @@ class PBXObjects: Equatable {
     // swiftlint:disable:next function_body_length Note: SwiftLint doesn't disable if @discardable and the function are on different lines.
     @discardableResult func delete(reference: PBXObjectReference) -> PBXObject? {
         lock.lock()
+        defer { lock.unlock() }
         if let index = buildFiles.index(forKey: reference) {
             return _buildFiles.remove(at: index).value
         } else if let index = aggregateTargets.index(forKey: reference) {
@@ -274,7 +275,6 @@ class PBXObjects: Equatable {
         } else if let index = swiftPackageProductDependencies.index(forKey: reference) {
             return _swiftPackageProductDependencies.remove(at: index).value
         }
-        lock.unlock()
         return nil
     }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/446

### Short description 📝
The `delete` from `PBXObjects`, does not use the lock properly and as a consequence, we end up with a dead lock.

### Solution 📦
Add a defer block to unlock the lock.