### PR TITLE
Add customLaunchCommand attribute to the launch action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - **Breaking** Added remote project support to PBXContainerItemProxy by @damirdavletov
 - **Breaking** Add support for `RemoteRunnable` https://github.com/tuist/xcodeproj/pull/400 by @pepibumur.
 - Support for Swift PM Packages https://github.com/tuist/xcodeproj/pull/439 https://github.com/tuist/xcodeproj/pull/444 by @pepibumur @yonaskolb.
+- `LaunchAction.customLaunchCommand` attribute https://github.com/tuist/xcodeproj/pull/451 by @pepibumur.
 
 ### Fixed
 

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0830"
-   version = "1.7">
+   version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -77,18 +77,6 @@
             </ActionContent>
          </ExecutionAction>
       </PostActions>
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "23766C251EAA3484007A9026"
-               BuildableName = "iOSTests.xctest"
-               BlueprintName = "iOSTests"
-               ReferencedContainer = "container:Project.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -111,17 +99,28 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "23766C251EAA3484007A9026"
+               BuildableName = "iOSTests.xctest"
+               BlueprintName = "iOSTests"
+               ReferencedContainer = "container:Project.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "0"
+      launchStyle = "2"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      customLaunchCommand = "custom command"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <PreActions>
@@ -183,8 +182,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
       <LocationScenarioReference
          identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
          referenceType = "1">

--- a/Sources/xcodeproj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/xcodeproj/Scheme/XCScheme+LaunchAction.swift
@@ -8,6 +8,7 @@ extension XCScheme {
         public enum Style: String {
             case auto = "0"
             case wait = "1"
+            case custom = "2"
         }
 
         public enum GPUFrameCaptureMode: String {
@@ -61,6 +62,8 @@ extension XCScheme {
         public var language: String?
         public var region: String?
         public var launchAutomaticallySubstyle: String?
+        // To enable the option in Xcode: defaults write com.apple.dt.Xcode IDEDebuggerFeatureSetting 12
+        public var customLaunchCommand: String?
 
         // MARK: - Init
 
@@ -93,7 +96,8 @@ extension XCScheme {
                     environmentVariables: [EnvironmentVariable]? = nil,
                     language: String? = nil,
                     region: String? = nil,
-                    launchAutomaticallySubstyle: String? = nil) {
+                    launchAutomaticallySubstyle: String? = nil,
+                    customLaunchCommand: String? = nil) {
             self.runnable = runnable
             self.macroExpansion = macroExpansion
             self.buildConfiguration = buildConfiguration
@@ -122,6 +126,7 @@ extension XCScheme {
             self.language = language
             self.region = region
             self.launchAutomaticallySubstyle = launchAutomaticallySubstyle
+            self.customLaunchCommand = customLaunchCommand
             super.init(preActions, postActions)
         }
 
@@ -187,6 +192,8 @@ extension XCScheme {
             language = element.attributes["language"]
             region = element.attributes["region"]
             launchAutomaticallySubstyle = element.attributes["launchAutomaticallySubstyle"]
+            customLaunchCommand = element.attributes["customLaunchCommand"]
+            
             try super.init(element: element)
         }
 
@@ -275,6 +282,10 @@ extension XCScheme {
             if let launchAutomaticallySubstyle = launchAutomaticallySubstyle {
                 element.attributes["launchAutomaticallySubstyle"] = launchAutomaticallySubstyle
             }
+            
+            if let customLaunchCommand = customLaunchCommand {
+                element.attributes["customLaunchCommand"] = customLaunchCommand
+            }
 
             let additionalOptionsElement = element.addChild(AEXMLElement(name: "AdditionalOptions"))
             additionalOptions.forEach { additionalOption in
@@ -315,7 +326,8 @@ extension XCScheme {
                 environmentVariables == rhs.environmentVariables &&
                 language == rhs.language &&
                 region == rhs.region &&
-                launchAutomaticallySubstyle == rhs.launchAutomaticallySubstyle
+                launchAutomaticallySubstyle == rhs.launchAutomaticallySubstyle &&
+                customLaunchCommand == rhs.customLaunchCommand
         }
     }
 }

--- a/Tests/xcodeprojTests/Scheme/XCSchemeTests.swift
+++ b/Tests/xcodeprojTests/Scheme/XCSchemeTests.swift
@@ -4,13 +4,9 @@ import XCTest
 @testable import XcodeProj
 
 final class XCSchemeIntegrationTests: XCTestCase {
-    func test_read_iosScheme() {
-        let subject = try? XCScheme(path: iosSchemePath)
-
-        XCTAssertNotNil(subject)
-        if let subject = subject {
-            assert(scheme: subject)
-        }
+    func test_read_iosScheme() throws {
+        let subject = try XCScheme(path: iosSchemePath)
+        assert(scheme: subject)
     }
 
     func test_write_iosScheme() {
@@ -76,7 +72,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
     // MARK: - Private
 
     private func assert(scheme: XCScheme) {
-        XCTAssertEqual(scheme.version, "1.7")
+        XCTAssertEqual(scheme.version, "2.0")
         XCTAssertEqual(scheme.lastUpgradeVersion, "0830")
         // Build action
         XCTAssertTrue(scheme.buildAction?.parallelizeBuild == true)
@@ -182,7 +178,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.buildConfiguration, "Debug")
         XCTAssertEqual(scheme.launchAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(scheme.launchAction?.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
-        XCTAssertEqual(scheme.launchAction?.launchStyle, .auto)
+        XCTAssertEqual(scheme.launchAction?.launchStyle, .custom)
         XCTAssertEqual(scheme.launchAction?.useCustomWorkingDirectory, false)
         XCTAssertEqual(scheme.launchAction?.ignoresPersistentStateOnLaunch, false)
         XCTAssertEqual(scheme.launchAction?.debugDocumentVersioning, true)


### PR DESCRIPTION
### Short description 📝
As described [here](https://twitter.com/wlisac/status/1136893256543789056) the new version of Xcode has a new feature that is disabled by default, using a custom command to launch a commandn line tool.

### Solution 📦
Add the `customLaunchCommand` attribute to `LaunchAction`.

### Implementation 👩‍💻👨‍💻
- [x] Add the `custom` case to the `LaunchAction.Style` enum.
- [x] Add the `customLaunchCommand` attribute to `XCScheme.LaunchAction`.
- [x] Decode and encode the new attribute.
- [x] Update the `==` method to include the new attribute.
