### PR TITLE
Add variant group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Adding additional `lastKnownFileType`s https://github.com/tuist/xcodeproj/pull/458 by @kwridan
+- Adding possibility to create variant group for referencing localized resources https://github.com/tuist/xcodeproj/pull/462 by @timbaev
 
 ## 0.7.0
 

--- a/Sources/xcodeproj/Objects/Files/PBXGroup.swift
+++ b/Sources/xcodeproj/Objects/Files/PBXGroup.swift
@@ -140,6 +140,25 @@ public extension PBXGroup {
         }
     }
 
+    /// Creates a variant group with the given name and returns it.
+    ///
+    /// - Parameters:
+    ///   - groupName: group name.
+    /// - Returns: created groups.
+    @discardableResult
+    func addVariantGroup(named groupName: String) throws -> [PBXVariantGroup] {
+        let objects = try self.objects()
+
+        return groupName.components(separatedBy: "/").reduce(into: [PBXVariantGroup]()) { groups, name in
+            let group = groups.last ?? self
+            let newGroup = PBXVariantGroup(children: [], sourceTree: .group, name: name)
+            newGroup.parent = self
+            group.childrenReferences.append(newGroup.reference)
+            objects.add(object: newGroup)
+            groups.append(newGroup)
+        }
+    }
+
     /// Adds file at the give path to the project or returns existing file and its reference.
     ///
     /// - Parameters:

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -52,7 +52,7 @@ final class PBXGroupTests: XCTestCase {
         XCTAssertNotNil(childGroup?.parent)
     }
 
-    func test_addVariantGroup_assignParent() {
+    func test_addVariantGroup() {
         let project = PBXProj(
             rootObject: nil,
             objectVersion: 0,
@@ -67,9 +67,25 @@ final class PBXGroupTests: XCTestCase {
 
         project.add(object: group)
 
-        let childVariantGroup = try? group.addVariantGroup(named: "child_variant_group").first
+        let expectedGroupNames = ["child", "variant", "group"]
 
-        XCTAssertNotNil(childVariantGroup?.parent)
+        guard let childVariantGroups = try? group.addVariantGroup(named: expectedGroupNames.joined(separator: "/")) else {
+            return XCTFail("Failed to create variant groups")
+        }
+
+        XCTAssertEqual(childVariantGroups.count, expectedGroupNames.count)
+
+        childVariantGroups.enumerated().forEach { index, variantGroup in
+            let parentGroup = (index == 0) ? group : childVariantGroups[index - 1]
+
+            XCTAssertTrue(variantGroup.children.isEmpty)
+            XCTAssertEqual(variantGroup.sourceTree, PBXSourceTree.group)
+            XCTAssertEqual(variantGroup.name, expectedGroupNames[index])
+
+            XCTAssertEqual(variantGroup.parent, group)
+            XCTAssertTrue(parentGroup.children.contains(variantGroup))
+            XCTAssertNotNil(group.group(named: expectedGroupNames[index]))
+        }
     }
 
     func test_createGroupWithFile_assignParent() {

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -78,14 +78,21 @@ final class PBXGroupTests: XCTestCase {
         childVariantGroups.enumerated().forEach { index, variantGroup in
             let parentGroup = (index == 0) ? group : childVariantGroups[index - 1]
 
-            XCTAssertTrue(variantGroup.children.isEmpty)
+            if index == childVariantGroups.count - 1 {
+                XCTAssertTrue(variantGroup.children.isEmpty)
+            } else {
+                XCTAssertEqual(variantGroup.children.count, 1)
+                XCTAssertEqual(variantGroup.children.first?.name, expectedGroupNames[index + 1])
+            }
+
             XCTAssertEqual(variantGroup.sourceTree, PBXSourceTree.group)
             XCTAssertEqual(variantGroup.name, expectedGroupNames[index])
 
             XCTAssertEqual(variantGroup.parent, group)
             XCTAssertTrue(parentGroup.children.contains(variantGroup))
-            XCTAssertNotNil(group.group(named: expectedGroupNames[index]))
         }
+
+        XCTAssertEqual(group.children.first?.name, expectedGroupNames.first)
     }
 
     func test_createGroupWithFile_assignParent() {

--- a/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/xcodeprojTests/Objects/Files/PBXGroupTests.swift
@@ -52,6 +52,26 @@ final class PBXGroupTests: XCTestCase {
         XCTAssertNotNil(childGroup?.parent)
     }
 
+    func test_addVariantGroup_assignParent() {
+        let project = PBXProj(
+            rootObject: nil,
+            objectVersion: 0,
+            archiveVersion: 0,
+            classes: [:],
+            objects: []
+        )
+
+        let group = PBXGroup(children: [],
+                             sourceTree: .group,
+                             name: "group")
+
+        project.add(object: group)
+
+        let childVariantGroup = try? group.addVariantGroup(named: "child_variant_group").first
+
+        XCTAssertNotNil(childVariantGroup?.parent)
+    }
+
     func test_createGroupWithFile_assignParent() {
         let fileref = PBXFileReference(sourceTree: .group,
                                        fileEncoding: 1,


### PR DESCRIPTION
### Short description 📝
> Add possibility to create variant group for referencing localized resources.

### Solution 📦
> Adding method to create variant group. It's similar with method `addGroup(named: String, options: GroupAddingOptions) throws -> [PBXGroup]`. But for variant groups not needed `GroupAddingOptions`, it's create always without folder. 