### PR TITLE
Package duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Adding additional `lastKnownFileType`s https://github.com/tuist/xcodeproj/pull/458 by @kwridan
 - Adding possibility to create variant group for referencing localized resources https://github.com/tuist/xcodeproj/pull/462 by @timbaev
 
+### Fixed
+
+- Duplication of packages https://github.com/tuist/XcodeProj/pull/470 by @fortmarek
+
 ## 0.7.0
 
 ### Changed

--- a/Sources/xcodeproj/Errors/Errors.swift
+++ b/Sources/xcodeproj/Errors/Errors.swift
@@ -165,6 +165,8 @@ enum PBXProjError: Error, CustomStringConvertible, Equatable {
     case frameworksBuildPhaseNotFound(targetName: String)
     case sourcesBuildPhaseNotFound(targetName: String)
     case pathIsAbsolute(Path)
+    case multipleLocalPackages(productName: String)
+    case multipleRemotePackages(productName: String)
     var description: String {
         switch self {
         case let .notFound(path):
@@ -179,6 +181,10 @@ enum PBXProjError: Error, CustomStringConvertible, Equatable {
             return "Could not find sources build phase for target \(targetName)"
         case let .pathIsAbsolute(path):
             return "Path must be relative, but path \(path.string) is absolute"
+        case let .multipleLocalPackages(productName: productName):
+            return "Found multiple top-level packages named \(productName)"
+        case let .multipleRemotePackages(productName: productName):
+            return "Can not resolve dependency \(productName) - conflicting version requirements"
         }
     }
 }

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -181,11 +181,17 @@ public final class PBXProject: PBXObject {
         let objects = try self.objects()
         
         guard let target = targets.first(where: { $0.name == targetName}) else { throw PBXProjError.targetNotFound(targetName: targetName) }
-
+        
         // Reference
-        let reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRequirement: versionRequirement)
-        objects.add(object: reference)
-        packages.append(reference)
+        let reference: XCRemoteSwiftPackageReference
+        if let package = packages.first(where: { $0.repositoryURL == repositoryURL }) {
+            guard package.versionRequirement == versionRequirement else { fatalError() }
+            reference = package
+        } else {
+            reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRequirement: versionRequirement)
+            objects.add(object: reference)
+            packages.append(reference)
+        }
 
         // Product
         let productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -183,29 +183,15 @@ public final class PBXProject: PBXObject {
         guard let target = targets.first(where: { $0.name == targetName}) else { throw PBXProjError.targetNotFound(targetName: targetName) }
         
         // Reference
-        let reference: XCRemoteSwiftPackageReference
-        if let package = packages.first(where: { $0.repositoryURL == repositoryURL }) {
-            guard package.versionRequirement == versionRequirement else {
-                throw PBXProjError.multipleRemotePackages(productName: productName)
-            }
-            reference = package
-        } else {
-            reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRequirement: versionRequirement)
-            objects.add(object: reference)
-            packages.append(reference)
-        }
+        let reference = try addSwiftPackageReference(repositoryURL: repositoryURL,
+                                                     productName: productName,
+                                                     versionRequirement: versionRequirement)
 
         // Product
-        let productDependency: XCSwiftPackageProductDependency
-        // Avoid duplication
-        if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.package == reference })?.value {
-            productDependency = product
-        } else {
-            productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
-            objects.add(object: productDependency)
-        }
-        target.packageProductDependencies.append(productDependency)
-
+        let productDependency = try addSwiftPackageProduct(reference: reference,
+                                                           productName: productName,
+                                                           target: target)
+        
         // Build file
         let buildFile = PBXBuildFile(product: productDependency)
         objects.add(object: buildFile)
@@ -235,19 +221,10 @@ public final class PBXProject: PBXObject {
         guard let target = targets.first(where: { $0.name == targetName}) else { throw PBXProjError.targetNotFound(targetName: targetName) }
         
         // Product
-        let productDependency: XCSwiftPackageProductDependency
-        // Avoid duplication
-        if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.productName == productName }) {
-            guard objects.fileReferences.first(where: { $0.value.name == productName })?.value.path == path.string else {
-                throw PBXProjError.multipleLocalPackages(productName: productName)
-            }
-            productDependency = product.value
-        } else {
-            productDependency = XCSwiftPackageProductDependency(productName: productName)
-            objects.add(object: productDependency)
-        }
-        target.packageProductDependencies.append(productDependency)
-
+        let productDependency = try addLocalSwiftPackageProduct(path: path,
+                                                                productName: productName,
+                                                                target: target)
+        
         // Build file
         let buildFile = PBXBuildFile(product: productDependency)
         objects.add(object: buildFile)
@@ -392,6 +369,70 @@ public final class PBXProject: PBXObject {
         self.targetAttributeReferences = targetAttributeReferences
 
         try super.init(from: decoder)
+    }
+}
+
+// MARK: - Helpers
+
+extension PBXProject {
+    /// Adds reference for remote Swift package
+    private func addSwiftPackageReference(repositoryURL: String,
+                                          productName: String,
+                                          versionRequirement: XCRemoteSwiftPackageReference.VersionRequirement) throws -> XCRemoteSwiftPackageReference {
+        let reference: XCRemoteSwiftPackageReference
+        if let package = packages.first(where: { $0.repositoryURL == repositoryURL }) {
+            guard package.versionRequirement == versionRequirement else {
+                throw PBXProjError.multipleRemotePackages(productName: productName)
+            }
+            reference = package
+        } else {
+            reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRequirement: versionRequirement)
+            try self.objects().add(object: reference)
+            packages.append(reference)
+        }
+        
+        return reference
+    }
+    
+    /// Adds package product for remote Swift package
+    private func addSwiftPackageProduct(reference: XCRemoteSwiftPackageReference,
+                                        productName: String,
+                                        target: PBXTarget) throws -> XCSwiftPackageProductDependency {
+        let objects = try self.objects()
+        
+        let productDependency: XCSwiftPackageProductDependency
+        // Avoid duplication
+        if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.package == reference })?.value {
+            productDependency = product
+        } else {
+            productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
+            objects.add(object: productDependency)
+        }
+        target.packageProductDependencies.append(productDependency)
+        
+        return productDependency
+    }
+    
+    /// Adds package product for local Swift package
+    private func addLocalSwiftPackageProduct(path: Path,
+                                             productName: String,
+                                             target: PBXTarget) throws -> XCSwiftPackageProductDependency {
+        let objects = try self.objects()
+        
+        let productDependency: XCSwiftPackageProductDependency
+        // Avoid duplication
+        if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.productName == productName }) {
+            guard objects.fileReferences.first(where: { $0.value.name == productName })?.value.path == path.string else {
+                throw PBXProjError.multipleLocalPackages(productName: productName)
+            }
+            productDependency = product.value
+        } else {
+            productDependency = XCSwiftPackageProductDependency(productName: productName)
+            objects.add(object: productDependency)
+        }
+        target.packageProductDependencies.append(productDependency)
+        
+        return productDependency
     }
 }
 

--- a/Sources/xcodeproj/Objects/Project/PBXProject.swift
+++ b/Sources/xcodeproj/Objects/Project/PBXProject.swift
@@ -194,8 +194,13 @@ public final class PBXProject: PBXObject {
         }
 
         // Product
-        let productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
-        objects.add(object: productDependency)
+        let productDependency: XCSwiftPackageProductDependency
+        if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.package == reference }) {
+            productDependency = product.value
+        } else {
+            productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
+            objects.add(object: productDependency)
+        }
         target.packageProductDependencies.append(productDependency)
 
         // Build file

--- a/Tests/xcodeprojTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/xcodeprojTests/Objects/Project/PBXProjectTests.swift
@@ -32,7 +32,7 @@ final class PBXProjectTests: XCTestCase {
     }
     
     
-    func test_addLocalSwiftPackage() throws {
+    func test_SwiftPackage() throws {
         // Given
         let objects = PBXObjects(objects: [])
 
@@ -196,5 +196,66 @@ final class PBXProjectTests: XCTestCase {
         
         // Then
         XCTAssertEqual(packageProduct, secondPackageProduct)
+        XCTAssertEqual(project.packages.count, 1)
+        XCTAssertEqual(target.packageProductDependencies, secondTarget.packageProductDependencies)
+        XCTAssertNotEqual(buildPhase.files?.first?.hashValue, secondBuildPhase.files?.first?.hashValue)
+        XCTAssertEqual(objects.swiftPackageProductDependencies.count, 1)
+    }
+    
+    func test_addLocalSwiftPackage_duplication() {
+        func test_addSwiftPackage_duplication() throws {
+            // Given
+            let objects = PBXObjects(objects: [])
+            
+            let buildPhase = PBXFrameworksBuildPhase(
+                files: [],
+                inputFileListPaths: nil,
+                outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+                runOnlyForDeploymentPostprocessing: true
+            )
+            let target = PBXNativeTarget(name: "Target",
+                                         buildConfigurationList: nil,
+                                         buildPhases: [buildPhase])
+            objects.add(object: target)
+            
+            let secondBuildPhase = PBXFrameworksBuildPhase(
+                files: [],
+                inputFileListPaths: nil,
+                outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+                runOnlyForDeploymentPostprocessing: true
+            )
+            let secondTarget = PBXNativeTarget(name: "SecondTarget",
+                                               buildConfigurationList: nil,
+                                               buildPhases: [secondBuildPhase])
+            objects.add(object: secondTarget)
+            
+            let configurationList = XCConfigurationList.fixture()
+            let mainGroup = PBXGroup.fixture()
+            objects.add(object: configurationList)
+            objects.add(object: mainGroup)
+            
+            let project = PBXProject(name: "Project",
+                                     buildConfigurationList: configurationList,
+                                     compatibilityVersion: "0",
+                                     mainGroup: mainGroup,
+                                     targets: [target, secondTarget])
+            
+            objects.add(object: project)
+            
+            // When
+            let packageProduct = try project.addLocalSwiftPackage(path: "Product",
+                                                                  productName: "Product",
+                                                                  targetName: target.name)
+            // When
+            let secondPackageProduct = try project.addLocalSwiftPackage(path: "Product",
+                                                                        productName: "Product",
+                                                                        targetName: secondTarget.name)
+            
+            // Then
+            XCTAssertEqual(packageProduct, secondPackageProduct)
+            XCTAssertEqual(target.packageProductDependencies, secondTarget.packageProductDependencies)
+            XCTAssertNotEqual(buildPhase.files?.first?.hashValue, secondBuildPhase.files?.first?.hashValue)
+            XCTAssertEqual(objects.swiftPackageProductDependencies.count, 1)
+        }
     }
 }


### PR DESCRIPTION
Resolving duplication of Swift package needed for `tuist` ad https://github.com/tuist/tuist/pull/394

### Short description 📝
Right now, if you added a package (remote or local) and then wanted to add the same one to another target, it'd add the package again, thus creating unnecessary duplication.

### Solution 📦
This PR finds if the package is already in the `.pbxproj` and if so, does not create new one, just adds new `PBXBuildFile` and `PBXFileReference`.
It also throws new errors when the package does not have the same version requirements as the one already in the project and for local package if you are adding a package that has the same `productName`, but different `path` (both of these would result in an error when opening the project in Xcode, so I figured, it'd be good practice to throw error as soon as possible)

### Implementation 👩‍💻👨‍💻
- [x] Add safe-guards against duplication
- [x] Tests
