### PR TITLE
Avoid warnings on Swift 5.1

### DIFF
--- a/Sources/xcodeproj/Extensions/String+md5.swift
+++ b/Sources/xcodeproj/Extensions/String+md5.swift
@@ -25,8 +25,10 @@ import Foundation
 extension String {
     var md5: String {
         if let data = data(using: .utf8, allowLossyConversion: true) {
-            let message = data.withUnsafeBytes { bytes -> [UInt8] in
-                Array(UnsafeBufferPointer(start: bytes, count: data.count))
+            let message = data.withUnsafeBytes { bufferPointer in
+                Array(UnsafeBufferPointer(
+                    start: bufferPointer.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    count: data.count))
             }
 
             let MD5Calculator = MD5(message)
@@ -215,7 +217,7 @@ class MD5: HashProtocol {
 
         for chunk in BytesSequence(chunkSize: chunkSizeBytes, data: tmpMessage) {
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15
-            var M = toUInt32Array(chunk)
+            let M = toUInt32Array(chunk)
             assert(M.count == 16, "Invalid array")
 
             // Initialize hash value for this chunk:

--- a/Sources/xcodeproj/Utils/PBXBatchUpdater.swift
+++ b/Sources/xcodeproj/Utils/PBXBatchUpdater.swift
@@ -119,7 +119,7 @@ public final class PBXBatchUpdater {
         if let fileParentGroup = try lazilyInstantiateGroups()[groupPath] {
             return (fileParentGroup, groupPath)
         }
-        var components = groupPath.components
+        let components = groupPath.components
         let componentsCount = components.count - 1
         for componentIndex in (0 ... componentsCount).reversed() {
             let currentPathComponents = components[0 ... componentIndex]

--- a/Sources/xcodeproj/Utils/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/Utils/ReferenceGenerator.swift
@@ -324,7 +324,7 @@ extension ReferenceGenerator {
             }
         case .xcode:
             let reference = "\(acronym)_\(typeNameAndIdentifiers)_\(counter)".md5.uppercased()
-            return String(reference.substring(to: reference.index(reference.startIndex, offsetBy: 24)))
+            return String(reference[...reference.index(reference.startIndex, offsetBy: 24)])
         }
     }
 }


### PR DESCRIPTION
# Short description 📝

This project raises some warnings on Xcode 11 toolchain.

```console
$ swift build
 XcodeProj (master) ~ swift build
'XcodeProj' /Users/giginet/.ghq/github.com/tuist/XcodeProj: warning: the target name XcodeProj has different case on the filesystem and the Package.swift manifest file
'XcodeProj' /Users/giginet/.ghq/github.com/tuist/XcodeProj: warning: the target name XcodeProjTests has different case on the filesystem and the Package.swift manifest file
/Users/giginet/.ghq/github.com/tuist/XcodeProj/Sources/XcodeProj/Utils/PBXBatchUpdater.swift:122:13: warning: variable 'components' was never mutated; consider changing to 'let' constant
        var components = groupPath.components
        ~~~ ^
        let
/Users/giginet/.ghq/github.com/tuist/XcodeProj/Sources/XcodeProj/Utils/ReferenceGenerator.swift:327:37: warning: 'substring(to:)' is deprecated: Please use String slicing subscript with a 'partial range upto' operator.
            return String(reference.substring(to: reference.index(reference.startIndex, offsetBy: 24)))
                                    ^
/Users/giginet/.ghq/github.com/tuist/XcodeProj/Sources/XcodeProj/Extensions/String+md5.swift:28:32: warning: 'withUnsafeBytes' is deprecated: use `withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead
            let message = data.withUnsafeBytes { bytes -> [UInt8] in
                               ^
/Users/giginet/.ghq/github.com/tuist/XcodeProj/Sources/XcodeProj/Extensions/String+md5.swift:218:17: warning: variable 'M' was never mutated; consider changing to 'let' constant
            var M = toUInt32Array(chunk)
            ~~~ ^
            let
[4/4] Merging module XcodeProj

```

<img width="487" alt="Screen Shot 2019-09-16 at 23 35 44" src="https://user-images.githubusercontent.com/147051/64967064-dfc1c900-d8da-11e9-8167-6e0091cad369.png">

### Solution 📦

This PR make changes to avoid some warnings.

### Implementation 👩‍💻👨‍💻

- Use `let` instead of `var`.
- `String.substring(to:)` is deprecated. Use Swift.Range instead
- `Data.withUnsafeBytes` is deprecated. Use instead another overload.