### PR TITLE
Fix the reference length

### DIFF
--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -324,7 +324,7 @@ extension ReferenceGenerator {
             }
         case .xcode:
             let reference = "\(acronym)_\(typeNameAndIdentifiers)_\(counter)".md5.uppercased()
-            return String(reference[...reference.index(reference.startIndex, offsetBy: 24)])
+            return String(reference[...reference.index(reference.startIndex, offsetBy: 23)])
         }
     }
 }


### PR DESCRIPTION
### Short description 📝
[This commit](https://github.com/tuist/XcodeProj/commit/3b909ba75da84e92c9b747540f8b9f4f8715ae09) introduced a regression that caused the tests to fail because the generated object reference is 25 characters long instead of 24.

This PR fixes it.