### PR TITLE
Add remote Swift packages to the Frameworks build phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+## Fixed
+
+- Add remote Swift packages to the Frameworks build phase https://github.com/tuist/XcodeProj/pull/487 by @kwridan
+
 ## 7.1.0
 
 ### Added

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -197,8 +197,8 @@ public final class PBXProject: PBXObject {
         objects.add(object: buildFile)
 
         // Link the product
-        guard let sourcesBuildPhase = try target.sourcesBuildPhase() else { throw PBXProjError.frameworksBuildPhaseNotFound(targetName: targetName) }
-        sourcesBuildPhase.files?.append(buildFile)
+        guard let frameworksBuildPhase = try target.frameworksBuildPhase() else { throw PBXProjError.frameworksBuildPhaseNotFound(targetName: targetName) }
+        frameworksBuildPhase.files?.append(buildFile)
 
         return reference
     }

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -107,7 +107,7 @@ final class PBXProjectTests: XCTestCase {
         // Given
         let objects = PBXObjects(objects: [])
         
-        let buildPhase = PBXSourcesBuildPhase(
+        let buildPhase = PBXFrameworksBuildPhase(
             files: [],
             inputFileListPaths: nil,
             outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
@@ -149,7 +149,7 @@ final class PBXProjectTests: XCTestCase {
         // Given
         let objects = PBXObjects(objects: [])
         
-        let buildPhase = PBXSourcesBuildPhase(
+        let buildPhase = PBXFrameworksBuildPhase(
             files: [],
             inputFileListPaths: nil,
             outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
@@ -160,7 +160,7 @@ final class PBXProjectTests: XCTestCase {
                                      buildPhases: [buildPhase])
         objects.add(object: target)
         
-        let secondBuildPhase = PBXSourcesBuildPhase(
+        let secondBuildPhase = PBXFrameworksBuildPhase(
             files: [],
             inputFileListPaths: nil,
             outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,


### PR DESCRIPTION
- There was a typo in one of the helper methods that adds remote Swift packages that led to products being added to the sources build phase rather than the frameworks build phase

<img width="687" alt="Screen Shot 2019-10-08 at 8 54 37 AM" src="https://user-images.githubusercontent.com/11914919/66377713-0dfe6a00-e9aa-11e9-8ae2-163a728e382b.png">

Test Plan:

- Update tuist/tuist to point to this branch of XcodeProj
- Run `tuist generate` within `fixtures/ios_app_with_remote_swift_package`
- Verify the remote packages do not appear within the sources build phase

