### PR TITLE
Fix Products group serialisation with temporary ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add remote Swift packages to the Frameworks build phase https://github.com/tuist/XcodeProj/pull/487 by @kwridan
 - System library added to a group has empty path https://github.com/tuist/XcodeProj/pull/488 by @damirdavletov
+- Fix Products group serialisation with temporary ids https://github.com/tuist/XcodeProj/pull/489 by @damirdavletov
 
 ## 7.1.0
 

--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -228,7 +228,7 @@ final class ReferenceGenerator: ReferenceGenerating {
         }
     }
 
-    /// Generates the reference for a reference proxy  object.
+    /// Generates the reference for a reference proxy object.
     ///
     /// - Parameters:
     ///   - referenceProxy: reference proxy instance.
@@ -248,13 +248,13 @@ final class ReferenceGenerator: ReferenceGenerating {
         }
     }
 
-    /// Generates the reference for a container item proxy  object.
+    /// Generates the reference for a container item proxy object.
     ///
     /// - Parameters:
     ///   - containerItemProxy: ontainer item proxy instance.
     ///   - identifiers: list of identifiers.
     private func generateContainerItemProxyReference(_ containerItemProxy: PBXContainerItemProxy,
-                                                      identifiers: [String]) throws  {
+                                                      identifiers: [String]) throws {
         var identifiers = identifiers
 
         if let remoteInfo = containerItemProxy.remoteInfo {

--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -234,7 +234,7 @@ final class ReferenceGenerator: ReferenceGenerating {
     ///   - referenceProxy: reference proxy instance.
     ///   - identifiers: list of identifiers.
     private func generateReferenceProxyReference(_ referenceProxy: PBXReferenceProxy,
-                                                    identifiers: [String]) throws {
+                                                 identifiers: [String]) throws {
         var identifiers = identifiers
 
         if let path = referenceProxy.path {
@@ -254,7 +254,7 @@ final class ReferenceGenerator: ReferenceGenerating {
     ///   - containerItemProxy: ontainer item proxy instance.
     ///   - identifiers: list of identifiers.
     private func generateContainerItemProxyReference(_ containerItemProxy: PBXContainerItemProxy,
-                                                      identifiers: [String]) throws {
+                                                     identifiers: [String]) throws {
         var identifiers = identifiers
 
         if let remoteInfo = containerItemProxy.remoteInfo {

--- a/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
+++ b/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import XCTest
+import PathKit
+@testable import XcodeProj
+
+class ReferenceGeneratorTests: XCTestCase {
+
+    func test_projectReferencingRemoteXcodeprojBundle_convertsReferencesToPermanent() throws {
+        let project = PBXProj(rootObject: nil, objectVersion: 0, archiveVersion: 0, classes: [:], objects: [])
+        let pbxProject = project.makeProject()
+        let remoteProjectFileReference = project.makeFileReference()
+        let containerItemProxy = project.makeContainerItemProxy(fileReference: remoteProjectFileReference)
+        let productReferenceProxy = project.makeReferenceProxy(containerItemProxy: containerItemProxy)
+        let productsGroup = project.makeProductsGroup(children: [productReferenceProxy])
+
+        pbxProject.projectReferences.append([ "ProductGroup" : productsGroup.reference ])
+
+        let referenceGenerator = ReferenceGenerator(outputSettings: PBXOutputSettings())
+        try referenceGenerator.generateReferences(proj: project)
+
+        XCTAssert(!productsGroup.reference.temporary)
+        XCTAssert(!containerItemProxy.reference.temporary)
+        XCTAssert(!productReferenceProxy.reference.temporary)
+        XCTAssert(!remoteProjectFileReference.reference.temporary)
+    }
+}
+
+private extension PBXProj {
+    func makeProject() -> PBXProject {
+        let mainGroup = PBXGroup(children: [],
+                                 sourceTree: .group,
+                                 name: "Main")
+
+        let project = PBXProject(name: "test",
+                                 buildConfigurationList: XCConfigurationList.fixture(),
+                                 compatibilityVersion: Xcode.Default.compatibilityVersion,
+                                 mainGroup: mainGroup)
+
+        self.add(object: mainGroup)
+        self.add(object: project)
+        self.rootObject = project
+
+        return project
+    }
+
+    func makeFileReference() -> PBXFileReference {
+        return try! self.rootObject!.mainGroup.addFile(at: Path("../Remote.xcodeproj"), sourceRoot: Path("/"), validatePresence: false)
+    }
+
+    func makeContainerItemProxy(fileReference: PBXFileReference) -> PBXContainerItemProxy {
+        let containerItemProxy = PBXContainerItemProxy(containerPortal: .fileReference(fileReference),
+                                                       remoteGlobalID: .string("remoteTargetGlobalIDString"),
+                                                       proxyType: .reference,
+                                                       remoteInfo: "RemoteTarget")
+
+        self.add(object: containerItemProxy)
+
+        return containerItemProxy
+    }
+
+    func makeReferenceProxy(containerItemProxy: PBXContainerItemProxy) -> PBXReferenceProxy {
+        let productReferenceProxy = PBXReferenceProxy(fileType: "wrapper.pb-project",
+                                                      path: "Remote.framework",
+                                                      remote: containerItemProxy,
+                                                      sourceTree: .buildProductsDir)
+        self.add(object: productReferenceProxy)
+        return productReferenceProxy
+    }
+
+    func makeProductsGroup(children: [PBXFileElement]) -> PBXGroup {
+        let productsGroup = PBXGroup(children: children,
+                                     sourceTree: .group,
+                                     name: "Products")
+        self.add(object: productsGroup)
+        return productsGroup
+    }
+}


### PR DESCRIPTION
### Short description 📝
When adding remote xcodeproj bundle reference to the project, remote product references are serialised with temporary ids.

### Solution 📦
Fix serialisation of **Products** group of the remote project references