### PR TITLE
Add test plans support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+### Added
+
+- Added support for Xcode 11 test plans https://github.com/tuist/XcodeProj/pull/491 by @maniramezan
+
 ## Fixed
 
 - Add remote Swift packages to the Frameworks build phase https://github.com/tuist/XcodeProj/pull/487 by @kwridan

--- a/Fixtures/iOS/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/Project.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		23766C261EAA3484007A9026 /* iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		23766C2A1EAA3484007A9026 /* iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTests.swift; sourceTree = "<group>"; };
 		23766C2C1EAA3484007A9026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		23C1E0AF23657FB500B8D1EF /* iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = iOS.xctestplan; sourceTree = "<group>"; };
 		3CD1EADC205763E400DAEECB /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		42AA1A1822AAF41000428760 /* MyLocalPackage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MyLocalPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -108,6 +109,7 @@
 		23766C091EAA3484007A9026 = {
 			isa = PBXGroup;
 			children = (
+				23C1E0AF23657FB500B8D1EF /* iOS.xctestplan */,
 				42AA1A1822AAF41000428760 /* MyLocalPackage */,
 				23766C141EAA3484007A9026 /* iOS */,
 				23766C291EAA3484007A9026 /* iOSTests */,

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -101,6 +101,12 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:iOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Fixtures/iOS/iOS.xctestplan
+++ b/Fixtures/iOS/iOS.xctestplan
@@ -1,0 +1,44 @@
+{
+  "configurations" : [
+    {
+      "id" : "B98CEFD8-D0A3-4BDD-BA5B-8DC671AA5291",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+
+      ]
+    },
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "MyLaunchArgument"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "key" : "ENV_VAR",
+        "value" : "RUN"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Project.xcodeproj",
+      "identifier" : "23766C111EAA3484007A9026",
+      "name" : "iOS"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Project.xcodeproj",
+        "identifier" : "23766C251EAA3484007A9026",
+        "name" : "iOSTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -15,6 +15,7 @@ extension XCScheme {
         // MARK: - Attributes
 
         public var testables: [TestableReference]
+        public var testPlans: [TestPlanReference]
         public var codeCoverageTargets: [BuildableReference]
         public var buildConfiguration: String
         public var selectedDebuggerIdentifier: String
@@ -41,6 +42,7 @@ extension XCScheme {
         public init(buildConfiguration: String,
                     macroExpansion: BuildableReference?,
                     testables: [TestableReference] = [],
+                    testPlans: [TestPlanReference] = [],
                     preActions: [ExecutionAction] = [],
                     postActions: [ExecutionAction] = [],
                     selectedDebuggerIdentifier: String = XCScheme.defaultDebugger,
@@ -64,6 +66,7 @@ extension XCScheme {
             self.buildConfiguration = buildConfiguration
             self.macroExpansion = macroExpansion
             self.testables = testables
+            self.testPlans = testPlans
             self.selectedDebuggerIdentifier = selectedDebuggerIdentifier
             self.selectedLauncherIdentifier = selectedLauncherIdentifier
             self.shouldUseLaunchSchemeArgsEnv = shouldUseLaunchSchemeArgsEnv
@@ -101,6 +104,9 @@ extension XCScheme {
             testables = try element["Testables"]["TestableReference"]
                 .all?
                 .map(TestableReference.init) ?? []
+            testPlans = try element["TestPlans"]["TestPlanReference"]
+                .all?
+                .map(TestPlanReference.init) ?? []
             codeCoverageTargets = try element["CodeCoverageTargets"]["BuildableReference"]
                 .all?
                 .map(BuildableReference.init) ?? []
@@ -173,6 +179,10 @@ extension XCScheme {
 
             let element = AEXMLElement(name: "TestAction", value: nil, attributes: attributes)
             super.writeXML(parent: element)
+            let testPlansElement = element.addChild(name: "TestPlans")
+            testPlans.forEach { testPlan in
+                testPlansElement.addChild(testPlan.xmlElement())
+            }
             let testablesElement = element.addChild(name: "Testables")
             testables.forEach { testable in
                 testablesElement.addChild(testable.xmlElement())
@@ -208,6 +218,7 @@ extension XCScheme {
         override func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? TestAction else { return false }
             return testables == rhs.testables &&
+                testPlans == rhs.testPlans &&
                 buildConfiguration == rhs.buildConfiguration &&
                 selectedDebuggerIdentifier == rhs.selectedDebuggerIdentifier &&
                 selectedLauncherIdentifier == rhs.selectedLauncherIdentifier &&

--- a/Sources/XcodeProj/Scheme/XCScheme+TestPlanReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestPlanReference.swift
@@ -1,0 +1,46 @@
+import AEXML
+import Foundation
+
+extension XCScheme {
+    public final class TestPlanReference: Equatable {
+        // MARK: - Attributes
+        
+        public var reference: String
+        public var `default`: Bool
+    
+        // MARK: -Init
+        
+        public init(reference: String,
+                    default: Bool = false) {
+            self.reference = reference
+            self.default = `default`
+        }
+        
+        init(element: AEXMLElement) throws {
+            reference = element.attributes["reference"]!
+            `default` = element.attributes["default"] == "YES"
+        }
+        
+        // MARK: - XML
+        
+        func xmlElement() -> AEXMLElement {
+            var attributes: [String: String] = ["reference": reference]
+            if `default` {
+                attributes["default"] = `default`.xmlString
+            }
+            
+            let element = AEXMLElement(name: "TestPlanReference",
+                                       value: nil,
+                                       attributes: attributes)
+            
+            return element
+        }
+        
+        // MARK: - Equatable
+        
+        public static func == (lhs: TestPlanReference, rhs: TestPlanReference) -> Bool {
+            return lhs.reference == rhs.reference &&
+                lhs.default == rhs.default
+        }
+    }
+}

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
@@ -20,7 +20,7 @@ class PBXProjEncoderTests: XCTestCase {
 
     func test_writeHeaders() throws {
         let lines = self.lines(fromFile: encodeProject())
-        XCTAssertEqual(581, lines.count)
+        XCTAssertEqual(583, lines.count)
         XCTAssertEqual("// !$*UTF8*$!", lines[0])
     }
 
@@ -82,6 +82,7 @@ class PBXProjEncoderTests: XCTestCase {
         line = lines.validate(lineContaining: "23766C261EAA3484007A9026 /* iOSTests.xctest */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C2A1EAA3484007A9026 /* iOSTests.swift */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C2C1EAA3484007A9026 /* Info.plist */", onLineAfter: line)
+        line = lines.validate(lineContaining: "23C1E0AF23657FB500B8D1EF /* iOS.xctestplan */", onLineAfter: line)
         line = lines.validate(lineContaining: "3CD1EADC205763E400DAEECB /* Model.xcdatamodel */", onLineAfter: line)
         line = lines.validate(lineContaining: "42AA1A1822AAF41000428760 /* MyLocalPackage */", onLineAfter: line)
         lines.validate(line: "/* End PBXFileReference section */", onLineAfter: line)
@@ -105,6 +106,7 @@ class PBXProjEncoderTests: XCTestCase {
         line = lines.validate(lineContaining: "04D5C0A01F153915008A2F98 /* Public.h */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C171EAA3484007A9026 /* ViewController.swift */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C121EAA3484007A9026 /* iOS.app */", onLineAfter: line)
+        line = lines.validate(lineContaining: "23C1E0AF23657FB500B8D1EF /* iOS.xctestplan */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C2A1EAA3484007A9026 /* iOSTests.swift */", onLineAfter: line)
         line = lines.validate(lineContaining: "23766C261EAA3484007A9026 /* iOSTests.xctest */", onLineAfter: line)
         lines.validate(line: "/* End PBXFileReference section */", onLineAfter: line)

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjIntegrationTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjIntegrationTests.swift
@@ -81,7 +81,7 @@ final class PBXProjIntegrationTests: XCTestCase {
         XCTAssertEqual(proj.objects.frameworksBuildPhases.count, 2)
         XCTAssertEqual(proj.objects.headersBuildPhases.count, 1)
         XCTAssertEqual(proj.objects.nativeTargets.count, 2)
-        XCTAssertEqual(proj.objects.fileReferences.count, 16)
+        XCTAssertEqual(proj.objects.fileReferences.count, 17)
         XCTAssertEqual(proj.objects.buildRules.count, 1)
         XCTAssertEqual(proj.objects.versionGroups.count, 1)
         XCTAssertEqual(proj.objects.projects.count, 1)

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -68,6 +68,22 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(subject.attributes["parallelizable"], "YES")
         XCTAssertEqual(subject.attributes["testExecutionOrdering"], "random")
     }
+    
+    func test_write_testPlanReferenceDefaultAttributesValuesAreOmitted() {
+        let reference = XCScheme.TestPlanReference(reference: "to_some_path")
+        let subject = reference.xmlElement()
+        XCTAssertNil(subject.attributes["default"])
+    }
+
+    func test_write_testPlanReferenceAttributesValues() {
+        let reference = XCScheme.TestPlanReference(
+            reference: "to_some_paht",
+            default: true
+        )
+        let subject = reference.xmlElement()
+        XCTAssertEqual(subject.attributes["reference"], "to_some_paht")
+        XCTAssertEqual(subject.attributes["default"], "YES")
+    }
 
     // MARK: - Private
 
@@ -107,6 +123,8 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.blueprintName, "iOSTests")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertEqual(scheme.testAction?.testPlans.first?.reference, "container:iOS.xctestplan")
+        XCTAssertEqual(scheme.testAction?.testPlans.first?.default, true)
         XCTAssertEqual(scheme.testAction?.preActions.first?.title, "First Pre-action")
         XCTAssertEqual(scheme.testAction?.preActions.first?.scriptText, "echo first")
         XCTAssertEqual(scheme.testAction?.preActions.last?.title, "Second Pre-action")


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/442

### Short description 📝
> This PR is for adding support for parsing and generating test plans feature added in Xcode 11.

### Solution 📦
> Since it's very similar to existing `Testables` structure, but much simpler, I followed the same pattern that already existed for `Testables`. Test plans structure in scheme file is as follow:

    ...
    <TestAction
        ...>
        <TestPlans>
            <TestPlanReference
                reference = "container:uitests.xctestplan"
                default = "YES">
            </TestPlanReference>
            <TestPlanReference
                reference = "container:unittests.xctestplan">
            </TestPlanReference>
        </TestPlans>
        ...
      </TestAction>
      ...

### Implementation 👩‍💻👨‍💻
> It was pretty straightforward with following the steps for `Testables` and the adding tests for XML parser. Then added the test plan support to iOS scheme that's used for scheme testing and fixed failing tests.