### PR TITLE
Replace Shell with SPM's process class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Replaced CircleCI with GitHub actions https://github.com/tuist/XcodeProj/pull/493 by @pepibumur
+- Replace CircleCI with GitHub actions https://github.com/tuist/XcodeProj/pull/493 by @pepibumur
+- Replace Shell with the SPM's Process utility class https://github.com/tuist/XcodeProj/pull/492 by @pepibumur
 
 ### Added
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 github "tuist/PathKit" == 1.0.0
 github "tadija/AEXML" == 4.4.0
-github "tuist/shell" == 2.0.3

--- a/Package.resolved
+++ b/Package.resolved
@@ -20,21 +20,30 @@
         }
       },
       {
-        "package": "Shell",
-        "repositoryURL": "https://github.com/tuist/Shell",
-        "state": {
-          "branch": null,
-          "revision": "ab06e1ae3fa52c26b076ff11dde60e950f6bbc7c",
-          "version": "2.0.1"
-        }
-      },
-      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
           "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
           "version": "0.9.0"
+        }
+      },
+      {
+        "package": "llbuild",
+        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "state": {
+          "branch": "master",
+          "revision": "0a778ca0c51025ffec95de881e59eb35c92f9944",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager",
+        "state": {
+          "branch": "swift-5.0-RELEASE",
+          "revision": "3a57975e10be0b1a8b87992ddf3a49701036f96c",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tadija/AEXML", .upToNextMinor(from: "4.4.0")),
         .package(url: "https://github.com/kylef/PathKit", .upToNextMinor(from: "1.0.0")),
-        .package(url: "https://github.com/tuist/Shell", .upToNextMinor(from: "2.0.1")),
+        .package(url: "https://github.com/apple/swift-package-manager", .branch("swift-5.0-RELEASE")),
     ],
     targets: [
         .target(name: "XcodeProj",
@@ -18,6 +18,6 @@ let package = Package(
                     "PathKit",
                     "AEXML",
                 ]),
-        .testTarget(name: "XcodeProjTests", dependencies: ["XcodeProj", "Shell"]),
+        .testTarget(name: "XcodeProjTests", dependencies: ["XcodeProj", "SPMUtility"]),
     ]
 )

--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -28,7 +28,8 @@ extension String {
             let message = data.withUnsafeBytes { bufferPointer in
                 Array(UnsafeBufferPointer(
                     start: bufferPointer.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                    count: data.count))
+                    count: data.count
+                ))
             }
 
             let MD5Calculator = MD5(message)

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -179,9 +179,9 @@ public final class PBXProject: PBXObject {
                                 versionRequirement: XCRemoteSwiftPackageReference.VersionRequirement,
                                 targetName: String) throws -> XCRemoteSwiftPackageReference {
         let objects = try self.objects()
-        
-        guard let target = targets.first(where: { $0.name == targetName}) else { throw PBXProjError.targetNotFound(targetName: targetName) }
-        
+
+        guard let target = targets.first(where: { $0.name == targetName }) else { throw PBXProjError.targetNotFound(targetName: targetName) }
+
         // Reference
         let reference = try addSwiftPackageReference(repositoryURL: repositoryURL,
                                                      productName: productName,
@@ -191,7 +191,7 @@ public final class PBXProject: PBXObject {
         let productDependency = try addSwiftPackageProduct(reference: reference,
                                                            productName: productName,
                                                            target: target)
-        
+
         // Build file
         let buildFile = PBXBuildFile(product: productDependency)
         objects.add(object: buildFile)
@@ -202,7 +202,7 @@ public final class PBXProject: PBXObject {
 
         return reference
     }
-    
+
     /// Adds a local swift package
     ///
     /// - Parameters:
@@ -215,27 +215,27 @@ public final class PBXProject: PBXObject {
                                      targetName: String,
                                      addFileReference: Bool = true) throws -> XCSwiftPackageProductDependency {
         guard path.isRelative else { throw PBXProjError.pathIsAbsolute(path) }
-        
+
         let objects = try self.objects()
-        
-        guard let target = targets.first(where: { $0.name == targetName}) else { throw PBXProjError.targetNotFound(targetName: targetName) }
-        
+
+        guard let target = targets.first(where: { $0.name == targetName }) else { throw PBXProjError.targetNotFound(targetName: targetName) }
+
         // Product
         let productDependency = try addLocalSwiftPackageProduct(path: path,
                                                                 productName: productName,
                                                                 target: target)
-        
+
         // Build file
         let buildFile = PBXBuildFile(product: productDependency)
         objects.add(object: buildFile)
-        
+
         // Link the product
         guard let frameworksBuildPhase = try target.frameworksBuildPhase() else {
             throw PBXProjError.frameworksBuildPhaseNotFound(targetName: targetName)
         }
-        
+
         frameworksBuildPhase.files?.append(buildFile)
-        
+
         // File reference
         // The user might want to control adding the file's reference (to be exact when the reference is added)
         // to achieve desired hierarchy of the group's children
@@ -247,7 +247,7 @@ public final class PBXProject: PBXObject {
             objects.add(object: reference)
             mainGroup.children.append(reference)
         }
-        
+
         return productDependency
     }
 
@@ -387,19 +387,19 @@ extension PBXProject {
             reference = package
         } else {
             reference = XCRemoteSwiftPackageReference(repositoryURL: repositoryURL, versionRequirement: versionRequirement)
-            try self.objects().add(object: reference)
+            try objects().add(object: reference)
             packages.append(reference)
         }
-        
+
         return reference
     }
-    
+
     /// Adds package product for remote Swift package
     private func addSwiftPackageProduct(reference: XCRemoteSwiftPackageReference,
                                         productName: String,
                                         target: PBXTarget) throws -> XCSwiftPackageProductDependency {
         let objects = try self.objects()
-        
+
         let productDependency: XCSwiftPackageProductDependency
         // Avoid duplication
         if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.package == reference })?.value {
@@ -409,16 +409,16 @@ extension PBXProject {
             objects.add(object: productDependency)
         }
         target.packageProductDependencies.append(productDependency)
-        
+
         return productDependency
     }
-    
+
     /// Adds package product for local Swift package
     private func addLocalSwiftPackageProduct(path: Path,
                                              productName: String,
                                              target: PBXTarget) throws -> XCSwiftPackageProductDependency {
         let objects = try self.objects()
-        
+
         let productDependency: XCSwiftPackageProductDependency
         // Avoid duplication
         if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.productName == productName }) {
@@ -431,7 +431,7 @@ extension PBXProject {
             objects.add(object: productDependency)
         }
         target.packageProductDependencies.append(productDependency)
-        
+
         return productDependency
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+TestPlanReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestPlanReference.swift
@@ -4,40 +4,40 @@ import Foundation
 extension XCScheme {
     public final class TestPlanReference: Equatable {
         // MARK: - Attributes
-        
+
         public var reference: String
         public var `default`: Bool
-    
+
         // MARK: - Init
-        
+
         public init(reference: String,
                     default: Bool = false) {
             self.reference = reference
             self.default = `default`
         }
-        
+
         init(element: AEXMLElement) throws {
             reference = element.attributes["reference"]!
             `default` = element.attributes["default"] == "YES"
         }
-        
+
         // MARK: - XML
-        
+
         func xmlElement() -> AEXMLElement {
             var attributes: [String: String] = ["reference": reference]
             if `default` {
                 attributes["default"] = `default`.xmlString
             }
-            
+
             let element = AEXMLElement(name: "TestPlanReference",
                                        value: nil,
                                        attributes: attributes)
-            
+
             return element
         }
-        
+
         // MARK: - Equatable
-        
+
         public static func == (lhs: TestPlanReference, rhs: TestPlanReference) -> Bool {
             return lhs.reference == rhs.reference &&
                 lhs.default == rhs.default

--- a/Tests/XcodeProjTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/XcodeProjTests/Objects/Files/PBXGroupTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import PathKit
-import Shell
 import XcodeProj
 import XCTest
 

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjIntegrationTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjIntegrationTests.swift
@@ -1,17 +1,10 @@
+import Basic
 import Foundation
 import PathKit
-import Shell
 import XCTest
 @testable import XcodeProj
 
 final class PBXProjIntegrationTests: XCTestCase {
-    var shell: Shell!
-
-    override func setUp() {
-        super.setUp()
-        shell = Shell()
-    }
-
     func test_init_initializesTheProjCorrectly() {
         let data = try! Data(contentsOf: fixturePath().url)
         let decoder = XcodeprojPropertyListDecoder()
@@ -44,15 +37,15 @@ final class PBXProjIntegrationTests: XCTestCase {
 
         try tmpDir.chdir {
             // Create a commit
-            _ = try shell.capture(["git", "init"]).get()
-            _ = try shell.capture(["git", "add", "."]).get()
-            _ = try shell.capture(["git", "commit", "-m", "'test'"]).get()
+            _ = try Basic.Process.checkNonZeroExit(args: "git", "init")
+            _ = try Basic.Process.checkNonZeroExit(args: "git", "add", ".")
+            _ = try Basic.Process.checkNonZeroExit(args: "git", "commit", "-m", "'test'")
 
             // Read/write the project
             let project = try XcodeProj(path: xcodeprojPath)
             try project.writePBXProj(path: xcodeprojPath, outputSettings: PBXOutputSettings())
 
-            let got = try shell.capture(["git", "status"]).get()
+            let got = try Basic.Process.checkNonZeroExit(args: "git", "status")
             XCTAssertTrue(got.contains("nothing to commit"))
         }
     }

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -30,8 +30,7 @@ final class PBXProjectTests: XCTestCase {
         ]
         XCTAssertEqual(attributes, expectedAttributes)
     }
-    
-    
+
     func test_addLocalSwiftPackage() throws {
         // Given
         let objects = PBXObjects(objects: [])
@@ -46,7 +45,7 @@ final class PBXProjectTests: XCTestCase {
                                      buildConfigurationList: nil,
                                      buildPhases: [buildPhase])
         objects.add(object: target)
-        
+
         let configurationList = XCConfigurationList.fixture()
         let mainGroup = PBXGroup.fixture()
         objects.add(object: configurationList)
@@ -59,54 +58,54 @@ final class PBXProjectTests: XCTestCase {
                                  targets: [target])
 
         objects.add(object: project)
-        
+
         // When
         let packageProduct = try project.addLocalSwiftPackage(path: "Product",
-                                         productName: "Product",
-                                         targetName: target.name)
-        
+                                                              productName: "Product",
+                                                              targetName: target.name)
+
         // Then
         XCTAssertEqual(packageProduct, objects.buildFiles.first?.value.product)
         XCTAssertEqual(packageProduct, objects.swiftPackageProductDependencies.first?.value)
         XCTAssertEqual(packageProduct, target.packageProductDependencies.first)
-        
+
         XCTAssertEqual(objects.fileReferences.first?.value.name, "Product")
-        
+
         XCTAssertEqual(objects.swiftPackageProductDependencies.first?.value, buildPhase.files?.first?.product)
     }
-    
+
     func test_addLocalSwiftPackage_throws_frameworksPhaseError() {
         // Given
         let objects = PBXObjects(objects: [])
 
         let target = PBXNativeTarget(name: "Target")
         objects.add(object: target)
-        
+
         let configurationList = XCConfigurationList.fixture()
         let mainGroup = PBXGroup.fixture()
         objects.add(object: configurationList)
         objects.add(object: mainGroup)
-        
+
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
                                  mainGroup: mainGroup,
                                  targets: [target])
-        
+
         objects.add(object: project)
-        
+
         // Then
-        
+
         XCTAssertThrowsSpecificError(try project.addLocalSwiftPackage(path: "Product",
                                                                       productName: "Product",
                                                                       targetName: target.name),
                                      PBXProjError.frameworksBuildPhaseNotFound(targetName: target.name))
     }
-    
+
     func test_addSwiftPackage() throws {
         // Given
         let objects = PBXObjects(objects: [])
-        
+
         let buildPhase = PBXFrameworksBuildPhase(
             files: [],
             inputFileListPaths: nil,
@@ -117,38 +116,38 @@ final class PBXProjectTests: XCTestCase {
                                      buildConfigurationList: nil,
                                      buildPhases: [buildPhase])
         objects.add(object: target)
-        
+
         let configurationList = XCConfigurationList.fixture()
         let mainGroup = PBXGroup.fixture()
         objects.add(object: configurationList)
         objects.add(object: mainGroup)
-        
+
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
                                  mainGroup: mainGroup,
                                  targets: [target])
-        
+
         objects.add(object: project)
-        
+
         // When
         let remoteReference = try project.addSwiftPackage(repositoryURL: "url",
-                                                         productName: "Product",
-                                                         versionRequirement: .branch("master"),
-                                                         targetName: "Target")
-        
+                                                          productName: "Product",
+                                                          versionRequirement: .branch("master"),
+                                                          targetName: "Target")
+
         // Then
         XCTAssertEqual(remoteReference, project.packages.first)
         XCTAssertEqual(remoteReference, objects.remoteSwiftPackageReferences.first?.value)
-        
+
         XCTAssertEqual(remoteReference, objects.buildFiles.first?.value.product?.package)
         XCTAssertEqual(objects.swiftPackageProductDependencies.first?.value, buildPhase.files?.first?.product)
     }
-    
+
     func test_addSwiftPackage_duplication() throws {
         // Given
         let objects = PBXObjects(objects: [])
-        
+
         let buildPhase = PBXFrameworksBuildPhase(
             files: [],
             inputFileListPaths: nil,
@@ -159,70 +158,7 @@ final class PBXProjectTests: XCTestCase {
                                      buildConfigurationList: nil,
                                      buildPhases: [buildPhase])
         objects.add(object: target)
-        
-        let secondBuildPhase = PBXFrameworksBuildPhase(
-            files: [],
-            inputFileListPaths: nil,
-            outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
-            runOnlyForDeploymentPostprocessing: true
-        )
-        let secondTarget = PBXNativeTarget(name: "SecondTarget",
-                                     buildConfigurationList: nil,
-                                     buildPhases: [secondBuildPhase])
-        objects.add(object: secondTarget)
-        
-        let configurationList = XCConfigurationList.fixture()
-        let mainGroup = PBXGroup.fixture()
-        objects.add(object: configurationList)
-        objects.add(object: mainGroup)
-        
-        let project = PBXProject(name: "Project",
-                                 buildConfigurationList: configurationList,
-                                 compatibilityVersion: "0",
-                                 mainGroup: mainGroup,
-                                 targets: [target, secondTarget])
-        
-        objects.add(object: project)
-        
-        // When
-        let packageProduct = try project.addSwiftPackage(repositoryURL: "url",
-                                                         productName: "Product",
-                                                         versionRequirement: .branch("master"),
-                                                         targetName: target.name)
-        let secondPackageProduct = try project.addSwiftPackage(repositoryURL: "url",
-                                                               productName: "Product",
-                                                               versionRequirement: .branch("master"),
-                                                               targetName: secondTarget.name)
-        
-        // Then
-        XCTAssertEqual(packageProduct, secondPackageProduct)
-        XCTAssertEqual(project.packages.count, 1)
-        XCTAssertEqual(target.packageProductDependencies, secondTarget.packageProductDependencies)
-        XCTAssertNotEqual(buildPhase.files?.first?.hashValue, secondBuildPhase.files?.first?.hashValue)
-        XCTAssertEqual(objects.swiftPackageProductDependencies.count, 1)
-        
-        XCTAssertThrowsSpecificError(try project.addSwiftPackage(repositoryURL: "url",
-                                                                 productName: "Product",
-                                                                 versionRequirement: .branch("second-master"),
-                                                                 targetName: secondTarget.name),
-                                     PBXProjError.multipleRemotePackages(productName: "Product"))
-    }
-    
-    func test_addLocalSwiftPackage_duplication() throws {
-        // Given
-        let objects = PBXObjects(objects: [])
-        
-        let buildPhase = PBXFrameworksBuildPhase(
-            files: [],
-            inputFileListPaths: nil,
-            outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
-            runOnlyForDeploymentPostprocessing: true
-        )
-        let target = PBXNativeTarget(name: "Target",
-                                     buildConfigurationList: nil,
-                                     buildPhases: [buildPhase])
-        objects.add(object: target)
-        
+
         let secondBuildPhase = PBXFrameworksBuildPhase(
             files: [],
             inputFileListPaths: nil,
@@ -233,20 +169,83 @@ final class PBXProjectTests: XCTestCase {
                                            buildConfigurationList: nil,
                                            buildPhases: [secondBuildPhase])
         objects.add(object: secondTarget)
-        
+
         let configurationList = XCConfigurationList.fixture()
         let mainGroup = PBXGroup.fixture()
         objects.add(object: configurationList)
         objects.add(object: mainGroup)
-        
+
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
                                  mainGroup: mainGroup,
                                  targets: [target, secondTarget])
-        
+
         objects.add(object: project)
-        
+
+        // When
+        let packageProduct = try project.addSwiftPackage(repositoryURL: "url",
+                                                         productName: "Product",
+                                                         versionRequirement: .branch("master"),
+                                                         targetName: target.name)
+        let secondPackageProduct = try project.addSwiftPackage(repositoryURL: "url",
+                                                               productName: "Product",
+                                                               versionRequirement: .branch("master"),
+                                                               targetName: secondTarget.name)
+
+        // Then
+        XCTAssertEqual(packageProduct, secondPackageProduct)
+        XCTAssertEqual(project.packages.count, 1)
+        XCTAssertEqual(target.packageProductDependencies, secondTarget.packageProductDependencies)
+        XCTAssertNotEqual(buildPhase.files?.first?.hashValue, secondBuildPhase.files?.first?.hashValue)
+        XCTAssertEqual(objects.swiftPackageProductDependencies.count, 1)
+
+        XCTAssertThrowsSpecificError(try project.addSwiftPackage(repositoryURL: "url",
+                                                                 productName: "Product",
+                                                                 versionRequirement: .branch("second-master"),
+                                                                 targetName: secondTarget.name),
+                                     PBXProjError.multipleRemotePackages(productName: "Product"))
+    }
+
+    func test_addLocalSwiftPackage_duplication() throws {
+        // Given
+        let objects = PBXObjects(objects: [])
+
+        let buildPhase = PBXFrameworksBuildPhase(
+            files: [],
+            inputFileListPaths: nil,
+            outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+            runOnlyForDeploymentPostprocessing: true
+        )
+        let target = PBXNativeTarget(name: "Target",
+                                     buildConfigurationList: nil,
+                                     buildPhases: [buildPhase])
+        objects.add(object: target)
+
+        let secondBuildPhase = PBXFrameworksBuildPhase(
+            files: [],
+            inputFileListPaths: nil,
+            outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+            runOnlyForDeploymentPostprocessing: true
+        )
+        let secondTarget = PBXNativeTarget(name: "SecondTarget",
+                                           buildConfigurationList: nil,
+                                           buildPhases: [secondBuildPhase])
+        objects.add(object: secondTarget)
+
+        let configurationList = XCConfigurationList.fixture()
+        let mainGroup = PBXGroup.fixture()
+        objects.add(object: configurationList)
+        objects.add(object: mainGroup)
+
+        let project = PBXProject(name: "Project",
+                                 buildConfigurationList: configurationList,
+                                 compatibilityVersion: "0",
+                                 mainGroup: mainGroup,
+                                 targets: [target, secondTarget])
+
+        objects.add(object: project)
+
         // When
         let packageProduct = try project.addLocalSwiftPackage(path: "Product",
                                                               productName: "Product",
@@ -254,16 +253,16 @@ final class PBXProjectTests: XCTestCase {
         let secondPackageProduct = try project.addLocalSwiftPackage(path: "Product",
                                                                     productName: "Product",
                                                                     targetName: secondTarget.name)
-        
+
         // Then
         XCTAssertEqual(packageProduct, secondPackageProduct)
         XCTAssertEqual(target.packageProductDependencies, secondTarget.packageProductDependencies)
         XCTAssertNotEqual(buildPhase.files?.first?.hashValue, secondBuildPhase.files?.first?.hashValue)
         XCTAssertEqual(objects.swiftPackageProductDependencies.count, 1)
-        
+
         XCTAssertThrowsSpecificError(try project.addLocalSwiftPackage(path: "Sources/Product",
-                                                              productName: "Product",
-                                                              targetName: target.name),
+                                                                      productName: "Product",
+                                                                      targetName: target.name),
                                      PBXProjError.multipleLocalPackages(productName: "Product"))
     }
 }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -68,7 +68,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(subject.attributes["parallelizable"], "YES")
         XCTAssertEqual(subject.attributes["testExecutionOrdering"], "random")
     }
-    
+
     func test_write_testPlanReferenceDefaultAttributesValuesAreOmitted() {
         let reference = XCScheme.TestPlanReference(reference: "to_some_path")
         let subject = reference.xmlElement()

--- a/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
+++ b/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
@@ -1,10 +1,9 @@
 import Foundation
-import XCTest
 import PathKit
+import XCTest
 @testable import XcodeProj
 
 class ReferenceGeneratorTests: XCTestCase {
-
     func test_projectReferencingRemoteXcodeprojBundle_convertsReferencesToPermanent() throws {
         let project = PBXProj(rootObject: nil, objectVersion: 0, archiveVersion: 0, classes: [:], objects: [])
         let pbxProject = project.makeProject()
@@ -13,7 +12,7 @@ class ReferenceGeneratorTests: XCTestCase {
         let productReferenceProxy = project.makeReferenceProxy(containerItemProxy: containerItemProxy)
         let productsGroup = project.makeProductsGroup(children: [productReferenceProxy])
 
-        pbxProject.projectReferences.append([ "ProductGroup" : productsGroup.reference ])
+        pbxProject.projectReferences.append(["ProductGroup": productsGroup.reference])
 
         let referenceGenerator = ReferenceGenerator(outputSettings: PBXOutputSettings())
         try referenceGenerator.generateReferences(proj: project)
@@ -36,15 +35,15 @@ private extension PBXProj {
                                  compatibilityVersion: Xcode.Default.compatibilityVersion,
                                  mainGroup: mainGroup)
 
-        self.add(object: mainGroup)
-        self.add(object: project)
-        self.rootObject = project
+        add(object: mainGroup)
+        add(object: project)
+        rootObject = project
 
         return project
     }
 
     func makeFileReference() -> PBXFileReference {
-        return try! self.rootObject!.mainGroup.addFile(at: Path("../Remote.xcodeproj"), sourceRoot: Path("/"), validatePresence: false)
+        return try! rootObject!.mainGroup.addFile(at: Path("../Remote.xcodeproj"), sourceRoot: Path("/"), validatePresence: false)
     }
 
     func makeContainerItemProxy(fileReference: PBXFileReference) -> PBXContainerItemProxy {
@@ -53,7 +52,7 @@ private extension PBXProj {
                                                        proxyType: .reference,
                                                        remoteInfo: "RemoteTarget")
 
-        self.add(object: containerItemProxy)
+        add(object: containerItemProxy)
 
         return containerItemProxy
     }
@@ -63,7 +62,7 @@ private extension PBXProj {
                                                       path: "Remote.framework",
                                                       remote: containerItemProxy,
                                                       sourceTree: .buildProductsDir)
-        self.add(object: productReferenceProxy)
+        add(object: productReferenceProxy)
         return productReferenceProxy
     }
 
@@ -71,7 +70,7 @@ private extension PBXProj {
         let productsGroup = PBXGroup(children: children,
                                      sourceTree: .group,
                                      name: "Products")
-        self.add(object: productsGroup)
+        add(object: productsGroup)
         return productsGroup
     }
 }

--- a/xcodeproj.podspec
+++ b/xcodeproj.podspec
@@ -16,5 +16,4 @@ Pod::Spec.new do |s|
 
   s.dependency "PathKit", "~> 1.0.0"
   s.dependency "AEXML", "~> 4.4.0"
-  s.dependency "Shell", "~> 2.0.0"
 end


### PR DESCRIPTION
### Short description 📝
In order to provide support for Linux, we have to make sure that the code and its dependencies are Linux-compatible. The only dependency that is not is [Shell](https://github.com/tuist/shell).

### Solution 📦
Since we only use the dependency from the tests target, I think we can use the SPM's `Process` utility instead.

Note that there are some extra changes in this PR because I ran Swift format to re-format the code.