### PR TITLE
Test Plan Consistent Serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Next
 
+### Fixed
+ - Make test plans deserialise correctly https://github.com/tuist/XcodeProj/pull/496 by @adamkhazi
+
 ## 7.2.1
 
 ### Fixed
-- Make test plans optional by https://github.com/tuist/XcodeProj/commit/c15034948a2a132bf559f14d3c6b4d1b73749663 @pepibumur
+- Make test plans optional https://github.com/tuist/XcodeProj/commit/c15034948a2a132bf559f14d3c6b4d1b73749663 by @pepibumur
 
 ### Changed
 

--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -106,7 +106,7 @@ extension XCScheme {
                 .map(TestableReference.init) ?? []
             testPlans = try element["TestPlans"]["TestPlanReference"]
                 .all?
-                .map(TestPlanReference.init) ?? []
+                .map(TestPlanReference.init)
             codeCoverageTargets = try element["CodeCoverageTargets"]["BuildableReference"]
                 .all?
                 .map(BuildableReference.init) ?? []

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -8,7 +8,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         let subject = try XCScheme(path: iosSchemePath)
         assert(scheme: subject)
     }
-
+    
     func test_write_iosScheme() {
         testWrite(from: iosSchemePath,
                   initModel: { try? XCScheme(path: $0) },
@@ -83,6 +83,18 @@ final class XCSchemeIntegrationTests: XCTestCase {
         let subject = reference.xmlElement()
         XCTAssertEqual(subject.attributes["reference"], "to_some_paht")
         XCTAssertEqual(subject.attributes["default"], "YES")
+    }
+    
+    func test_testAction_serializingAndDeserializing() throws {
+        // Given
+        let subject = XCScheme.TestAction(buildConfiguration: "Debug", macroExpansion: nil)
+        
+        // When
+        let element = subject.xmlElement()
+        let reconstructedSubject = try XCScheme.TestAction(element: element)
+        
+        // Then
+        XCTAssertEqual(subject, reconstructedSubject)
     }
 
     // MARK: - Private


### PR DESCRIPTION
### Short description 📝
Test plans were recently made optional (c15034948a2a132bf559f14d3c6b4d1b73749663). When reading from a file, test plans were wrongly defaulting to an empty array even when a `nil` test plan was set on the `TestAction` that was written to file originally.

### Solution 📦
Remove `?? []`and leave `testPlans` as `nil`.

### Implementation 👩‍💻👨‍💻
- [X] Remove default test plan behaviour
- [X] Write a test for this case
