### PR TITLE
Remove SwiftPM dependency and use Foundation.Process in tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -27,24 +27,6 @@
           "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
           "version": "0.9.0"
         }
-      },
-      {
-        "package": "llbuild",
-        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
-        "state": {
-          "branch": "master",
-          "revision": "0a778ca0c51025ffec95de881e59eb35c92f9944",
-          "version": null
-        }
-      },
-      {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager",
-        "state": {
-          "branch": "swift-5.0-RELEASE",
-          "revision": "3a57975e10be0b1a8b87992ddf3a49701036f96c",
-          "version": null
-        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tadija/AEXML", .upToNextMinor(from: "4.4.0")),
         .package(url: "https://github.com/kylef/PathKit", .upToNextMinor(from: "1.0.0")),
-        .package(url: "https://github.com/apple/swift-package-manager", .branch("swift-5.0-RELEASE")),
     ],
     targets: [
         .target(name: "XcodeProj",
@@ -18,6 +17,6 @@ let package = Package(
                     "PathKit",
                     "AEXML",
                 ]),
-        .testTarget(name: "XcodeProjTests", dependencies: ["XcodeProj", "SPMUtility"]),
+        .testTarget(name: "XcodeProjTests", dependencies: ["XcodeProj"]),
     ]
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/498

### Short description 📝
SwiftPM's `Basic` has a useful higher-level subprocess API, but depending on SwiftPM itself is heavy and breaks resolution for consumers of XcodeProj (#498). This change removes the SwiftPM dependency and uses Foundation's `Process` to execute subprocesses in XcodeProj's tests.

### Solution 📦
`Process` is marked "complete" in [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/Status.md), so the API should be considered portable across Windows, Linux, and macOS.

I've added a private function to `PBXProjIntegrationTests` that provides a similarly-high-level function for executing a command and getting its output. I'd be happy to move it somewhere more reusable if you anticipate needing it from other tests in the future 🙂 