### PR TITLE
Provide default build settings for unit and ui test targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Fixed
+
+- Provide default build settings for unit and ui test targets https://github.com/tuist/XcodeProj/pull/501 by @kwridan
+
 ## 7.4.0
 
 ### Changed

--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -32,7 +32,7 @@ public class BuildSettingsProvider {
     /// - appExtension: application extension
     /// - watchExtension: watch extension
     public enum Product {
-        case framework, staticLibrary, dynamicLibrary, application, bundle, appExtension, watchExtension
+        case framework, staticLibrary, dynamicLibrary, application, bundle, appExtension, watchExtension, unitTests, uiTests
     }
 
     /// Returns the default target build settings.
@@ -308,6 +308,14 @@ public class BuildSettingsProvider {
                     "@executable_path/../../../../Frameworks"
                 ]
             ]
+        case ([.iOS, .tvOS], [.unitTests, .uiTests]):
+        return [
+            "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
+        ]
+        case (.macOS, [.unitTests, .uiTests]):
+        return [
+            "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/../Frameworks", "@loader_path/../Frameworks"]
+        ]
         default:
             return [:]
         }

--- a/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
+++ b/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
@@ -143,6 +143,96 @@ class BuildSettingProviderTests: XCTestCase {
         ])
     }
     
+    func test_targetSettings_iOSUnitTests() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .debug,
+                                                          platform: .iOS,
+                                                          product: .unitTests,
+                                                          swift: true)
+        
+        // Then
+        assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "iPhone Developer",
+            "SDKROOT": "iphoneos",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@loader_path/Frameworks"
+            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+            "SWIFT_COMPILATION_MODE": "singlefile",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+            "TARGETED_DEVICE_FAMILY": "1,2"
+        ])
+    }
+    
+    func test_targetSettings_iOSUITests() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .debug,
+                                                          platform: .iOS,
+                                                          product: .uiTests,
+                                                          swift: true)
+        
+        // Then
+        assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "iPhone Developer",
+            "SDKROOT": "iphoneos",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@loader_path/Frameworks"
+            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+            "SWIFT_COMPILATION_MODE": "singlefile",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+            "TARGETED_DEVICE_FAMILY": "1,2"
+        ])
+    }
+    
+    func test_targetSettings_macOSUnitTests() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .debug,
+                                                          platform: .macOS,
+                                                          product: .unitTests,
+                                                          swift: true)
+        
+        // Then
+        assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "-",
+            "SDKROOT": "macosx",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/../Frameworks",
+                "@loader_path/../Frameworks"
+            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+            "SWIFT_COMPILATION_MODE": "singlefile",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+        ])
+    }
+    
+    func test_targetSettings_tvOSUnitTests() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .debug,
+                                                          platform: .tvOS,
+                                                          product: .unitTests,
+                                                          swift: true)
+        
+        // Then
+        assertEqualSettings(results, [
+            "SDKROOT": "appletvos",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@loader_path/Frameworks"
+            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+            "SWIFT_COMPILATION_MODE": "singlefile",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+            "TARGETED_DEVICE_FAMILY": "3"
+        ])
+    }
+    
     // MARK: - Helpers
     
     func assertEqualSettings(_ lhs: BuildSettings, _ rhs: BuildSettings, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
### Short description 📝

- The previous diff https://github.com/tuist/XcodeProj/pull/497 restructured the way the build settings were provided
- This sadly caused a regression of not providing some of the default build settings for Unit/UI test bundles (e.g `LD_RUNPATH_SEARCH_PATHS`)

### Solution 📦

- Unit tests/UI tests are now explicitly added as product types
- Tests have been added to prevent future regressions

### Implementation 👩‍💻👨‍💻

- [x] Update build setting provider
- [x] Update tests
- [x] Validate other settings
- [x] Update change log

### Test Plan 🛠:

- Verify the build settings match those provided by Xcode