### PR TITLE
Make target attributes optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+### Changed
+- **Breaking** Make `PBXProject.targetAttributes` optional https://github.com/tuist/XcodeProj/pull/517 by @pepibumur
+
 ### Fixed
 - Remove "Shell" Carthage dependency from carthage xcode project as it's no longer used https://github.com/tuist/XcodeProj/pull/507 by @imben123
 

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -497,7 +497,7 @@ extension PBXProject: PlistSerializable {
         }
 
         var plistAttributes: [String: Any] = attributes
-        if let targetAttributeReferences = targetAttributeReferences, !targetAttributeReferences.isEmpty {
+        if let targetAttributeReferences = targetAttributeReferences {
             // merge target attributes
             var plistTargetAttributes: [String: Any] = [:]
             for (reference, value) in targetAttributeReferences {

--- a/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
@@ -176,7 +176,9 @@ extension PBXProject {
         if projectRoots != rhs.projectRoots { return false }
         if targetReferences != rhs.targetReferences { return false }
         if !NSDictionary(dictionary: attributes).isEqual(to: rhs.attributes) { return false }
-        if !NSDictionary(dictionary: targetAttributeReferences).isEqual(to: rhs.targetAttributeReferences) { return false }
+        guard let targetAttributeReferences = targetAttributeReferences,
+            let rhsTargetAttributeReferences = rhs.targetAttributeReferences,
+            NSDictionary(dictionary: targetAttributeReferences).isEqual(to: rhsTargetAttributeReferences) else { return false }
         return super.isEqual(to: rhs)
     }
 }


### PR DESCRIPTION
Related https://github.com/tuist/tuist/issues/904

The `PBXProject` `targetAttributes` is not written when the dictionary is empty. That's causing some [issues](https://github.com/tuist/tuist/issues/904) because Fastlane expects the dictionary to be defined in the .pbxproj. Since this is an optional attribute, I'm defining it as such and writing it even if the dictionary is empty.