### PR TITLE
Generate project references before targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+### Fixed
+- Ensure references to products in external projects are generated with deterministic UUIDs https://github.com/tuist/XcodeProj/pull/518 by @evandcoleman
+
 ## 7.6.0
 
 ### Changed

--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -50,10 +50,6 @@ final class ReferenceGenerator: ReferenceGenerating {
             try generateGroupReferences(productsGroup, identifiers: identifiers)
         }
 
-        // Targets
-        let targets: [PBXTarget] = project.targets
-        try targets.forEach { try generateTargetReferences($0, identifiers: identifiers) }
-
         // Project references
         try project.projectReferences.flatMap { $0.values }.forEach { objectReference in
             if let fileReference = objectReference.getObject() as? PBXFileReference {
@@ -62,6 +58,10 @@ final class ReferenceGenerator: ReferenceGenerating {
                 try generateGroupReferences(group, identifiers: identifiers)
             }
         }
+
+        // Targets
+        let targets: [PBXTarget] = project.targets
+        try targets.forEach { try generateTargetReferences($0, identifiers: identifiers) }
 
         /// Configuration list
         if let configurationList: XCConfigurationList = project.buildConfigurationListReference.getObject() {


### PR DESCRIPTION
### Short description 📝
Previously, targets were generated before project references. This means that any build files in your main project that reference build files in another project will be generated with non-deterministic UUIDs.

### Solution 📦
Generate project references before generating targets

### Implementation 👩‍💻👨‍💻
This bug was surfaced to me while implementing a new feature in XcodeGen (https://github.com/yonaskolb/XcodeGen/pull/701) which allows you to link with targets in external Xcode projects. Every time the project was generated, the UUIDs of the `PBXBuildFile`s were different. I realized that this is because the `PBXProductReferenceProxy` object still had a `TEMP` UUID by the time it got to generating build phases for the main project. After changing the order of generating, the problem went away because the reference proxy no longer had the temporary UUID.
