### PR TITLE
Fix target attribute optionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Fixes
+
+- Make `PBXProject.targetAttributes` non optional again and fix equality https://github.com/tuist/XcodeProj/pull/519 by @yonaskolb
+
 ## 7.7.0
 
 ### Fixed

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -105,31 +105,23 @@ public final class PBXProject: PBXObject {
     public var attributes: [String: Any]
 
     /// Target attribute references.
-    var targetAttributeReferences: [PBXObjectReference: [String: Any]]?
+    var targetAttributeReferences: [PBXObjectReference: [String: Any]]
 
     /// Target attributes.
-    public var targetAttributes: [PBXTarget: [String: Any]]? {
+    public var targetAttributes: [PBXTarget: [String: Any]] {
         set {
-            if let newValue = newValue {
-                targetAttributeReferences = [:]
-                newValue.forEach {
-                    targetAttributeReferences?[$0.key.reference] = $0.value
-                }
-            } else {
-                targetAttributeReferences = nil
+            targetAttributeReferences = [:]
+            newValue.forEach {
+                targetAttributeReferences[$0.key.reference] = $0.value
             }
         } get {
-            if let targetAttributeReferences = targetAttributeReferences {
-                var attributes: [PBXTarget: [String: Any]] = [:]
-                targetAttributeReferences.forEach {
-                    if let object: PBXTarget = $0.key.getObject() {
-                        attributes[object] = $0.value
-                    }
+            var attributes: [PBXTarget: [String: Any]] = [:]
+            targetAttributeReferences.forEach {
+                if let object: PBXTarget = $0.key.getObject() {
+                    attributes[object] = $0.value
                 }
-                return attributes
-            } else {
-                return nil
             }
+            return attributes
         }
     }
 
@@ -152,22 +144,19 @@ public final class PBXProject: PBXObject {
     ///   - attributes: attributes that will be set.
     ///   - target: target.
     public func setTargetAttributes(_ attributes: [String: Any], target: PBXTarget) {
-        if targetAttributeReferences == nil {
-            targetAttributeReferences = [:]
-        }
-        targetAttributeReferences?[target.reference] = attributes
+        targetAttributeReferences[target.reference] = attributes
     }
 
     /// Removes the attributes for the given target.
     ///
     /// - Parameter target: target whose attributes will be removed.
     public func removeTargetAttributes(target: PBXTarget) {
-        targetAttributeReferences?.removeValue(forKey: target.reference)
+        targetAttributeReferences.removeValue(forKey: target.reference)
     }
 
     /// Removes the all the target attributes
     public func clearAllTargetAttributes() {
-        targetAttributeReferences?.removeAll()
+        targetAttributeReferences.removeAll()
     }
 
     /// Returns the attributes of a given target.
@@ -175,7 +164,7 @@ public final class PBXProject: PBXObject {
     /// - Parameter for: target whose attributes will be returned.
     /// - Returns: target attributes.
     public func attributes(for target: PBXTarget) -> [String: Any]? {
-        return targetAttributeReferences?[target.reference]
+        return targetAttributeReferences[target.reference]
     }
 
     /// Adds a remote swift package
@@ -497,16 +486,16 @@ extension PBXProject: PlistSerializable {
         }
 
         var plistAttributes: [String: Any] = attributes
-        if let targetAttributeReferences = targetAttributeReferences {
-            // merge target attributes
-            var plistTargetAttributes: [String: Any] = [:]
-            for (reference, value) in targetAttributeReferences {
-                plistTargetAttributes[reference.value] = value.mapValues { value in
-                    (value as? PBXObject)?.reference.value ?? value
-                }
+
+        // merge target attributes
+        var plistTargetAttributes: [String: Any] = [:]
+        for (reference, value) in targetAttributeReferences {
+            plistTargetAttributes[reference.value] = value.mapValues { value in
+                (value as? PBXObject)?.reference.value ?? value
             }
-            plistAttributes[PBXProject.targetAttributesKey] = plistTargetAttributes
         }
+        plistAttributes[PBXProject.targetAttributesKey] = plistTargetAttributes
+
         dictionary["attributes"] = plistAttributes.plist()
 
         return (key: CommentedString(reference,

--- a/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
@@ -176,9 +176,7 @@ extension PBXProject {
         if projectRoots != rhs.projectRoots { return false }
         if targetReferences != rhs.targetReferences { return false }
         if !NSDictionary(dictionary: attributes).isEqual(to: rhs.attributes) { return false }
-        guard let targetAttributeReferences = targetAttributeReferences,
-            let rhsTargetAttributeReferences = rhs.targetAttributeReferences,
-            NSDictionary(dictionary: targetAttributeReferences).isEqual(to: rhsTargetAttributeReferences) else { return false }
+        if !NSDictionary(dictionary: targetAttributeReferences).isEqual(to: rhs.targetAttributeReferences) { return false }
         return super.isEqual(to: rhs)
     }
 }


### PR DESCRIPTION
https://github.com/tuist/XcodeProj/pull/517 made a breaking change to make `targetAttributes` optional.

This PR fixes:
- project equality always returning false if `targetAttributes` were optional
- makes `targetAttributes` non optional, as they are always set in both the initializers. The attributes are always still written which solves the aim of https://github.com/tuist/XcodeProj/pull/517