### PR TITLE
Add PathRunnable to LaunchAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+### Added
+- Added `PathRunnable` to the `LaunchAction` to allow running any executable https://github.com/tuist/XcodeProj/pull/521 by @vytis
+
 ## 7.7.0
 
 ### Fixed

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -41,6 +41,7 @@ extension XCScheme {
         public var buildConfiguration: String
         public var launchStyle: Style
         public var askForAppToLaunch: Bool?
+        public var pathRunnable: PathRunnable?
         public var useCustomWorkingDirectory: Bool
         public var ignoresPersistentStateOnLaunch: Bool
         public var debugDocumentVersioning: Bool
@@ -77,6 +78,7 @@ extension XCScheme {
                     selectedLauncherIdentifier: String = XCScheme.defaultLauncher,
                     launchStyle: Style = .auto,
                     askForAppToLaunch: Bool? = nil,
+                    pathRunnable: PathRunnable? = nil,
                     useCustomWorkingDirectory: Bool = false,
                     ignoresPersistentStateOnLaunch: Bool = false,
                     debugDocumentVersioning: Bool = true,
@@ -107,6 +109,7 @@ extension XCScheme {
             self.selectedDebuggerIdentifier = selectedDebuggerIdentifier
             self.selectedLauncherIdentifier = selectedLauncherIdentifier
             self.askForAppToLaunch = askForAppToLaunch
+            self.pathRunnable = pathRunnable
             self.useCustomWorkingDirectory = useCustomWorkingDirectory
             self.ignoresPersistentStateOnLaunch = ignoresPersistentStateOnLaunch
             self.debugDocumentVersioning = debugDocumentVersioning
@@ -154,7 +157,12 @@ extension XCScheme {
             } else if remoteRunnableElement.error == nil {
                 runnable = try RemoteRunnable(element: remoteRunnableElement)
             }
-
+            
+            let pathRunnable = element["PathRunnable"]
+            if pathRunnable.error == nil {
+                self.pathRunnable = try PathRunnable(element: pathRunnable)
+            }
+            
             let buildableReferenceElement = element["MacroExpansion"]["BuildableReference"]
             if buildableReferenceElement.error == nil {
                 macroExpansion = try BuildableReference(element: buildableReferenceElement)
@@ -261,6 +269,10 @@ extension XCScheme {
             if let runnable = runnable {
                 element.addChild(runnable.xmlElement())
             }
+            
+            if let pathRunnable = pathRunnable {
+                element.addChild(pathRunnable.xmlElement())
+            }
 
             if let locationScenarioReference = locationScenarioReference {
                 element.addChild(locationScenarioReference.xmlElement())
@@ -313,6 +325,7 @@ extension XCScheme {
                 buildConfiguration == rhs.buildConfiguration &&
                 launchStyle == rhs.launchStyle &&
                 askForAppToLaunch == rhs.askForAppToLaunch &&
+                pathRunnable == rhs.pathRunnable &&
                 useCustomWorkingDirectory == rhs.useCustomWorkingDirectory &&
                 ignoresPersistentStateOnLaunch == rhs.ignoresPersistentStateOnLaunch &&
                 debugDocumentVersioning == rhs.debugDocumentVersioning &&

--- a/Sources/XcodeProj/Scheme/XCScheme+PathRunnable.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+PathRunnable.swift
@@ -1,0 +1,44 @@
+import AEXML
+import Foundation
+import PathKit
+
+extension XCScheme {
+    public class PathRunnable: Equatable {
+        // MARK: - Attributes
+
+        public var runnableDebuggingMode: String
+        public var filePath: String
+
+        // MARK: - Init
+
+        public init(filePath: String,
+                    runnableDebuggingMode: String = "0") {
+            self.filePath = filePath
+            self.runnableDebuggingMode = runnableDebuggingMode
+        }
+
+        init(element: AEXMLElement) throws {
+            runnableDebuggingMode = element.attributes["runnableDebuggingMode"] ?? "0"
+            filePath = element.attributes["FilePath"] ?? ""
+        }
+
+        // MARK: - XML
+
+        func xmlElement() -> AEXMLElement {
+            return AEXMLElement(name: "PathRunnable",
+                                       value: nil,
+                                       attributes: [
+                                        "runnableDebuggingMode": runnableDebuggingMode,
+                                        "FilePath" : filePath
+                ]
+            )
+        }
+
+        // MARK: - Equatable
+
+        public static func == (lhs: PathRunnable, rhs: PathRunnable) -> Bool {
+            return lhs.runnableDebuggingMode == rhs.runnableDebuggingMode &&
+                lhs.filePath == rhs.filePath
+        }
+    }
+}

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -85,6 +85,20 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(subject.attributes["default"], "YES")
     }
     
+    func test_testAction_pathRunnable_serializingAndDeserializing() throws {
+        // Given
+        let filePath = "/usr/bin/foo"
+        let pathRunnable = XCScheme.PathRunnable(filePath: filePath, runnableDebuggingMode: "0")
+        let subject = XCScheme.LaunchAction(runnable: nil, buildConfiguration: "Debug", pathRunnable: pathRunnable)
+        
+        // When
+        let element = subject.xmlElement()
+        let reconstructedSubject = try XCScheme.LaunchAction(element: element)
+        
+        // Then
+        XCTAssertEqual(subject, reconstructedSubject)
+    }
+    
     func test_testAction_serializingAndDeserializing() throws {
         // Given
         let subject = XCScheme.TestAction(buildConfiguration: "Debug", macroExpansion: nil)


### PR DESCRIPTION
Resolves #520 

### Short description 📝
There was no way to specify `PathRunnable` in `LaunchAction`. This PR adds the functionality.

### Solution 📦
Created a new `PathRunnable` class and added it as a parameter to `LaunchAction`.