### PR TITLE
Code Coverage Targets and Additional Options Scheme Instability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove `Tapestries` folder for tapestry 0.0.5 version https://github.com/tuist/XcodeProj/pull/523 by @fortmarek
 
+### Fixed
+
+- Code Coverage Targets and Additional Options Scheme Instability https://github.com/tuist/XcodeProj/pull/522 by @adamkhazi
+
 ## 7.8.0
 
 ### Added

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -306,10 +306,13 @@ extension XCScheme {
                 element.attributes["customLaunchCommand"] = customLaunchCommand
             }
 
-            let additionalOptionsElement = element.addChild(AEXMLElement(name: "AdditionalOptions"))
-            additionalOptions.forEach { additionalOption in
-                additionalOptionsElement.addChild(additionalOption.xmlElement())
+            if !additionalOptions.isEmpty {
+                let additionalOptionsElement = element.addChild(AEXMLElement(name: "AdditionalOptions"))
+                additionalOptions.forEach { additionalOption in
+                    additionalOptionsElement.addChild(additionalOption.xmlElement())
+                }
             }
+
             return element
         }
 

--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -204,16 +204,20 @@ extension XCScheme {
                 element.addChild(EnvironmentVariable.xmlElement(from: environmentVariables))
             }
 
-            let additionalOptionsElement = element.addChild(AEXMLElement(name: "AdditionalOptions"))
-            additionalOptions.forEach { additionalOption in
-                additionalOptionsElement.addChild(additionalOption.xmlElement())
+            if !additionalOptions.isEmpty {
+                let additionalOptionsElement = element.addChild(AEXMLElement(name: "AdditionalOptions"))
+                additionalOptions.forEach { additionalOption in
+                    additionalOptionsElement.addChild(additionalOption.xmlElement())
+                }
             }
 
-            let codeCoverageTargetsElement = element.addChild(AEXMLElement(name: "CodeCoverageTargets"))
-            codeCoverageTargets.forEach { target in
-                codeCoverageTargetsElement.addChild(target.xmlElement())
+            if !codeCoverageTargets.isEmpty {
+                let codeCoverageTargetsElement = element.addChild(AEXMLElement(name: "CodeCoverageTargets"))
+                codeCoverageTargets.forEach { target in
+                    codeCoverageTargetsElement.addChild(target.xmlElement())
+                }
             }
-
+            
             return element
         }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/971

### Short description 📝
Opening the scheme editing interface in Xcode without making changes should not make any changes to the opened `.xcscheme` file on disk. Such changes are easily spotted if the generated  `.xcodeproj` is checked into a version controlled repository for example. Below are the unstable changes that this pull request addresses:

```diff
@@ -57,10 +57,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <CodeCoverageTargets>
-      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -82,8 +78,6 @@
             ReferencedContainer = "container:MainApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
```


### Solution 📦
Only add `<CodeCoverageTargets>` and `<AdditionalOptions>` to the `.xcscheme` if the array that holds these elements inside the relevant `XCScheme+<type>.swift` files is not empty. 

This behaviour is in line with Xcode 11.3. The changes in a version controlled repository to the `.xcscheme` files result from Xcodeproj adding empty  `<CodeCoverageTargets>` and `<AdditionalOptions>` elements and Xcode subsequently removing them upon opening/using the scheme editing interface.

### Implementation 👩‍💻👨‍💻
- [X] Make sure `<CodeCoverageTargets>` and `<AdditionalOptions>` are not added unless `codeCoverageTargets` and `additionalOptions` is not empty respectively inside `XCScheme+TestAction.swift`.
- [X] Make sure `<AdditionalOptions>` is not added unless `additionalOptions` is not empty inside `XCScheme+LaunchAction.swift`.
