### PR TITLE
Fix `XCWorkspace` `Equatable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove `Tapestries` folder for tapestry 0.0.5 version https://github.com/tuist/XcodeProj/pull/523 by @fortmarek
 
+### Fixed
+
+- Fix `XCWorkspace` `Equatable` https://github.com/tuist/XcodeProj/pull/524 by @adamkhazi
+
 ## 7.8.0
 
 ### Added

--- a/Sources/XcodeProj/Workspace/XCWorkspace.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspace.swift
@@ -61,7 +61,7 @@ public final class XCWorkspace: Writable, Equatable {
 
     // MARK: - Equatable
 
-    public static func == (_: XCWorkspace, rhs: XCWorkspace) -> Bool {
-        return rhs.data == rhs.data
+    public static func == (lhs: XCWorkspace, rhs: XCWorkspace) -> Bool {
+        return lhs.data == rhs.data
     }
 }

--- a/Sources/XcodeProj/Workspace/XCWorkspaceData.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspaceData.swift
@@ -11,8 +11,8 @@ public final class XCWorkspaceData {
 }
 
 extension XCWorkspaceData: Equatable {
-    public static func == (_: XCWorkspaceData, rhs: XCWorkspaceData) -> Bool {
-        return rhs.children == rhs.children
+    public static func == (lhs: XCWorkspaceData, rhs: XCWorkspaceData) -> Bool {
+        return lhs.children == rhs.children
     }
 }
 

--- a/Tests/XcodeProjTests/Workspace/XCWorkspaceDataElementTests.swift
+++ b/Tests/XcodeProjTests/Workspace/XCWorkspaceDataElementTests.swift
@@ -21,4 +21,38 @@ final class XCWorkspaceDataElementTests: XCTestCase {
 
         XCTAssertEqual(element.location, location)
     }
+    
+    func test_equatable_when_unequal_data_elements() {
+        // Given
+        let location: XCWorkspaceDataElementLocationType = .absolute("/path/to/file.swift")
+        let file = XCWorkspaceDataFileRef(location: location)
+        let element = XCWorkspaceDataElement.file(file)
+        
+        // When
+        let firstWorkspace = XCWorkspace(data: .init(children: [element]))
+        let secondWorkspace = XCWorkspace(data: .init(children: []))
+
+        // Then
+        XCTAssertNotEqual(firstWorkspace, secondWorkspace)
+    }
+    
+    func test_equatable_when_equal_data_elements() {
+        // Given
+        let groupLocation: XCWorkspaceDataElementLocationType = .absolute("/path/to/group")
+        let group = XCWorkspaceDataGroup(location: groupLocation,
+                                         name: "group",
+                                         children: [])
+        let elementOne = XCWorkspaceDataElement.group(group)
+        
+        let fileLocation: XCWorkspaceDataElementLocationType = .absolute("/path/to/file.swift")
+        let file = XCWorkspaceDataFileRef(location: fileLocation)
+        let elementTwo = XCWorkspaceDataElement.file(file)
+        
+        // When
+        let firstWorkspace = XCWorkspace(data: .init(children: [elementOne, elementTwo]))
+        let secondWorkspace = XCWorkspace(data: .init(children: [elementOne, elementTwo]))
+
+        // Then
+        XCTAssertEqual(firstWorkspace, secondWorkspace)
+    }
 }

--- a/Tests/XcodeProjTests/Workspace/XCWorkspaceTests.swift
+++ b/Tests/XcodeProjTests/Workspace/XCWorkspaceTests.swift
@@ -21,4 +21,39 @@ final class XCWorkspaceIntegrationTests: XCTestCase {
         XCTAssertEqual(XCWorkspace().data.children.count, 1)
         XCTAssertEqual(XCWorkspace().data.children.first, .file(.init(location: .self(""))))
     }
+    
+    func test_equatable_emptyWorkspacesAreEqual() {
+        // When
+        let firstWorkspace = XCWorkspace(data: .init(children: []))
+        let secondWorkspace = XCWorkspace(data: .init(children: []))
+        
+        // Then
+        XCTAssertEqual(firstWorkspace, secondWorkspace)
+    }
+    
+    func test_equatable_unEqualWorkspacesAreNotEqual() {
+        // Given
+        let pathOne = fixturesPath() + "iOS/Project.xcodeproj/project.xcworkspace"
+        let pathTwo = fixturesPath() + "iOS/Workspace.xcworkspace"
+
+        // When
+        let firstWorkspace = try? XCWorkspace(path: pathOne)
+        let secondWorkspace = try? XCWorkspace(path: pathTwo)
+        
+        // Then
+        XCTAssertNotEqual(firstWorkspace, secondWorkspace)
+    }
+    
+    func test_equatable_equalWorkspacesAreEqual() {
+        // Given
+        let pathOne = fixturesPath() + "iOS/Workspace.xcworkspace"
+        let pathTwo = fixturesPath() + "iOS/Workspace.xcworkspace"
+
+        // When
+        let firstWorkspace = try? XCWorkspace(path: pathOne)
+        let secondWorkspace = try? XCWorkspace(path: pathTwo)
+        
+        // Then
+        XCTAssertEqual(firstWorkspace, secondWorkspace)
+    }
 }


### PR DESCRIPTION
# Short description 📝
Equatable on `XCWorkspace` was not implemented correctly. This meant that `WorkspaceOne == WorkspaceTwo` would always return `true`.

### Solution 📦
Compare both `lhs` and `rhs` `XCWorkspace` correctly now.

### Implementation 👩‍💻👨‍💻
- [X] Update the `Equatable` implementation
- [X] Write tests to check equatable on `XCWorkspace` works now in the failure and success cases
- [X] Update the change log
