### PR TITLE
Remove warning when compiling with Swift 5.2

### DIFF
--- a/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
@@ -88,8 +88,8 @@ extension XCWorkspaceDataElementLocationType: Equatable {
             return lhs == rhs
         case let (.self(lhs), .self(rhs)):
             return lhs == rhs
-        case let (.other(lhs), .other(rhs)):
-            return lhs.0 == rhs.0 && lhs.1 == rhs.1
+        case let (.other(lhs0, lhs1), .other(rhs0, rhs1)):
+            return lhs0 == rhs0 && lhs1 == rhs1
         default: return false
         }
     }


### PR DESCRIPTION
### Short description 📝
When compiling with Swift 5.2, the following warning is given in `XCWorkspaceDataElementLocationType`:

<img width="1346" alt="XCWorkspaceDataElementLocationType-Warnings" src="https://user-images.githubusercontent.com/1164565/77525207-51359200-6e91-11ea-8fc0-8c4f935f2966.png">

### Solution 📦
Declaring the tuple values instead of the tuple itself

This works fine as well when compiling with Swift 5.1.