### PR TITLE
XcodeProjCExt 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Changed
+
+- Point `XcodeProjCExt` to version 0.1.0 https://github.com/tuist/XcodeProj/pull/540 by @khoi
+
 ## 7.10.0
 
 ### Changed

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProjCExt",
         "state": {
           "branch": null,
-          "revision": "3873f83da1a2c99207af387972589c495785b93f",
-          "version": "7.8.0-1"
+          "revision": "21a510c225ff2bc83d5920a21d902af4b1e7e218",
+          "version": "0.1.0"
         }
       }
     ]


### PR DESCRIPTION
### Short description 📝
A simple update to the `Package.resolved` file. Somehow it was pointing to XcodeProjCExt version `7.8.0-1`.
