### PR TITLE
Added useTestSelectionWhitelist attribute to XCScheme.TestableReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 - Added `com.apple.product-type.xcframework` to `PBXProductType`. https://github.com/tuist/XcodeProj/pull/508 by @lakpa
 - Added `askForAppToLaunch` parameter to `LaunchAction` and `ProfileAction`. https://github.com/tuist/XcodeProj/pull/515 by @YutoMizutani
+- Added `useTestSelectionWhitelist` attribute to `XCScheme.TestableReference` https://github.com/tuist/xcodeproj/pull/516 by @basvankuijck.
 
 ## 7.5.0
 

--- a/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
@@ -8,6 +8,7 @@ extension XCScheme {
         public var skipped: Bool
         public var parallelizable: Bool
         public var randomExecutionOrdering: Bool
+        public var useTestSelectionWhitelist: Bool
         public var buildableReference: BuildableReference
         public var skippedTests: [SkippedTest]
 
@@ -17,17 +18,20 @@ extension XCScheme {
                     parallelizable: Bool = false,
                     randomExecutionOrdering: Bool = false,
                     buildableReference: BuildableReference,
-                    skippedTests: [SkippedTest] = []) {
+                    skippedTests: [SkippedTest] = [],
+                    useTestSelectionWhitelist: Bool = false) {
             self.skipped = skipped
             self.parallelizable = parallelizable
             self.randomExecutionOrdering = randomExecutionOrdering
             self.buildableReference = buildableReference
             self.skippedTests = skippedTests
+            self.useTestSelectionWhitelist = useTestSelectionWhitelist
         }
 
         init(element: AEXMLElement) throws {
             skipped = element.attributes["skipped"] == "YES"
             parallelizable = element.attributes["parallelizable"] == "YES"
+            useTestSelectionWhitelist = element.attributes["useTestSelectionWhitelist"] == "YES"
             randomExecutionOrdering = element.attributes["testExecutionOrdering"] == "random"
             buildableReference = try BuildableReference(element: element["BuildableReference"])
             if let skippedTests = element["SkippedTests"]["Test"].all, !skippedTests.isEmpty {
@@ -42,6 +46,7 @@ extension XCScheme {
         func xmlElement() -> AEXMLElement {
             var attributes: [String: String] = ["skipped": skipped.xmlString]
             attributes["parallelizable"] = parallelizable ? parallelizable.xmlString : nil
+            attributes["useTestSelectionWhitelist"] = useTestSelectionWhitelist ? useTestSelectionWhitelist.xmlString : nil
             attributes["testExecutionOrdering"] = randomExecutionOrdering ? "random" : nil
             let element = AEXMLElement(name: "TestableReference",
                                        value: nil,
@@ -63,6 +68,7 @@ extension XCScheme {
                 lhs.parallelizable == rhs.parallelizable &&
                 lhs.randomExecutionOrdering == rhs.randomExecutionOrdering &&
                 lhs.buildableReference == rhs.buildableReference &&
+                lhs.useTestSelectionWhitelist == rhs.useTestSelectionWhitelist &&
                 lhs.skippedTests == rhs.skippedTests
         }
     }

--- a/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
@@ -8,7 +8,7 @@ extension XCScheme {
         public var skipped: Bool
         public var parallelizable: Bool
         public var randomExecutionOrdering: Bool
-        public var useTestSelectionWhitelist: Bool
+        public var useTestSelectionWhitelist: Bool?
         public var buildableReference: BuildableReference
         public var skippedTests: [SkippedTest]
 
@@ -19,7 +19,7 @@ extension XCScheme {
                     randomExecutionOrdering: Bool = false,
                     buildableReference: BuildableReference,
                     skippedTests: [SkippedTest] = [],
-                    useTestSelectionWhitelist: Bool = false) {
+                    useTestSelectionWhitelist: Bool? = nil) {
             self.skipped = skipped
             self.parallelizable = parallelizable
             self.randomExecutionOrdering = randomExecutionOrdering
@@ -46,7 +46,9 @@ extension XCScheme {
         func xmlElement() -> AEXMLElement {
             var attributes: [String: String] = ["skipped": skipped.xmlString]
             attributes["parallelizable"] = parallelizable ? parallelizable.xmlString : nil
-            attributes["useTestSelectionWhitelist"] = useTestSelectionWhitelist ? useTestSelectionWhitelist.xmlString : nil
+            if let useTestSelectionWhitelist = useTestSelectionWhitelist {
+                attributes["useTestSelectionWhitelist"] = useTestSelectionWhitelist.xmlString
+            }
             attributes["testExecutionOrdering"] = randomExecutionOrdering ? "random" : nil
             let element = AEXMLElement(name: "TestableReference",
                                        value: nil,

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -48,6 +48,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         let subject = reference.xmlElement()
         XCTAssertNil(subject.attributes["parallelizable"])
         XCTAssertNil(subject.attributes["testExecutionOrdering"])
+        XCTAssertNil(subject.attributes["useTestSelectionWhitelist"])
     }
 
     func test_write_testableReferenceAttributesValues() {
@@ -61,11 +62,13 @@ final class XCSchemeIntegrationTests: XCTestCase {
                 buildableName: "",
                 blueprintName: ""
             ),
-            skippedTests: []
+            skippedTests: [],
+            useTestSelectionWhitelist: true
         )
         let subject = reference.xmlElement()
         XCTAssertEqual(subject.attributes["skipped"], "NO")
         XCTAssertEqual(subject.attributes["parallelizable"], "YES")
+        XCTAssertEqual(subject.attributes["useTestSelectionWhitelist"], "YES")
         XCTAssertEqual(subject.attributes["testExecutionOrdering"], "random")
     }
 
@@ -129,6 +132,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.testAction?.testables.first?.skipped, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.parallelizable, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.randomExecutionOrdering, false)
+        XCTAssertEqual(scheme.testAction?.testables.first?.useTestSelectionWhitelist, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableIdentifier, "primary")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.blueprintIdentifier, "23766C251EAA3484007A9026")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableName, "iOSTests.xctest")


### PR DESCRIPTION
Solves https://github.com/tuist/XcodeProj/pull/516

This PR contains [this one](https://github.com/tuist/XcodeProj/pull/516/) and makes the `useTestSelectionWhitelist` attribute optional. 