### PR TITLE
Add customLLDBInitFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Added
+
+- `LaunchAction.customLLDBInitFile` and `TestAction.customLLDBInitFile` attributes https://github.com/tuist/xcodeproj/pull/553 by @polac24
+
 ## 7.11.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `LaunchAction.customLLDBInitFile` and `TestAction.customLLDBInitFile` attributes https://github.com/tuist/xcodeproj/pull/553 by @polac24
+- Added `LaunchAction.customLLDBInitFile` and `TestAction.customLLDBInitFile` attributes https://github.com/tuist/xcodeproj/pull/553 by @polac24
 
 ## 7.11.1
 

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -66,6 +66,7 @@ extension XCScheme {
         public var launchAutomaticallySubstyle: String?
         // To enable the option in Xcode: defaults write com.apple.dt.Xcode IDEDebuggerFeatureSetting 12
         public var customLaunchCommand: String?
+        public var customLLDBInitFile: String?
 
         // MARK: - Init
 
@@ -101,7 +102,8 @@ extension XCScheme {
                     language: String? = nil,
                     region: String? = nil,
                     launchAutomaticallySubstyle: String? = nil,
-                    customLaunchCommand: String? = nil) {
+                    customLaunchCommand: String? = nil,
+                    customLLDBInitFile: String? = nil) {
             self.runnable = runnable
             self.macroExpansion = macroExpansion
             self.buildConfiguration = buildConfiguration
@@ -133,6 +135,7 @@ extension XCScheme {
             self.region = region
             self.launchAutomaticallySubstyle = launchAutomaticallySubstyle
             self.customLaunchCommand = customLaunchCommand
+            self.customLLDBInitFile = customLLDBInitFile
             super.init(preActions, postActions)
         }
 
@@ -205,6 +208,7 @@ extension XCScheme {
             region = element.attributes["region"]
             launchAutomaticallySubstyle = element.attributes["launchAutomaticallySubstyle"]
             customLaunchCommand = element.attributes["customLaunchCommand"]
+            customLLDBInitFile = element.attributes["customLLDBInitFile"]
 
             try super.init(element: element)
         }
@@ -306,6 +310,10 @@ extension XCScheme {
                 element.attributes["customLaunchCommand"] = customLaunchCommand
             }
 
+            if let customLLDBInitFile = customLLDBInitFile {
+                element.attributes["customLLDBInitFile"] = customLLDBInitFile
+            }
+
             if !additionalOptions.isEmpty {
                 let additionalOptionsElement = element.addChild(AEXMLElement(name: "AdditionalOptions"))
                 additionalOptions.forEach { additionalOption in
@@ -351,7 +359,8 @@ extension XCScheme {
                 language == rhs.language &&
                 region == rhs.region &&
                 launchAutomaticallySubstyle == rhs.launchAutomaticallySubstyle &&
-                customLaunchCommand == rhs.customLaunchCommand
+                customLaunchCommand == rhs.customLaunchCommand &&
+                customLLDBInitFile == rhs.customLLDBInitFile
         }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -36,6 +36,7 @@ extension XCScheme {
         public var region: String?
         public var systemAttachmentLifetime: AttachmentLifetime?
         public var userAttachmentLifetime: AttachmentLifetime?
+        public var customLLDBInitFile: String?
 
         // MARK: - Init
 
@@ -62,7 +63,8 @@ extension XCScheme {
                     language: String? = nil,
                     region: String? = nil,
                     systemAttachmentLifetime: AttachmentLifetime? = nil,
-                    userAttachmentLifetime: AttachmentLifetime? = nil) {
+                    userAttachmentLifetime: AttachmentLifetime? = nil,
+                    customLLDBInitFile: String? = nil) {
             self.buildConfiguration = buildConfiguration
             self.macroExpansion = macroExpansion
             self.testables = testables
@@ -85,6 +87,7 @@ extension XCScheme {
             self.region = region
             self.systemAttachmentLifetime = systemAttachmentLifetime
             self.userAttachmentLifetime = userAttachmentLifetime
+            self.customLLDBInitFile = customLLDBInitFile
             super.init(preActions, postActions)
         }
 
@@ -136,6 +139,7 @@ extension XCScheme {
                 .flatMap(AttachmentLifetime.init(rawValue:))
             userAttachmentLifetime = element.attributes["userAttachmentLifetime"]
                 .flatMap(AttachmentLifetime.init(rawValue:))
+            customLLDBInitFile = element.attributes["customLLDBInitFile"]
             try super.init(element: element)
         }
 
@@ -175,6 +179,9 @@ extension XCScheme {
             attributes["systemAttachmentLifetime"] = systemAttachmentLifetime?.rawValue
             if case .keepAlways? = userAttachmentLifetime {
                 attributes["userAttachmentLifetime"] = userAttachmentLifetime?.rawValue
+            }
+            if let customLLDBInitFile = customLLDBInitFile {
+                attributes["customLLDBInitFile"] = customLLDBInitFile
             }
 
             let element = AEXMLElement(name: "TestAction", value: nil, attributes: attributes)
@@ -246,7 +253,8 @@ extension XCScheme {
                 region == rhs.region &&
                 systemAttachmentLifetime == rhs.systemAttachmentLifetime &&
                 userAttachmentLifetime == rhs.userAttachmentLifetime &&
-                codeCoverageTargets == rhs.codeCoverageTargets
+                codeCoverageTargets == rhs.codeCoverageTargets &&
+                customLLDBInitFile == rhs.customLLDBInitFile
         }
     }
 }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -114,6 +114,34 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(subject, reconstructedSubject)
     }
 
+    func test_launchAction_customLLDBInitFile_serializingAndDeserializing() throws {
+        // Given
+        let lldbInitPath = "/Users/user/custom/.lldbinit"
+        let subject = XCScheme.LaunchAction(runnable: nil, buildConfiguration: "Debug", customLLDBInitFile: lldbInitPath)
+
+
+        // When
+        let element = subject.xmlElement()
+        let reconstructedSubject = try XCScheme.LaunchAction(element: element)
+
+        // Then
+        XCTAssertEqual(subject, reconstructedSubject)
+    }
+
+    func test_testAction_customLLDBInitFile_serializingAndDeserializing() throws {
+        // Given
+        let lldbInitPath = "/Users/user/custom/.lldbinit"
+        let subject = XCScheme.TestAction(buildConfiguration: "Debug", macroExpansion: nil, customLLDBInitFile: lldbInitPath)
+
+
+        // When
+        let element = subject.xmlElement()
+        let reconstructedSubject = try XCScheme.TestAction(element: element)
+
+        // Then
+        XCTAssertEqual(subject, reconstructedSubject)
+    }
+
     // MARK: - Private
 
     private func assert(scheme: XCScheme) {
@@ -277,6 +305,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertTrue(!launchCLIArgs.arguments.isEmpty)
         XCTAssertEqual(launchCLIArgs.arguments[0].name, "MyLaunchArgument")
         XCTAssertTrue(launchCLIArgs.arguments[0].enabled)
+        XCTAssertNil(scheme.launchAction?.customLLDBInitFile)
     }
 
     private func assert(minimalScheme scheme: XCScheme) {


### PR DESCRIPTION
### Short description 📝
Adding new scheme (Xcode 11.4+) attribute `customLLDBInitFile`. 
_That was never included in the Release Notes (but all future Xcode versions support that), [link](https://twitter.com/dmartincy/status/1228399375442903040)._

### Solution 📦
Test and Run actions can optionally specify `customLLDBInitFile` with a path to the per-project .lldbinit. 

### Implementation 👩‍💻👨‍💻
- [x] Add new optional properties for TestAction and RunAction
- [x] Write unit tests
