### PR TITLE
Support on-demand-install-capable application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+### Added
+- Support `on-demand-install-capable` application https://github.com/tuist/XcodeProj/pull/554 by @d-date
+
 ## 7.12.0
 
 ### Added

--- a/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
@@ -27,11 +27,12 @@ public enum PBXProductType: String, Decodable {
     case xcodeExtension = "com.apple.product-type.xcode-extension"
     case instrumentsPackage = "com.apple.product-type.instruments-package"
     case intentsServiceExtension = "com.apple.product-type.app-extension.intents-service"
+    case onDemandInstallCapableApplication = "com.apple.product-type.application.on-demand-install-capable"
 
     /// Returns the file extension for the given product type.
     public var fileExtension: String? {
         switch self {
-        case .application, .watchApp, .watch2App, .watch2AppContainer, .messagesApplication:
+        case .application, .watchApp, .watch2App, .watch2AppContainer, .messagesApplication, .onDemandInstallCapableApplication:
             return "app"
         case .framework, .staticFramework:
             return "framework"

--- a/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
@@ -90,4 +90,8 @@ final class PBXProductTypeTests: XCTestCase {
     func test_intentsServiceExtension_hasTheRightValue() {
         XCTAssertEqual(PBXProductType.intentsServiceExtension.rawValue, "com.apple.product-type.app-extension.intents-service")
     }
+
+    func test_appClip_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.onDemandInstallCapableApplication.rawValue, "com.apple.product-type.application.on-demand-install-capable")
+    }
 }


### PR DESCRIPTION

### Short description 📝
Supporting App clips application.

### Solution 📦
Added new case `onDemandInstallCapableApplication` into `PBXProductType`.

When I added App Clip target in Xcode, the diff below has occured.
```
D5380B5A24A347750069887E /* CafeClip */ = {
			isa = PBXNativeTarget;
			buildConfigurationList = D5380B9924A347760069887E /* Build configuration list for PBXNativeTarget "CafeClip" */;
			buildPhases = (
				D5380B5724A347750069887E /* Sources */,
				D5380B5824A347750069887E /* Frameworks */,
				D5380B5924A347750069887E /* Resources */,
			);
			buildRules = (
			);
			dependencies = (
			);
			name = CafeClip;
			productName = CafeClip;
			productReference = D5380B5B24A347750069887E /* CafeClip.app */;
			productType = "com.apple.product-type.application.on-demand-install-capable";
		};
```

And generated app with App Clip.
```
		D5380B8524A347760069887E /* CafeClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = D5380B5B24A347750069887E /* CafeClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
```