### PR TITLE
Generate references for product groups of nested projects

### DIFF
--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -49,6 +49,9 @@ final class ReferenceGenerator: ReferenceGenerating {
         if let productsGroup: PBXGroup = project.productsGroup {
             try generateGroupReferences(productsGroup, identifiers: identifiers)
         }
+        for embeddedProductGroup in project.projects.compactMap({ $0["ProductGroup"] as? PBXGroup }) {
+            try generateGroupReferences(embeddedProductGroup, identifiers: identifiers)
+        }
 
         // Project references
         try project.projectReferences.forEach { objectReferenceDict in


### PR DESCRIPTION
### Short description 📝

When you embed one project in another, Xcode creates (among other things) a `projectReferences` entry in the root PBXProject:

```
projectReferences = (
	{
		ProductGroup = DD594C4B24C7AAB500624E89 /* Products */;
		ProjectRef = DD594C4A24C7AAB500624E89 /* nested.xcodeproj */;
	},
);
```

The `ProductGroup` referenced here is a PBXGroup inside the pbxproj, but is _not_ inside the `mainGroup`. AFAICT, it's generated by Xcode when the project is embedded.

This group isn't within the main group, so it never has a permanent reference generated. Because of this, you can't create this data structure for Xcode and have to rely on Xcode adding it itself.

Example project that demonstrates this: [nested project demo.zip](https://github.com/tuist/XcodeProj/files/4956889/nested.project.demo.zip)

### Solution 📦

Immediately after main group references are generated, any PBXGroups referenced by the root `PBXProject.projects` dictionary have references generated.

TODO:

- [ ] Ensure that Xcode (11.5) likes these identifiers and doesn't mutate them when the project is opened.