### PR TITLE
.bundle `explicitFileType` corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+### Fixed
+- explicitFileType corrected for .bundle https://github.com/tuist/XcodeProj/pull/563 by @adamkhazi
+
 ## 7.14.0
 
 ### Fixed

--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -102,7 +102,7 @@ public struct Xcode {
         "avi": "video.avi",
         "bin": "archive.macbinary",
         "bmp": "image.bmp",
-        "bundle": "wrapper.plug-in",
+        "bundle": "wrapper.cfbundle",
         "c": "sourcecode.c.c",
         "c++": "sourcecode.cpp.cpp",
         "cc": "sourcecode.cpp.cpp",


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/562

### Short description 📝
Adding a bundle in Xcode 12 Beta 2 and Xcode 11.5 will add a .bundle reference under the Products folder. This reference in the `.pbxproj` will have `explicitFileType = wrapper.cfbundle`. Tuist will use `Xcode.swift` and set the value of `explicitFileType` to the wrong value.

### Solution 📦
Correct the value for `"bundle"` in `Xcode.swift` to use wrapper.cfbundle which mimics the behaviour of Xcode 12 Beta 2 and Xcode 11.5. 
