### PR TITLE
Upgrade tapestry and run github release.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Create a new release
+        uses: fortmarek/tapestry-action@0.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Changed
+
+- Simplify release process with new tapestry version https://github.com/tuist/XcodeProj/pull/564 by @fortmarek
+
 ## 7.14.0
 
 ### Fixed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,4 @@
 
 In this document you'll find all the necessary steps to release a new version of `xcodeproj`:
 
-1. Run `tapestry release version-number` (eg `tapestry release 7.1.0`) *(Install [tapestry](https://github.com/ackeecz/tapestry) and [tuist](https://github.com/tuist/tuist) if you don't have them installed already)*.
-2. Create a new release on [GitHub](https://github.com/tuist/XcodeProj) including the information from the last entry in the `CHANGELOG.md`.
-3. Attach `XcodeProj.framework.zip` to the GitHub release.
+1. Run `tapestry github-release version-number` (eg `tapestry github-release 7.1.0`) *(Install [tapestry](https://github.com/ackeecz/tapestry) and [tuist](https://github.com/tuist/tuist) if you don't have them installed already)*.

--- a/TapestryConfig.swift
+++ b/TapestryConfig.swift
@@ -1,14 +1,24 @@
-import PackageDescription
+import TapestryDescription
 
-let config = TapestryConfig(release: Release(actions: [.pre(.dependenciesCompatibility([.cocoapods, .spm(.all)])),
-                                                       .pre(tool: "tuist", arguments: ["generate"]),
-                                                       .pre(tool: "bundle", arguments: ["exec", "rake", "carthage_update_dependencies"]),
-                                                       .pre(tool: "bundle", arguments: ["exec", "rake", "release_check"]),
-                                                       .pre(.docsUpdate),
-                                                       .post(tool: "bundle", arguments: ["exec", "pod", "trunk", "push", "--allow-warnings", "--verbose"]),
-                                                       .post(tool: "bundle", arguments: ["exec", "rake", "archive_carthage"])],
-                                             add: ["README.md",
-                                                   "xcodeproj.podspec",
-                                                   "CHANGELOG.md"],
-                                             commitMessage: "Version \(Argument.version)",
-                                             push: true))
+let config = TapestryConfig(
+    release: Release(
+        actions:
+        [
+            .pre(.dependenciesCompatibility([.cocoapods, .spm(.all)])),
+            .pre(tool: "tuist", arguments: ["generate"]),
+            .pre(tool: "bundle", arguments: ["exec", "rake", "carthage_update_dependencies"]),
+            .pre(tool: "bundle", arguments: ["exec", "rake", "release_check"]),
+            .pre(.docsUpdate),
+            .post(tool: "bundle", arguments: ["exec", "pod", "trunk", "push", "--allow-warnings", "--verbose"]),
+            .post(tool: "bundle", arguments: ["exec", "rake", "archive_carthage"]),
+            .post(.githubRelease(owner: "tuist", repository: "xcodeproj", assetPaths: ["XcodeProj.framework.zip"]))
+        ],
+        add: [
+            "README.md",
+            "xcodeproj.podspec",
+            "CHANGELOG.md"
+        ],
+        commitMessage: "Version \(Argument.version)",
+        push: true
+    )
+)


### PR DESCRIPTION
### Short description 📝

To further simplify release process, new `tapestry` version has support for creating new github release along with uploading github assets. This means that simply running `tapestry github-release 0.0.6` is all you need to do ✨ 

### Implementation 👩‍💻👨‍💻

- [x] Add tapestry 
- [ ] Try it out in the next release 😛 
