### PR TITLE
Faster path operations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,11 +12,20 @@
       },
       {
         "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit",
+        "repositoryURL": "https://github.com/michaeleisel/PathKit",
         "state": {
-          "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "branch": "master",
+          "revision": "f5f8bc3c31a787e639b545205309c661c894d8e0",
+          "version": null
+        }
+      },
+      {
+        "package": "PathKitCExt",
+        "repositoryURL": "https://github.com/michaeleisel/PathKitCExt.git",
+        "state": {
+          "branch": "master",
+          "revision": "766dbfbc530618278be879a295c5b417c799541f",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/tadija/AEXML", .upToNextMinor(from: "4.4.0")),
-        .package(url: "https://github.com/kylef/PathKit", .upToNextMinor(from: "1.0.0")),
+        .package(url: "https://github.com/michaeleisel/PathKit", .branch("master")),
     ],
     targets: [
         .target(name: "XcodeProj",


### PR DESCRIPTION
There are inefficiencies in PathKit that I tried to fix in master (rough sketch at https://github.com/kylef/PathKit/pull/72), but that project is basically no longer maintained. So, here we just use my fork directly. I also want to move Xcodeproj to using this version as well. Not only does it deliver nice perf wins, but I will be maintaining my fork for others to make changes for the foreseeable future. It adds a new dep, PathKitCExt, for C/C++-level changes. It's worked well for us at Spotify for the past several months. This is the diff (including one commit that was made after 1.0.0 was released) - https://github.com/kylef/PathKit/compare/73f8e9dca9b7a3078cb79128217dc8f2e585a511...michaeleisel:master