### PR TITLE
Add support for runOncePerArchitecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - explicitFileType corrected for .bundle https://github.com/tuist/XcodeProj/pull/563 by @adamkhazi
+### Added
+- Added `runOncePerArchitecture` attribute to `PBXBuildRule` https://github.com/tuist/XcodeProj/pull/570 by @sascha
 
 ## 7.14.0
 

--- a/Sources/XcodeProj/Objects/BuildPhase/PBXBuildRule.swift
+++ b/Sources/XcodeProj/Objects/BuildPhase/PBXBuildRule.swift
@@ -31,6 +31,9 @@ public final class PBXBuildRule: PBXObject {
     /// Element script.
     public var script: String?
 
+    /// Element run once per architecture.
+    public var runOncePerArchitecture: Bool?
+
     // MARK: - Init
 
     public init(compilerSpec: String,
@@ -41,7 +44,8 @@ public final class PBXBuildRule: PBXObject {
                 outputFiles: [String] = [],
                 inputFiles: [String]? = nil,
                 outputFilesCompilerFlags: [String]? = nil,
-                script: String? = nil) {
+                script: String? = nil,
+                runOncePerArchitecture: Bool? = nil) {
         self.compilerSpec = compilerSpec
         self.filePatterns = filePatterns
         self.fileType = fileType
@@ -51,6 +55,7 @@ public final class PBXBuildRule: PBXObject {
         self.inputFiles = inputFiles
         self.outputFilesCompilerFlags = outputFilesCompilerFlags
         self.script = script
+        self.runOncePerArchitecture = runOncePerArchitecture
         super.init()
     }
 
@@ -66,6 +71,7 @@ public final class PBXBuildRule: PBXObject {
         case inputFiles
         case outputFilesCompilerFlags
         case script
+        case runOncePerArchitecture
     }
 
     public required init(from decoder: Decoder) throws {
@@ -79,6 +85,7 @@ public final class PBXBuildRule: PBXObject {
         inputFiles = try container.decodeIfPresent(.inputFiles)
         outputFilesCompilerFlags = try container.decodeIfPresent(.outputFilesCompilerFlags)
         script = try container.decodeIfPresent(.script)
+        runOncePerArchitecture = try container.decodeIntBoolIfPresent(.runOncePerArchitecture)
         try super.init(from: decoder)
     }
 }
@@ -109,6 +116,9 @@ extension PBXBuildRule: PlistSerializable {
         }
         if let script = script {
             dictionary["script"] = .string(CommentedString(script))
+        }
+        if let runOncePerArchitecture = runOncePerArchitecture {
+            dictionary["runOncePerArchitecture"] = .string(CommentedString("\(runOncePerArchitecture.int)"))
         }
         return (key: CommentedString(reference, comment: PBXBuildRule.isa),
                 value: .dictionary(dictionary))

--- a/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
@@ -46,6 +46,7 @@ extension PBXBuildRule {
         if outputFiles != rhs.outputFiles { return false }
         if outputFilesCompilerFlags != rhs.outputFilesCompilerFlags { return false }
         if script != rhs.script { return false }
+        if runOncePerArchitecture != rhs.runOncePerArchitecture { return false }
         return super.isEqual(to: rhs)
     }
 }

--- a/Tests/XcodeProjTests/Objects/BuildPhase/PBXBuildRuleTests.swift
+++ b/Tests/XcodeProjTests/Objects/BuildPhase/PBXBuildRuleTests.swift
@@ -14,7 +14,8 @@ final class PBXBuildRuleTests: XCTestCase {
                                name: "rule",
                                outputFiles: ["a", "b"],
                                outputFilesCompilerFlags: ["-1", "-2"],
-                               script: "script")
+                               script: "script",
+                               runOncePerArchitecture: false)
     }
 
     func test_init_initializesTheBuildRuleWithTheRightAttributes() {
@@ -26,6 +27,7 @@ final class PBXBuildRuleTests: XCTestCase {
         XCTAssertEqual(subject.outputFiles, ["a", "b"])
         XCTAssertEqual(subject.outputFilesCompilerFlags ?? [], ["-1", "-2"])
         XCTAssertEqual(subject.script, "script")
+        XCTAssertEqual(subject.runOncePerArchitecture, false)
     }
 
     func test_isa_returnsTheCorrectValue() {
@@ -40,7 +42,8 @@ final class PBXBuildRuleTests: XCTestCase {
                                    name: "rule",
                                    outputFiles: ["a", "b"],
                                    outputFilesCompilerFlags: ["-1", "-2"],
-                                   script: "script")
+                                   script: "script",
+                                   runOncePerArchitecture: false)
         XCTAssertEqual(subject, another)
     }
 }


### PR DESCRIPTION
This pull request adds support for the `runOncePerArchitecture` flag to `PBXBuildRule`. More details about the flag are available at https://github.com/CocoaPods/Xcodeproj/issues/713.