### PR TITLE
Add support for alwaysOutOfDate flag in PBXShellScriptBuildPhase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - explicitFileType corrected for .bundle https://github.com/tuist/XcodeProj/pull/563 by @adamkhazi
 
+### Added
+- Add support for alwaysOutOfDate flag in PBXShellScriptBuildPhase https://github.com/tuist/XcodeProj/pull/572 by @marciniwanicki
+
 ## 7.14.0
 
 ### Fixed

--- a/Sources/XcodeProj/Objects/BuildPhase/PBXShellScriptBuildPhase.swift
+++ b/Sources/XcodeProj/Objects/BuildPhase/PBXShellScriptBuildPhase.swift
@@ -22,6 +22,9 @@ public final class PBXShellScriptBuildPhase: PBXBuildPhase {
     /// Show environment variables in the logs.
     public var showEnvVarsInLog: Bool
 
+    /// Force script to run in all incremental builds.
+    public var alwaysOutOfDate: Bool
+
     override public var buildPhase: BuildPhase {
         .runScript
     }
@@ -39,6 +42,7 @@ public final class PBXShellScriptBuildPhase: PBXBuildPhase {
     ///   - shellPath: shell path.
     ///   - shellScript: shell script.
     ///   - buildActionMask: build action mask.
+    ///   - alwaysOutOfDate: always out of date.
     public init(files: [PBXBuildFile] = [],
                 name: String? = nil,
                 inputPaths: [String] = [],
@@ -49,13 +53,15 @@ public final class PBXShellScriptBuildPhase: PBXBuildPhase {
                 shellScript: String? = nil,
                 buildActionMask: UInt = defaultBuildActionMask,
                 runOnlyForDeploymentPostprocessing: Bool = false,
-                showEnvVarsInLog: Bool = true) {
+                showEnvVarsInLog: Bool = true,
+                alwaysOutOfDate: Bool = false) {
         self.name = name
         self.inputPaths = inputPaths
         self.outputPaths = outputPaths
         self.shellPath = shellPath
         self.shellScript = shellScript
         self.showEnvVarsInLog = showEnvVarsInLog
+        self.alwaysOutOfDate = alwaysOutOfDate
         super.init(files: files,
                    inputFileListPaths: inputFileListPaths,
                    outputFileListPaths: outputFileListPaths,
@@ -72,6 +78,7 @@ public final class PBXShellScriptBuildPhase: PBXBuildPhase {
         case shellPath
         case shellScript
         case showEnvVarsInLog
+        case alwaysOutOfDate
     }
 
     public required init(from decoder: Decoder) throws {
@@ -82,6 +89,7 @@ public final class PBXShellScriptBuildPhase: PBXBuildPhase {
         shellPath = try container.decodeIfPresent(.shellPath)
         shellScript = try container.decodeIfPresent(.shellScript)
         showEnvVarsInLog = try container.decodeIntBoolIfPresent(.showEnvVarsInLog) ?? true
+        alwaysOutOfDate = try container.decodeIntBoolIfPresent(.alwaysOutOfDate) ?? false
         try super.init(from: decoder)
     }
 }
@@ -106,6 +114,10 @@ extension PBXShellScriptBuildPhase: PlistSerializable {
         if !showEnvVarsInLog {
             // Xcode only writes this key if it's set to false; default is true and is omitted
             dictionary["showEnvVarsInLog"] = .string(CommentedString("\(showEnvVarsInLog.int)"))
+        }
+        if alwaysOutOfDate {
+            // Xcode only write this key if it's set to true; default is false and it omitted
+            dictionary["alwaysOutOfDate"] = .string(CommentedString("\(alwaysOutOfDate.int)"))
         }
         return (key: CommentedString(reference, comment: name ?? "ShellScript"), value: .dictionary(dictionary))
     }

--- a/Sources/XcodeProj/Objects/BuildPhase/PBXShellScriptBuildPhase.swift
+++ b/Sources/XcodeProj/Objects/BuildPhase/PBXShellScriptBuildPhase.swift
@@ -116,7 +116,7 @@ extension PBXShellScriptBuildPhase: PlistSerializable {
             dictionary["showEnvVarsInLog"] = .string(CommentedString("\(showEnvVarsInLog.int)"))
         }
         if alwaysOutOfDate {
-            // Xcode only write this key if it's set to true; default is false and it omitted
+            // Xcode only write this key if it's set to true; default is false and is omitted
             dictionary["alwaysOutOfDate"] = .string(CommentedString("\(alwaysOutOfDate.int)"))
         }
         return (key: CommentedString(reference, comment: name ?? "ShellScript"), value: .dictionary(dictionary))

--- a/Tests/XcodeProjTests/Objects/BuildPhase/PBXShellScriptBuildPhaseTests.swift
+++ b/Tests/XcodeProjTests/Objects/BuildPhase/PBXShellScriptBuildPhaseTests.swift
@@ -24,6 +24,28 @@ final class PBXShellScriptBuildPhaseTests: XCTestCase {
         }
     }
 
+    func test_write_alwaysOutOfDate() throws {
+        // Given
+        let alwaysOutOfDateNotPresent = PBXShellScriptBuildPhase()
+        let alwaysOutOfDateFalse = PBXShellScriptBuildPhase(alwaysOutOfDate: false)
+        let alwaysOutOfDateTrue = PBXShellScriptBuildPhase(alwaysOutOfDate: true)
+        let proj = PBXProj.fixture()
+
+        // When
+        guard
+            case let .dictionary(valuesWhenNotPresent) = try alwaysOutOfDateNotPresent.plistKeyAndValue(proj: proj, reference: "ref").value,
+            case let .dictionary(valuesWhenFalse) = try alwaysOutOfDateFalse.plistKeyAndValue(proj: proj, reference: "ref").value,
+            case let .dictionary(valuesWhenTrue) = try alwaysOutOfDateTrue.plistKeyAndValue(proj: proj, reference: "ref").value else {
+            XCTFail("Plist should contain dictionary")
+            return
+        }
+
+        // Then
+        XCTAssertFalse(valuesWhenNotPresent.keys.contains("alwaysOutOfDate"))
+        XCTAssertFalse(valuesWhenFalse.keys.contains("alwaysOutOfDate"))
+        XCTAssertEqual(valuesWhenTrue["alwaysOutOfDate"], "1")
+    }
+
     private func testDictionary() -> [String: Any] {
         [
             "files": ["files"],


### PR DESCRIPTION
### Short description 📝
Added support for `alwaysOutOfDate` flag in `PBXShellScriptBuildPhase` available in Xcode12. It's a great feature which enables better integration with external build automation tools like Gradle, Make, and many others.

![alwaysOutOfDate](https://user-images.githubusercontent.com/946649/95020502-87837380-0663-11eb-9606-80b442a3fbb6.png)
The pbxproj file does not contain the property when the attribute is checked (default value) in the Xcode UI.


