### PR TITLE
Add support for StoreKitConfigurationFileReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 - Add support for alwaysOutOfDate flag in PBXShellScriptBuildPhase https://github.com/tuist/XcodeProj/pull/572 by @marciniwanicki
 - Added `PBXShellScriptBuildPhase.dependencyFile` attribute https://github.com/tuist/xcodeproj/pull/568 by @polac24
+- Add support for StoreKitConfigurationFileReference in LaunchAction of XCScheme https://github.com/tuist/XcodeProj/pull/573
 
 ## 7.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Added
 - Add support for alwaysOutOfDate flag in PBXShellScriptBuildPhase https://github.com/tuist/XcodeProj/pull/572 by @marciniwanicki
 - Added `PBXShellScriptBuildPhase.dependencyFile` attribute https://github.com/tuist/xcodeproj/pull/568 by @polac24
-- Add support for StoreKitConfigurationFileReference in LaunchAction of XCScheme https://github.com/tuist/XcodeProj/pull/573
+- Add support for StoreKitConfigurationFileReference in LaunchAction of XCScheme https://github.com/tuist/XcodeProj/pull/573 by @jcolicchio
 
 ## 7.14.0
 

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -194,6 +194,9 @@
          identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
          referenceType = "1">
       </LocationScenarioReference>
+      <StoreKitConfigurationFileReference
+        identifier = "../../Configuration.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
@@ -52,6 +52,7 @@ let attributesOrder: [String: [String]] = [
         "enableGPUFrameCaptureMode",
         "enableGPUValidationMode",
         "allowLocationSimulation",
+        "storeKitConfigurationFileReference",
     ],
     "ProfileAction": [
         "buildConfiguration",

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -64,6 +64,7 @@ extension XCScheme {
         public var language: String?
         public var region: String?
         public var launchAutomaticallySubstyle: String?
+        public var storeKitConfigurationFileReference: StoreKitConfigurationFileReference?
         // To enable the option in Xcode: defaults write com.apple.dt.Xcode IDEDebuggerFeatureSetting 12
         public var customLaunchCommand: String?
         public var customLLDBInitFile: String?
@@ -102,6 +103,7 @@ extension XCScheme {
                     language: String? = nil,
                     region: String? = nil,
                     launchAutomaticallySubstyle: String? = nil,
+                    storeKitConfigurationFileReference: StoreKitConfigurationFileReference? = nil,
                     customLaunchCommand: String? = nil,
                     customLLDBInitFile: String? = nil) {
             self.runnable = runnable
@@ -134,6 +136,7 @@ extension XCScheme {
             self.language = language
             self.region = region
             self.launchAutomaticallySubstyle = launchAutomaticallySubstyle
+            self.storeKitConfigurationFileReference = storeKitConfigurationFileReference
             self.customLaunchCommand = customLaunchCommand
             self.customLLDBInitFile = customLLDBInitFile
             super.init(preActions, postActions)
@@ -207,6 +210,12 @@ extension XCScheme {
             language = element.attributes["language"]
             region = element.attributes["region"]
             launchAutomaticallySubstyle = element.attributes["launchAutomaticallySubstyle"]
+
+            if element["StoreKitConfigurationFileReference"].all?.first != nil {
+                storeKitConfigurationFileReference = try StoreKitConfigurationFileReference(element: element["StoreKitConfigurationFileReference"])
+            } else {
+                storeKitConfigurationFileReference = nil
+            }
             customLaunchCommand = element.attributes["customLaunchCommand"]
             customLLDBInitFile = element.attributes["customLLDBInitFile"]
 
@@ -306,6 +315,10 @@ extension XCScheme {
                 element.attributes["launchAutomaticallySubstyle"] = launchAutomaticallySubstyle
             }
 
+            if let storeKitConfigurationFileReference = storeKitConfigurationFileReference {
+                element.addChild(storeKitConfigurationFileReference.xmlElement())
+            }
+
             if let customLaunchCommand = customLaunchCommand {
                 element.attributes["customLaunchCommand"] = customLaunchCommand
             }
@@ -359,6 +372,7 @@ extension XCScheme {
                 language == rhs.language &&
                 region == rhs.region &&
                 launchAutomaticallySubstyle == rhs.launchAutomaticallySubstyle &&
+                storeKitConfigurationFileReference == rhs.storeKitConfigurationFileReference &&
                 customLaunchCommand == rhs.customLaunchCommand &&
                 customLLDBInitFile == rhs.customLLDBInitFile
         }

--- a/Sources/XcodeProj/Scheme/XCScheme+StoreKitConfigurationFileReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+StoreKitConfigurationFileReference.swift
@@ -1,0 +1,43 @@
+//
+//  XCScheme+StoreKitConfigurationFileReference.swift
+//  XcodeProj
+//
+//  Created by Joseph Colicchio on 10/7/20.
+//
+
+import AEXML
+import Foundation
+
+extension XCScheme {
+    public final class StoreKitConfigurationFileReference: Equatable {
+        // MARK: - Attributes
+
+        public var identifier: String
+
+        // MARK: - Init
+
+        public init(identifier: String) {
+            self.identifier = identifier
+        }
+
+        init(element: AEXMLElement) throws {
+            identifier = element.attributes["identifier"]!
+        }
+
+        // MARK: - XML
+
+        func xmlElement() -> AEXMLElement {
+            AEXMLElement(name: "StoreKitConfigurationFileReference",
+                         value: nil,
+                         attributes: [
+                             "identifier": identifier,
+                         ])
+        }
+
+        // MARK: - Equatable
+
+        public static func == (lhs: StoreKitConfigurationFileReference, rhs: StoreKitConfigurationFileReference) -> Bool {
+            lhs.identifier == rhs.identifier
+        }
+    }
+}

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -305,6 +305,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.testAction?.enableUBSanitizer, false)
         XCTAssertEqual(scheme.testAction?.disableMainThreadChecker, false)
         XCTAssertEqual(scheme.testAction?.additionalOptions.isEmpty, true)
+        XCTAssertEqual(scheme.launchAction?.storeKitConfigurationFileReference?.identifier, "../../Configuration.storekit")
 
         let testEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.testAction?.environmentVariables)
         XCTAssertEqual(testEnvironmentVariables.count, 1)
@@ -469,6 +470,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.disableMainThreadChecker, false)
         XCTAssertEqual(scheme.launchAction?.stopOnEveryMainThreadCheckerIssue, false)
         XCTAssertEqual(scheme.launchAction?.additionalOptions.isEmpty, true)
+        XCTAssertNil(scheme.launchAction?.storeKitConfigurationFileReference)
 
         let launchEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.launchAction?.environmentVariables)
         XCTAssertEqual(launchEnvironmentVariables.count, 1)

--- a/XcodeProj_Carthage.xcodeproj/project.pbxproj
+++ b/XcodeProj_Carthage.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		B07C3C11C0C5E9123C5D9D15 /* PBXObjectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE4FB9142BF91F6E449998C /* PBXObjectParser.swift */; };
 		B7703E87F0E986D0BECC6C92 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8485AE4255BB935C7B7FE93C /* PBXResourcesBuildPhase.swift */; };
 		B972348A969282D604A5C325 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5C2732048660AC71431D9C /* XCScheme+Runnable.swift */; };
+		B9B6EEA9252EBD4600BAD611 /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B6EEA8252EBD4600BAD611 /* XCScheme+StoreKitConfigurationFileReference.swift */; };
 		BBA09A7C8D3D9697C10F300B /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C46C4D934731EA4A844FD3 /* PBXLegacyTarget.swift */; };
 		BD65503EF698EE4EAF11892C /* Path+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE041A9A60D18302045BA2AE /* Path+Extras.swift */; };
 		BD7A3EBFD6C9D1AA78E6E822 /* Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F663AC6487521F684ED182 /* Decoders.swift */; };
@@ -192,6 +193,7 @@
 		B50CD65FDAA9B3F4269F4AAF /* PBXBuildRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildRule.swift; sourceTree = "<group>"; };
 		B837566EDF23D002AC881D07 /* XCScheme+CommandLineArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+CommandLineArguments.swift"; sourceTree = "<group>"; };
 		B92DC66EE80F3D7611319ACC /* XCWorkspaceDataFileRef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataFileRef.swift; sourceTree = "<group>"; };
+		B9B6EEA8252EBD4600BAD611 /* XCScheme+StoreKitConfigurationFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+StoreKitConfigurationFileReference.swift"; sourceTree = "<group>"; };
 		BFFE462CBB08512CB108E356 /* XCScheme+AnalyzeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+AnalyzeAction.swift"; sourceTree = "<group>"; };
 		C3FE679A53603AE3FE43462F /* XCScheme+ExecutionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ExecutionAction.swift"; sourceTree = "<group>"; };
 		C6F7AC32AFFBEA9741906F2B /* PBXVariantGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXVariantGroup.swift; sourceTree = "<group>"; };
@@ -348,6 +350,7 @@
 				0BFCA27253AECAC6A2EF5E66 /* XCScheme+RemoteRunnable.swift */,
 				1D5C2732048660AC71431D9C /* XCScheme+Runnable.swift */,
 				694034B4B7C9DF231B007A84 /* XCScheme+SerialAction.swift */,
+				B9B6EEA8252EBD4600BAD611 /* XCScheme+StoreKitConfigurationFileReference.swift */,
 				0AE91C6982618C1EDDAAD596 /* XCScheme+TestableReference.swift */,
 				161E967D0979EF34C7DF6348 /* XCScheme+TestAction.swift */,
 				7DFDD2E86D3F0ADE3502A29A /* XCScheme+TestItem.swift */,
@@ -548,8 +551,6 @@
 		223DB5C7FA35E8FD593C4040 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 477F800A701B31C60A80EACC /* Build configuration list for PBXProject "XcodeProj_Carthage" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -668,6 +669,7 @@
 				735E1C6466FF56969767BAA0 /* XCScheme+CommandLineArguments.swift in Sources */,
 				7C3555C09B170AEA2D56E8F2 /* XCScheme+EnvironmentVariable.swift in Sources */,
 				AC49ED6F358FFBF504A3D0AE /* XCScheme+ExecutionAction.swift in Sources */,
+				B9B6EEA9252EBD4600BAD611 /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */,
 				147157016720CE9BC5943AF2 /* XCScheme+LaunchAction.swift in Sources */,
 				69CBD38E1B96198049A02795 /* XCScheme+LocationScenarioReference.swift in Sources */,
 				1270ABC0B6133C84F57A8D3F /* XCScheme+PathRunnable.swift in Sources */,


### PR DESCRIPTION
Addresses #574
Will allow XcodeGen to specify a StoreKit configuration file in the scheme

### Short description 📝
Adds a new XML element, `StoreKitConfigurationFileReference`, to the `LaunchAction`

### Solution 📦
Created `StoreKitConfigurationFileReference` and added it to `LaunchAction` following a similar pattern to `locationScenarioReference`

### Implementation 👩‍💻👨‍💻

- [ ] Added class `StoreKitConfigurationFileReference` mirroring structure of `LocationScenarioReference` 
- [ ] Added property to `LaunchAction` mirroring all usages and initializations of `locationScenarioReference`
- [ ] Updated example scheme and ran tests to make sure it still parses