### PR TITLE
podspec: add module_name

### DIFF
--- a/xcodeproj.podspec
+++ b/xcodeproj.podspec
@@ -13,6 +13,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/**/*.{swift}"
 
+  s.module_name = 'XcodeProj'
+
   s.dependency "XcodeProjCExt", "0.1.0"
   s.dependency "PathKit", "~> 1.0.0"
   s.dependency "AEXML", "~> 4.4.0"


### PR DESCRIPTION
The package was renamed to `XcodeProj` from `xcodeproj` in #398 but this change was not applied to the podspec. Seems like [`module_name`](https://guides.cocoapods.org/syntax/podspec.html#module_name) is the best fit for this.

@pepibumur 