### PR TITLE
Fix build warning

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXObjects.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXObjects.swift
@@ -138,7 +138,7 @@ class PBXObjects: Equatable {
     ///   - objects: project objects
     init(objects: [PBXObject] = []) {
         objects.forEach {
-            _ = self.add(object: $0)
+            self.add(object: $0)
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/YYY

### Short description 📝
Fix warning message `Using '_' to ignore the result of a Void-returning function is redundant` when building the project as a dependency.

### Solution 📦
Remove `_ =` from the code.
