### PR TITLE
[Fix] JSON decoder not properly decoding `defaultConfigurationIsVisible` in some projects

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
           "branch": null,
-          "revision": "502c4d43a6cc9c395d19111e09dc62ad834977b5",
-          "version": "4.6.0"
+          "revision": "8623e73b193386909566a9ca20203e33a09af142",
+          "version": "4.5.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
           "branch": null,
-          "revision": "8623e73b193386909566a9ca20203e33a09af142",
-          "version": "4.5.0"
+          "revision": "502c4d43a6cc9c395d19111e09dc62ad834977b5",
+          "version": "4.6.0"
         }
       },
       {

--- a/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
+++ b/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
@@ -12,9 +12,9 @@ extension KeyedDecodingContainer {
     func decodeIntIfPresent(_ key: KeyedDecodingContainer.Key) throws -> UInt? {
         if let string: String = try? decodeIfPresent(key) {
             return UInt(string)
-        } else if let int: Int = try? decodeIfPresent(key) {
-            return UInt(int)
-        } else if let bool: Bool = try? decodeIfPresent(key) {
+        } else if let bool: Bool = try decodeIfPresent(key) {
+            // don't `try?` here in case key _does_ exist but isn't an expected type
+            // ie. not a string/bool
             return bool ? 0 : 1
         } else {
             return nil

--- a/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
+++ b/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
@@ -10,10 +10,13 @@ extension KeyedDecodingContainer {
     }
 
     func decodeIntIfPresent(_ key: KeyedDecodingContainer.Key) throws -> UInt? {
-        guard let string: String = try decodeIfPresent(key) else {
+        if let string: String = try? decodeIfPresent(key) {
+            return UInt(string)
+        } else if let int: Int = try? decodeIfPresent(key) {
+            return UInt(int)
+        } else {
             return nil
         }
-        return UInt(string)
     }
 
     func decodeIntBool(_ key: KeyedDecodingContainer.Key) throws -> Bool {

--- a/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
+++ b/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
@@ -15,7 +15,7 @@ extension KeyedDecodingContainer {
         } else if let int: Int = try? decodeIfPresent(key) {
             return UInt(int)
         } else if let bool: Bool = try? decodeIfPresent(key) {
-            return UInt(bool)
+            return bool ? 0 : 1
         } else {
             return nil
         }

--- a/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
+++ b/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
@@ -14,6 +14,8 @@ extension KeyedDecodingContainer {
             return UInt(string)
         } else if let int: Int = try? decodeIfPresent(key) {
             return UInt(int)
+        } else if let bool: Bool = try? decodeIfPresent(key) {
+            return UInt(bool)
         } else {
             return nil
         }


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/592

### Short description 📝
This PR should fix decoding `defaultConfigurationIsVisible` (and other booleans) of multiple types of encoding (ie. plist encoded which encodes to a proper boolean or a normal pbxproj which encodes into a string).

### Solution 📦
Try decoding it as a string like before, then an int, then a boolean and finally return nil if it cannot. Notice each try is marked with `try?` so it doesn't actually throw in case there is a type mismatch.

### Implementation 👩‍💻👨‍💻

- [X] Fix decoder process for booleans
- [X] Test out in both pbxproj formats
