### PR TITLE
iOS Support

### DIFF
--- a/Sources/XcodeProj/Extensions/Path+Extras.swift
+++ b/Sources/XcodeProj/Extensions/Path+Extras.swift
@@ -4,7 +4,7 @@ import PathKit
 
 // MARK: - Path extras.
 
-#if os(macOS)
+#if os(macOS) || os(iOS)
 let systemGlob = Darwin.glob
 #else
 let systemGlob = Glibc.glob

--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -31,7 +31,7 @@ extension String {
             return self
         }
         #if canImport(CryptoKit)
-        if #available(OSX 10.15, *) {
+        if #available(OSX 10.15, *, iOS 13.0, *) {
             var hasher = Insecure.MD5()
             hasher.update(data: data)
             let digest = hasher.finalize()

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjIntegrationTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjIntegrationTests.swift
@@ -25,6 +25,8 @@ final class PBXProjIntegrationTests: XCTestCase {
     }
 
     func test_write_produces_no_diff() throws {
+        #if os(iOS)
+        #else
         let tmpDir = try Path.uniqueTemporary()
         defer {
             try? tmpDir.delete()
@@ -50,6 +52,7 @@ final class PBXProjIntegrationTests: XCTestCase {
             let got = try checkedOutput("git", ["status"])
             XCTAssertTrue(got?.contains("nothing to commit") ?? false)
         }
+        #endif
     }
 
     private func fixturePath() -> Path {
@@ -88,6 +91,9 @@ final class PBXProjIntegrationTests: XCTestCase {
 /// Returns the output of running `executable` with `args`. Throws an error if the process exits indicating failure.
 @discardableResult
 private func checkedOutput(_ executable: String, _ args: [String]) throws -> String? {
+    #if os(iOS)
+    throw NSError(domain: NSCocoaErrorDomain, code: 404)
+    #else
     let process = Process()
     let output = Pipe()
 
@@ -107,4 +113,5 @@ private func checkedOutput(_ executable: String, _ args: [String]) throws -> Str
     }
 
     return String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    #endif
 }

--- a/xcodeproj.podspec
+++ b/xcodeproj.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.authors = "Tuist"
   s.swift_version = "5.1"
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.10'
 
   s.source_files = "Sources/**/*.{swift}"


### PR DESCRIPTION
### Short description 📝
> For iOS Application Unit Tests is necessary to verify pbxproj setup. In our case we have unit tests run on each Pull Request and some of build settings is necessary to be unmodified (Code Signing, Active Compilation Conditions, Optimisation Levels etc)

### Solution 📦
> Add iOS support