### PR TITLE
[#596][#597] Fix `decodeIntIfPresent` and related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - JSON decoder not properly decoding `defaultConfigurationIsVisible` in some projects [#593](https://github.com/tuist/XcodeProj/pull/593) by [@tjwio](https://github.com/tjwio)
+- JSON decoder not properly decoding `proxyType` in some projects [#596](https://github.com/tuist/XcodeProj/issues/596) by [@tjwio](https://github.com/tjwio)
+- BuildPhaseTests not handling failure cases properly [#597](https://github.com/tuist/XcodeProj/issues/597) by [@tjwio](https://github.com/tjwio)
 
 ## 7.18.0 - Penguin
 

--- a/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
+++ b/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
@@ -16,7 +16,7 @@ extension KeyedDecodingContainer {
             return bool ? 0 : 1
         } else if let int: UInt = try decodeIfPresent(key) {
             // don't `try?` here in case key _does_ exist but isn't an expected type
-            // ie. not a string/bool
+            // ie. not a string/bool/int
             return int
         } else {
             return nil

--- a/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
+++ b/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift
@@ -12,26 +12,33 @@ extension KeyedDecodingContainer {
     func decodeIntIfPresent(_ key: KeyedDecodingContainer.Key) throws -> UInt? {
         if let string: String = try? decodeIfPresent(key) {
             return UInt(string)
-        } else if let bool: Bool = try decodeIfPresent(key) {
+        } else if let bool: Bool = try? decodeIfPresent(key) {
+            return bool ? 0 : 1
+        } else if let int: UInt = try decodeIfPresent(key) {
             // don't `try?` here in case key _does_ exist but isn't an expected type
             // ie. not a string/bool
-            return bool ? 0 : 1
+            return int
         } else {
             return nil
         }
     }
 
     func decodeIntBool(_ key: KeyedDecodingContainer.Key) throws -> Bool {
-        guard let int = try decodeIntIfPresent(key) else {
+        guard let bool = try decodeIntBoolIfPresent(key) else {
             return false
         }
-        return int == 1
+        return bool
     }
 
     func decodeIntBoolIfPresent(_ key: KeyedDecodingContainer.Key) throws -> Bool? {
         guard let int = try decodeIntIfPresent(key) else {
             return nil
         }
+
+        guard int <= 2 else {
+            throw DecodingError.dataCorruptedError(forKey: key, in: self, debugDescription: "Expected to decode Bool but found a number that is not 0 or 1")
+        }
+
         return int == 1
     }
 }

--- a/Tests/XcodeProjTests/Objects/BuildPhase/PBXCopyFilesBuildPhaseTests.swift
+++ b/Tests/XcodeProjTests/Objects/BuildPhase/PBXCopyFilesBuildPhaseTests.swift
@@ -49,8 +49,8 @@ final class PBXCopyFilesBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertNil(phase.dstPath, "Expected dstPath to be nil but it's present")
         } catch {}
     }
 
@@ -60,8 +60,8 @@ final class PBXCopyFilesBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertEqual(phase.buildActionMask, PBXBuildPhase.defaultBuildActionMask, "Expected buildActionMask to be equal to \(PBXBuildPhase.defaultBuildActionMask) but it's \(phase.buildActionMask)")
         } catch {}
     }
 
@@ -71,8 +71,8 @@ final class PBXCopyFilesBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertNil(phase.dstSubfolderSpec, "Expected dstSubfolderSpec to be nil but it's present")
         } catch {}
     }
 
@@ -82,8 +82,8 @@ final class PBXCopyFilesBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertNil(phase.files, "Expected files to be nil but it's present")
         } catch {}
     }
 
@@ -93,8 +93,8 @@ final class PBXCopyFilesBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertFalse(phase.runOnlyForDeploymentPostprocessing, "Expected runOnlyForDeploymentPostprocessing to default to false")
         } catch {}
     }
 

--- a/Tests/XcodeProjTests/Objects/BuildPhase/PBXFrameworksBuildPhaseTests.swift
+++ b/Tests/XcodeProjTests/Objects/BuildPhase/PBXFrameworksBuildPhaseTests.swift
@@ -13,8 +13,8 @@ final class PBXFrameworksBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXFrameworksBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertNil(phase.files, "Expected files to be nil but it's present")
         } catch {}
     }
 

--- a/Tests/XcodeProjTests/Objects/BuildPhase/PBXHeadersBuildPhaseTests.swift
+++ b/Tests/XcodeProjTests/Objects/BuildPhase/PBXHeadersBuildPhaseTests.swift
@@ -13,8 +13,8 @@ final class PBXHeadersBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXHeadersBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertEqual(phase.buildActionMask, PBXBuildPhase.defaultBuildActionMask, "Expected buildActionMask to be equal to \(PBXBuildPhase.defaultBuildActionMask) but it's \(phase.buildActionMask)")
         } catch {}
     }
 
@@ -24,8 +24,8 @@ final class PBXHeadersBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXHeadersBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertNil(phase.files, "Expected files to be nil but it's present")
         } catch {}
     }
 
@@ -35,8 +35,8 @@ final class PBXHeadersBuildPhaseTests: XCTestCase {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = XcodeprojJSONDecoder()
         do {
-            _ = try decoder.decode(PBXHeadersBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+            let phase = try decoder.decode(PBXCopyFilesBuildPhase.self, from: data)
+            XCTAssertFalse(phase.runOnlyForDeploymentPostprocessing, "Expected runOnlyForDeploymentPostprocessing to default to false")
         } catch {}
     }
 


### PR DESCRIPTION
Resolves #596 and #597 

### Short description 📝
Some of our Xcode projects were failing to be decoded due to `proxyType` being encoded as an Int when `decodeIntIfPresent` only tries to decode as String/Bool.

### Solution 📦
- Fix `decodeIntIfPresent` to try to decode `UInt` if decoding as String/Bool fails.
- Fix `_____BuildPhaseTests` to properly check failure cases now that `decodeIntIfPresent` doesn't wrongly throw when trying to decode encoded ints.

### Implementation 👩‍💻👨‍💻
> Detail in a checklist the steps that you took to implement the PR.

- [X] Fix `decodeIntIfPresent
- [X] Fix tests
- [X] Run tests
- [X] Test in failing project
