### PR TITLE
Add runPostActionsOnFailure to scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 🚀 Check out the guidelines [here](https://tuist.io/docs/contribution/changelog-guidelines/)
 
 ## Next
+- Added `runPostActionsOnFailure` to `XCScheme` [#603](https://github.com/tuist/XcodeProj/pull/603) by [@FranzBusch](https://github.com/FranzBusch)
 
 ## 7.19.0 - Kreuzberg
 

--- a/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
@@ -13,6 +13,7 @@ let attributesOrder: [String: [String]] = [
     "BuildAction": [
         "parallelizeBuildables",
         "buildImplicitDependencies",
+        "runPostActionsOnFailure",
     ],
     "BuildActionEntry": [
         "buildForTesting",

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -75,6 +75,7 @@ extension XCScheme {
         public var buildActionEntries: [Entry]
         public var parallelizeBuild: Bool
         public var buildImplicitDependencies: Bool
+        public var runPostActionsOnFailure: Bool
 
         // MARK: - Init
 
@@ -82,16 +83,19 @@ extension XCScheme {
                     preActions: [ExecutionAction] = [],
                     postActions: [ExecutionAction] = [],
                     parallelizeBuild: Bool = false,
-                    buildImplicitDependencies: Bool = false) {
+                    buildImplicitDependencies: Bool = false,
+                    runPostActionsOnFailure: Bool = false) {
             self.buildActionEntries = buildActionEntries
             self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies
+            self.runPostActionsOnFailure = runPostActionsOnFailure
             super.init(preActions, postActions)
         }
 
         override init(element: AEXMLElement) throws {
             parallelizeBuild = element.attributes["parallelizeBuildables"].map { $0 == "YES" } ?? true
             buildImplicitDependencies = element.attributes["buildImplicitDependencies"].map { $0 == "YES" } ?? true
+            runPostActionsOnFailure = element.attributes["runPostActionsOnFailure"].map { $0 == "YES" } ?? false
             buildActionEntries = try element["BuildActionEntries"]["BuildActionEntry"]
                 .all?
                 .map(Entry.init) ?? []
@@ -115,6 +119,7 @@ extension XCScheme {
                                        attributes: [
                                            "parallelizeBuildables": parallelizeBuild.xmlString,
                                            "buildImplicitDependencies": buildImplicitDependencies.xmlString,
+                                           "runPostActionsOnFailure": runPostActionsOnFailure.xmlString,
                                        ])
             super.writeXML(parent: element)
             let entries = element.addChild(name: "BuildActionEntries")
@@ -131,7 +136,8 @@ extension XCScheme {
             return super.isEqual(to: to) &&
                 buildActionEntries == rhs.buildActionEntries &&
                 parallelizeBuild == rhs.parallelizeBuild &&
-                buildImplicitDependencies == rhs.buildImplicitDependencies
+                buildImplicitDependencies == rhs.buildImplicitDependencies &&
+                runPostActionsOnFailure == rhs.runPostActionsOnFailure
         }
     }
 }

--- a/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
+++ b/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
@@ -15,13 +15,15 @@ class AEXML_XcodeFormatTests: XCTestCase {
         <?xml version="1.0" encoding="UTF-8"?>
         <BuildAction
            parallelizeBuildables = "YES"
-           buildImplicitDependencies = "NO">
+           buildImplicitDependencies = "NO"
+           runPostActionsOnFailure = "YES">
         </BuildAction>
         """
 
     func test_BuildAction_attributes_sorted_when_original_sorted() {
         validateAttributes(attributes: [
             "parallelizeBuildables": "YES",
+            "runPostActionsOnFailure": "YES",
             "buildImplicitDependencies": "NO",
         ])
     }
@@ -30,6 +32,7 @@ class AEXML_XcodeFormatTests: XCTestCase {
         validateAttributes(attributes: [
             "buildImplicitDependencies": "NO",
             "parallelizeBuildables": "YES",
+            "runPostActionsOnFailure": "YES",
         ])
     }
 

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -253,6 +253,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         // Build action
         XCTAssertTrue(scheme.buildAction?.parallelizeBuild == true)
         XCTAssertTrue(scheme.buildAction?.buildImplicitDependencies == true)
+        XCTAssertTrue(scheme.buildAction?.runPostActionsOnFailure == false)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.testing) == true)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.running) == true)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.profiling) == true)
@@ -419,6 +420,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         // Build action
         XCTAssertTrue(scheme.buildAction?.parallelizeBuild == true)
         XCTAssertTrue(scheme.buildAction?.buildImplicitDependencies == true)
+        XCTAssertTrue(scheme.buildAction?.runPostActionsOnFailure == false)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.testing) == true)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.running) == false)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.profiling) == true)


### PR DESCRIPTION
### Short description 📝
Schemes have an additional option to run post actions even on failure modes. This is particularly useful when you want to run a script to track something like the build time after any build concluded.

### Solution 📦
I added a new attribute to the scheme `runPostActionsOnFailure` similar to the already existing `buildImplicitDependencies` attribute.
