### PR TITLE
Add inline comments support to the `xcconfig` parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - JSON decoder not properly decoding `defaultConfigurationIsVisible` in some projects [#593](https://github.com/tuist/XcodeProj/pull/593) by [@tjwio](https://github.com/tjwio)
 - JSON decoder not properly decoding `proxyType` in some projects [#596](https://github.com/tuist/XcodeProj/issues/596) by [@tjwio](https://github.com/tjwio)
 - BuildPhaseTests not handling failure cases properly [#597](https://github.com/tuist/XcodeProj/issues/597) by [@tjwio](https://github.com/tjwio)
+- `xcconfig` parser does not support inline comments [#602](https://github.com/tuist/XcodeProj/issues/602) by [@dive](https://github.com/dive)
 
 ## 7.18.0 - Penguin
 

--- a/Fixtures/XCConfigs/Children.xcconfig
+++ b/Fixtures/XCConfigs/Children.xcconfig
@@ -1,5 +1,5 @@
 #include "Parent.xcconfig"
 
-CONFIGURATION_BUILD_DIR = Test/ // NOTE: Test comment line to check several bachslashes
+CONFIGURATION_BUILD_DIR = Test/ // NOTE: Test comment line to check several slashes
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited)
 WARNING_CFLAGS = -Wall -Wno-direct-ivar-access -Wno-objc-missing-property-synthesis -Wno-readonly-iboutlet-property -Wno-switch-enum -Wno-padded

--- a/Fixtures/XCConfigs/Children.xcconfig
+++ b/Fixtures/XCConfigs/Children.xcconfig
@@ -1,5 +1,5 @@
 #include "Parent.xcconfig"
 
-CONFIGURATION_BUILD_DIR = Test/
+CONFIGURATION_BUILD_DIR = Test/ // NOTE: Test comment line to check several bachslashes
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited)
 WARNING_CFLAGS = -Wall -Wno-direct-ivar-access -Wno-objc-missing-property-synthesis -Wno-readonly-iboutlet-property -Wno-switch-enum -Wno-padded

--- a/Fixtures/XCConfigs/Parent.xcconfig
+++ b/Fixtures/XCConfigs/Parent.xcconfig
@@ -1,2 +1,4 @@
+// NOTE: Top level comment
 OTHER_SWIFT_FLAGS_XCODE_0821 = $(inherited)
 OTHER_SWIFT_FLAGS_XCODE_0830 = $(inherited) -enable-bridging-pch
+PRODUCT_NAME = $(TARGET_NAME) // NOTE: Test Comment

--- a/Fixtures/XCConfigs/Parent.xcconfig
+++ b/Fixtures/XCConfigs/Parent.xcconfig
@@ -2,3 +2,4 @@
 OTHER_SWIFT_FLAGS_XCODE_0821 = $(inherited)
 OTHER_SWIFT_FLAGS_XCODE_0830 = $(inherited) -enable-bridging-pch
 PRODUCT_NAME = $(TARGET_NAME) // NOTE: Test Comment
+SWIFT_OPTIMIZATION_LEVEL = -Onone// Edge-case when a comment has no space

--- a/Sources/XcodeProj/Utils/XCConfig.swift
+++ b/Sources/XcodeProj/Utils/XCConfig.swift
@@ -99,7 +99,7 @@ final class XCConfigParser {
     // swiftlint:disable:next force_try
     private static var includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
     // swiftlint:disable:next force_try
-    private static var settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*?\"?)\\s*(?:;\\s*)?$", options: [])
+    private static var settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*?\"?)\\s*(?:;\\s*)?(?=$|\\/\\/)", options: [])
 }
 
 // MARK: - XCConfig Extension (Equatable)

--- a/Tests/XcodeProjTests/Utils/XCConfigTests.swift
+++ b/Tests/XcodeProjTests/Utils/XCConfigTests.swift
@@ -111,5 +111,6 @@ final class XCConfigIntegrationTests: XCTestCase {
         XCTAssertEqual(config.flattenedBuildSettings()["OTHER_SWIFT_FLAGS_XCODE_0821"] as? String, "$(inherited)")
         XCTAssertEqual(config.flattenedBuildSettings()["OTHER_SWIFT_FLAGS_XCODE_0830"] as? String, "$(inherited) -enable-bridging-pch")
         XCTAssertEqual(config.flattenedBuildSettings()["PRODUCT_NAME"] as? String, "$(TARGET_NAME)")
+        XCTAssertEqual(config.flattenedBuildSettings()["SWIFT_OPTIMIZATION_LEVEL"] as? String, "-Onone")
     }
 }

--- a/Tests/XcodeProjTests/Utils/XCConfigTests.swift
+++ b/Tests/XcodeProjTests/Utils/XCConfigTests.swift
@@ -110,5 +110,6 @@ final class XCConfigIntegrationTests: XCTestCase {
         XCTAssertEqual(config.includes.count, 1)
         XCTAssertEqual(config.flattenedBuildSettings()["OTHER_SWIFT_FLAGS_XCODE_0821"] as? String, "$(inherited)")
         XCTAssertEqual(config.flattenedBuildSettings()["OTHER_SWIFT_FLAGS_XCODE_0830"] as? String, "$(inherited) -enable-bridging-pch")
+        XCTAssertEqual(config.flattenedBuildSettings()["PRODUCT_NAME"] as? String, "$(TARGET_NAME)")
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/602

### Short description 📝
Add support for inline comments in `xcconfig` files.

### Solution 📦
Extend the existed regular expression to support `xcconfig` comments and use them as a full-stop condition.

### Implementation 👩‍💻👨‍💻
`XCConfig.swift` regular expression (`settingRegex`) extended with a positive lookahead condition as the last statement. Previously, the expression handles the end of the line ('$') as a final grouping statement and now it parses up until the end of the line or up to the comment indication (`//`) with the `(?=$|\\/\\/)` group.

- [X] Update `XCConfigTests` with failing scenarios
- [X] Adjust the `settingRegex` `NSRegularExpression` to support comments
- [X] Extend `XCConfigTests` with edge-cases

P.S. You can play with the updated regular expression [here](https://regexr.com/5mg3v).