### PR TITLE
Allows passing `BuildableIdentifier` String to `BuildableReference` initializer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Added
+
+- Allows passing BuildableIdentifier String to BuildableReference initializer [#605](https://github.com/tuist/XcodeProj/pull/605) by [@freddi-kit](https://github.com/freddi-kit)
+
 ## 7.22.0 - Ringui Dingui
 
 ### Added

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift
@@ -46,6 +46,18 @@ extension XCScheme {
             self.blueprintName = blueprintName
         }
 
+        public init(referencedContainer: String,
+                    blueprintIdentifier: String,
+                    buildableName: String,
+                    blueprintName: String,
+                    buildableIdentifier: String = "primary") {
+            self.referencedContainer = referencedContainer
+            self.blueprint = .string(blueprintIdentifier)
+            self.buildableName = buildableName
+            self.buildableIdentifier = buildableIdentifier
+            self.blueprintName = blueprintName
+        }
+
         // MARK: - XML
 
         init(element: AEXMLElement) throws {


### PR DESCRIPTION
### Short description 📝
At `BuildableReference`, it would be better to pass `buildableIdentifier` String by the user on some case

For example, when Xcode adding testing for Local Swift Package in scheme like below image, 

(`MyLibrary` is a local swift package)

<img src="https://user-images.githubusercontent.com/13707872/114443632-df99c480-9c08-11eb-9a1d-b24992838336.png" width="700px">


The (AppName).xcscheme will be like the below code.

```xml
<Testables>
   <TestableReference
      skipped = "NO">
      <BuildableReference
         BuildableIdentifier = "primary"
         BlueprintIdentifier = "96072DB32624C6A200AB94A5" # <--- HERE
         BuildableName = "freddiTestAppTests.xctest"
         BlueprintName = "freddiTestAppTests"
         ReferencedContainer = "container:freddiTestApp.xcodeproj">
      </BuildableReference>
   </TestableReference>
   <TestableReference
      skipped = "NO">
      <BuildableReference
         BuildableIdentifier = "primary"
         BlueprintIdentifier = "MyLibraryTests" # <--- HERE
         BuildableName = "MyLibraryTests"
         BlueprintName = "MyLibraryTests"
         ReferencedContainer = "container:MyLibrary">
      </BuildableReference>
   </TestableReference>
</Testables>
```
<details>
<summary>FYI: `MyLibrary`'s Package.swift </summary>

```swift
// swift-tools-version:5.3
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "MyLibrary",
    products: [
        // Products define the executables and libraries a package produces, and make them visible to other packages.
        .library(
            name: "MyLibrary",
            targets: ["MyLibrary"]),
    ],
    dependencies: [
        // Dependencies declare other packages that this package depends on.
        // .package(url: /* package url */, from: "1.0.0"),
    ],
    targets: [
        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
        // Targets can depend on other targets in this package, and on products in packages this package depends on.
        .target(
            name: "MyLibrary",
            dependencies: []),
        .testTarget(
            name: "MyLibraryTests",
            dependencies: ["MyLibrary"]),
    ]
)
```

</details>


As you can see, the application test's `BlueprintIdentifier` is for reference of xctest. But `MyLibrary`'s `BlueprintIdentifier` is not the same format with main app one(`96072DB32624C6A200AB94A5`). It is the name of test target of `MyLibrary`.

Currently, `BlueprintIdentifier`'s initalizer only set `BlueprintIdentifier` via received `PBXObject` like 

```swift
        public init(...,
                    blueprint: PBXObject,
                    ...) {
            ...
            self.blueprint = .reference(blueprint.reference)
            ...
        }
```


However, it is hard to pass the actual `PBXObject`'s reference when adding `BuildableReference` for testing Local Swift Package.

### Solution 📦

So I added an initializer that receives `BlueprintIdentifier` as a string to make it easy to set as expected.

```swift
        public init(...,
                    blueprintIdentifier: String,
                    ...) {
            ...
            self.blueprint = .string(blueprintIdentifier)
            ...
        }
```


### Implementation 👩‍💻👨‍💻

- [x] add new initalizer for `BuildableReference` which receives `BuildableIdentifier` string
