### PR TITLE
🛑 Prevent overwriting identical workspace data

### DIFF
--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -130,6 +130,12 @@ extension XcodeProj: Writable {
     /// - Parameter override: if workspace should be overridden. Default is true.
     ///   If false will throw error if workspace already exists at the given path.
     public func writeWorkspace(path: Path, override: Bool = true) throws {
+
+        // prevent overwriting identical workspace data
+        if let prevData = try? XCWorkspaceData(path: path), prevData == workspace.data {
+            return
+        }
+
         try workspace.write(path: XcodeProj.workspacePath(path), override: override)
     }
 

--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -130,7 +130,7 @@ extension XcodeProj: Writable {
     /// - Parameter override: if workspace should be overridden. Default is true.
     ///   If false will throw error if workspace already exists at the given path.
     public func writeWorkspace(path: Path, override: Bool = true) throws {
-        guard workspace.data != (try? XCWorkspace(path: path))?.data else { return }
+        guard let p = path.glob("*.xcworkspacedata").first, workspace.data != (try? XCWorkspaceData(path: p)) else { return }
         try workspace.write(path: XcodeProj.workspacePath(path), override: override)
     }
 

--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -130,7 +130,6 @@ extension XcodeProj: Writable {
     /// - Parameter override: if workspace should be overridden. Default is true.
     ///   If false will throw error if workspace already exists at the given path.
     public func writeWorkspace(path: Path, override: Bool = true) throws {
-        guard let p = path.glob("*.xcworkspacedata").first, workspace.data != (try? XCWorkspaceData(path: p)) else { return }
         try workspace.write(path: XcodeProj.workspacePath(path), override: override)
     }
 

--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -130,12 +130,7 @@ extension XcodeProj: Writable {
     /// - Parameter override: if workspace should be overridden. Default is true.
     ///   If false will throw error if workspace already exists at the given path.
     public func writeWorkspace(path: Path, override: Bool = true) throws {
-
-        // prevent overwriting identical workspace data
-        if let prevData = try? XCWorkspaceData(path: path), prevData == workspace.data {
-            return
-        }
-
+        guard workspace.data != (try? XCWorkspaceData(path: path)) else { return }
         try workspace.write(path: XcodeProj.workspacePath(path), override: override)
     }
 

--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -130,7 +130,7 @@ extension XcodeProj: Writable {
     /// - Parameter override: if workspace should be overridden. Default is true.
     ///   If false will throw error if workspace already exists at the given path.
     public func writeWorkspace(path: Path, override: Bool = true) throws {
-        guard workspace.data != (try? XCWorkspaceData(path: path)) else { return }
+        guard workspace.data != (try? XCWorkspace(path: path))?.data else { return }
         try workspace.write(path: XcodeProj.workspacePath(path), override: override)
     }
 

--- a/Sources/XcodeProj/Workspace/XCWorkspace.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspace.swift
@@ -59,7 +59,7 @@ public final class XCWorkspace: Writable, Equatable {
                 // there's no need to overwrite the contents
                 // this mitigates Xcode forcing users to
                 // close and re-open projects/workspaces
-                // on regneration.
+                // on regeneration.
                 return
             }
             try dataPath.delete()

--- a/Sources/XcodeProj/Workspace/XCWorkspace.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspace.swift
@@ -53,6 +53,15 @@ public final class XCWorkspace: Writable, Equatable {
     public func write(path: Path, override: Bool = true) throws {
         let dataPath = path + "contents.xcworkspacedata"
         if override, dataPath.exists {
+            if let existingContent: String = try? dataPath.read(),
+               existingContent == data.rawContents() {
+                // Raw data matches what's on disk
+                // there's no need to overwrite the contents
+                // this mitigates Xcode forcing users to
+                // close and re-open projects/workspaces
+                // on regneration.
+                return
+            }
             try dataPath.delete()
         }
         try dataPath.mkpath()

--- a/Sources/XcodeProj/Workspace/XCWorkspaceData.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspaceData.swift
@@ -36,20 +36,24 @@ extension XCWorkspaceData: Writable {
 
         self.init(children: children)
     }
-
-    // MARK: - <Writable>
-
-    public func write(path: Path, override: Bool = true) throws {
+    
+    func rawContents() -> String {
         let document = AEXMLDocument()
         let workspace = document.addChild(name: "Workspace", value: nil, attributes: ["version": "1.0"])
         _ = children
             .map { $0.xmlElement() }
             .map(workspace.addChild)
+        return document.xmlXcodeFormat
+    }
 
+    // MARK: - <Writable>
+    
+    public func write(path: Path, override: Bool = true) throws {
+        let rawXml = rawContents()
         if override, path.exists {
             try path.delete()
         }
-        try path.write(document.xmlXcodeFormat)
+        try path.write(rawXml)
     }
 }
 


### PR DESCRIPTION
Partially resolves https://github.com/tuist/tuist/issues/2809 ~for projects using `App.xcodeproj` -- without `App.xcworkspace` at project root. I haven't investigated the issue beyond the scope of `.xcodeproj` generation.~

Edit: The implementation has been updated to prevent overwriting identical workspace data (regardless of whether it's a project or a workspace)

### Short description 📝
Prevent overwriting identical workspace data

### Solution 📦
Check if previous workspace data is equal to newly generated workspace data.

### Implementation 👩‍💻👨‍💻
- [x] Add a check in `XCWorkspace` that prevents overwriting of identical data

How can I test this change @fortmarek? I ran into complications when trying with `1.40.0` tag via `swift build -c release --product tuist` and using that with Xcode `12.4` version:

```
Users/ferologics/Dev/tuist/.build/x86_64-apple-macosx/release/tuist generate --project-only                                     ✔
The 'swiftc' was interrupted with a signal 11 and message:
Stack dump:
0.      Program arguments: /Applications/Xcode-12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -interpret /Users/ferologics/Globekeeper/Connect/Tuist/Config.swift -enable-objc-interop -sdk /Applications/Xcode-12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk -I /Users/ferologics/Dev/tuist/.build/x86_64-apple-macosx/release -F /Users/ferologics/Dev/tuist/.build/x86_64-apple-macosx/release -suppress-warnings -target-sdk-version 11.1 -module-name Config -lProjectDescription -framework ProjectDescription -- --tuist-dump
1.      Apple Swift version 5.3.2 (swiftlang-1200.0.45 clang-1200.0.32.28)
2.      While running user code "/Users/ferologics/Globekeeper/Connect/Tuist/Config.swift"
0  swift                       0x0000000111d7c615 llvm::sys::PrintStackTrace(llvm::raw_ostream&) + 37
1  swift                       0x0000000111d7b615 llvm::sys::RunSignalHandlers() + 85
2  swift                       0x0000000111d7cbcf SignalHandler(int) + 111
3  libsystem_platform.dylib    0x00007fff206a8d7d _sigtramp + 29
4  libsystem_platform.dylib    0x00007fdedd704ef0 _sigtramp + 18446743935146901904
5  libProjectDescription.dylib 0x0000000117195165 $s18ProjectDescription6ConfigV17GenerationOptionsOSEAASE6encode2toys7Encoder_p_tKFTW + 21
6  libswiftCore.dylib          0x00007fff2ccae3a7 $sSE6encode2toys7Encoder_p_tKFTj + 7
7  libswiftFoundation.dylib    0x00007fff306b17bf $s10Foundation13__JSONEncoder33_12768CA107A31EF2DCE034FD75B541C9LLC4box_ySo8NSObjectCSgSE_pKF + 2591
8  libswiftFoundation.dylib    0x00007fff3076af76 $s10Foundation29_JSONUnkeyedEncodingContainer33_12768CA107A31EF2DCE034FD75B541C9LLV6encodeyyxKSERzlF + 550
9  libswiftFoundation.dylib    0x00007fff3076bf49 $s10Foundation29_JSONUnkeyedEncodingContainer33_12768CA107A31EF2DCE034FD75B541C9LLVs07UnkeyedcD0AAsAEP6encodeyyqd__KSERd__lFTW + 9
10 libswiftCore.dylib          0x00007fff2ca3872b $sSasSERzlE6encode2toys7Encoder_p_tKF + 507
11 libswiftCore.dylib          0x00007fff2ca38828 $sSayxGSEsSERzlSE6encode2toys7Encoder_p_tKFTW + 24
12 libswiftCore.dylib          0x00007fff2ccae3a7 $sSE6encode2toys7Encoder_p_tKFTj + 7
13 libswiftFoundation.dylib    0x00007fff306b17bf $s10Foundation13__JSONEncoder33_12768CA107A31EF2DCE034FD75B541C9LLC4box_ySo8NSObjectCSgSE_pKF + 2591
14 libswiftFoundation.dylib    0x00007fff306b60ae $s10Foundation27_JSONKeyedEncodingContainer33_12768CA107A31EF2DCE034FD75B541C9LLV6encode_6forKeyyqd___xtKSERd__lF + 2734
15 libswiftFoundation.dylib    0x00007fff306b55f5 $s10Foundation27_JSONKeyedEncodingContainer33_12768CA107A31EF2DCE034FD75B541C9LLVyxGs05KeyedcD8ProtocolAAsAFP6encode_6forKeyyqd___0P0QztKSERd__lFTW + 21
16 libswiftCore.dylib          0x00007fff2ca21dce $ss26_KeyedEncodingContainerBoxC6encode_6forKeyyqd___qd_0_tKSERd__s06CodingG0Rd_0_r0_lF + 206
17 libswiftCore.dylib          0x00007fff2ca19c34 $ss22KeyedEncodingContainerV6encode_6forKeyyqd___xtKSERd__lF + 36
18 libProjectDescription.dylib 0x0000000117196fa7 $s18ProjectDescription6ConfigV6encode2toys7Encoder_p_tKF + 247
19 libProjectDescription.dylib 0x0000000117197417 $s18ProjectDescription6ConfigVSEAASE6encode2toys7Encoder_p_tKFTW + 39
20 libswiftCore.dylib          0x00007fff2ccae3a7 $sSE6encode2toys7Encoder_p_tKFTj + 7
21 libswiftFoundation.dylib    0x00007fff306b17bf $s10Foundation13__JSONEncoder33_12768CA107A31EF2DCE034FD75B541C9LLC4box_ySo8NSObjectCSgSE_pKF + 2591
22 libswiftFoundation.dylib    0x00007fff3075f8dc $s10Foundation11JSONEncoderC6encodeyAA4DataVxKSERzlF + 460
23 libswiftFoundation.dylib    0x00007fff3077c84e $s10Foundation11JSONEncoderC6encodeyAA4DataVxKSERzlFTj + 14
24 libProjectDescription.dylib 0x000000011719580a $s18ProjectDescription12dumpIfNeededyyxSERzlFAA6ConfigV_Tg5 + 298
25 libProjectDescription.dylib 0x00000001171955ec $s18ProjectDescription6ConfigV23compatibleXcodeVersions5cloud5cache7plugins17generationOptionsAcA010CompatibleeF0O_AA5CloudVSgAA5CacheVSgSayAA14PluginLocationVGSayAC010GenerationK0OGtcfC + 412
26 libProjectDescription.dylib 0x000000011743b077 $s18ProjectDescription6ConfigV23compatibleXcodeVersions5cloud5cache7plugins17generationOptionsAcA010CompatibleeF0O_AA5CloudVSgAA5CacheVSgSayAA14PluginLocationVGSayAC010GenerationK0OGtcfC + 2776103
27 swift                       0x000000010d937a6f llvm::orc::runAsMain(int (*)(int, char**), llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, llvm::Optional<llvm::StringRef>) + 2495
28 swift                       0x000000010d914e5b swift::RunImmediately(swift::CompilerInstance&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&, swift::IRGenOptions const&, swift::SILOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >&&) + 6747
29 swift                       0x000000010d8eff7a performCompileStepsPostSILGen(swift::CompilerInstance&, swift::CompilerInvocation const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 2426
30 swift                       0x000000010d8dff4e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 21134
31 swift                       0x000000010d860c27 main + 1255
32 libdyld.dylib               0x00007fff2067ef3d start + 1
33 libdyld.dylib               0x0000000000000015 start + 18446603339972481241
```