### PR TITLE
Fix Wrong Product Type String for tvOS App Extensions

### DIFF
--- a/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
@@ -18,7 +18,7 @@ public enum PBXProductType: String, Decodable {
     case watch2AppContainer = "com.apple.product-type.application.watchapp2-container"
     case watchExtension = "com.apple.product-type.watchkit-extension"
     case watch2Extension = "com.apple.product-type.watchkit2-extension"
-    case tvExtension = "com.apple.product-type.tv-app-extension"
+    case tvExtension = "com.apple.product-type.app-extension"
     case messagesApplication = "com.apple.product-type.application.messages"
     case messagesExtension = "com.apple.product-type.app-extension.messages"
     case stickerPack = "com.apple.product-type.app-extension.messages-sticker-pack"


### PR DESCRIPTION
### Short description 📝
I was working on https://github.com/tuist/tuist/pull/2793 and realised that the product type "com.apple.product-type.tv-app-extension" caused the top shelf to crash. There is a solution posted on [StackOverflow]( https://stackoverflow.com/questions/58504864/tvos-13-top-shelf-nsextensionprincipalclass-product-module-name-contentprovid). In addition, I compared the product type to the product type in Apple's [example](https://developer.apple.com/documentation/tvservices/building_a_full_screen_top_shelf_extension). 

### Solution 📦
The product type string of `PBXProductType.tvExtension` was updated to 

``` swift
case tvExtension = "com.apple.product-type.app-extension"
```