### PR TITLE
Add ability to initialize scheme without a blueprint identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Adding group set incorrect parent in case of complex path [#614](https://github.com/tuist/XcodeProj/pull/614) by [@avdyushin](https://github.com/avdyushin)
+- **Breaking** Fixed issue where some schemes could not be deserialized because a buildable reference did not contain a blueprint identifier [#612](https://github.com/tuist/XcodeProj/pull/612) by [@daltonclaybrook](https://github.com/daltonclaybrook)
 
 ## 7.23.0 - Bonsai
 ### Added

--- a/Fixtures/Schemes/NoBlueprintID.xcscheme
+++ b/Fixtures/Schemes/NoBlueprintID.xcscheme
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion = "9999" version = "1.3">
+  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
+    <BuildActionEntries>
+      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
+        <BuildableReference
+          BuildableIdentifier = "primary"
+          BuildableName = "'lib$(TARGET_NAME)'"
+          BlueprintName = "NoBlueprintID"
+          ReferencedContainer = "container:NoBlueprintID.xcodeproj">
+        </BuildableReference>
+      </BuildActionEntry>
+    </BuildActionEntries>
+  </BuildAction>
+  <TestAction
+    buildConfiguration = "Debug"
+    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+    shouldUseLaunchSchemeArgsEnv = "YES"
+    codeCoverageEnabled = "NO">
+    <Testables>
+        <TestableReference
+          skipped = "NO">
+          <BuildableReference
+            BuildableIdentifier = "primary"
+            BuildableName = "'$(TARGET_NAME)'"
+            BlueprintName = "NoBlueprintIDTests"
+            ReferencedContainer = "container:NoBlueprintID.xcodeproj">
+          </BuildableReference>
+        </TestableReference>
+    </Testables>
+  </TestAction>
+</Scheme>

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift
@@ -23,9 +23,9 @@ extension XCScheme {
             blueprint = .reference(object.reference)
         }
 
-        private var blueprint: Blueprint
-        public var blueprintIdentifier: String {
-            blueprint.string
+        private var blueprint: Blueprint?
+        public var blueprintIdentifier: String? {
+            blueprint?.string
         }
 
         public var buildableName: String
@@ -35,24 +35,24 @@ extension XCScheme {
         // MARK: - Init
 
         public init(referencedContainer: String,
-                    blueprint: PBXObject,
+                    blueprint: PBXObject?,
                     buildableName: String,
                     blueprintName: String,
                     buildableIdentifier: String = "primary") {
             self.referencedContainer = referencedContainer
-            self.blueprint = .reference(blueprint.reference)
+            self.blueprint = blueprint.map { Blueprint.reference($0.reference) }
             self.buildableName = buildableName
             self.buildableIdentifier = buildableIdentifier
             self.blueprintName = blueprintName
         }
 
         public init(referencedContainer: String,
-                    blueprintIdentifier: String,
+                    blueprintIdentifier: String?,
                     buildableName: String,
                     blueprintName: String,
                     buildableIdentifier: String = "primary") {
             self.referencedContainer = referencedContainer
-            self.blueprint = .string(blueprintIdentifier)
+            self.blueprint = blueprintIdentifier.map(Blueprint.string)
             self.buildableName = buildableName
             self.buildableIdentifier = buildableIdentifier
             self.blueprintName = blueprintName
@@ -64,9 +64,6 @@ extension XCScheme {
             guard let buildableIdentifier = element.attributes["BuildableIdentifier"] else {
                 throw XCSchemeError.missing(property: "BuildableIdentifier")
             }
-            guard let blueprintIdentifier = element.attributes["BlueprintIdentifier"] else {
-                throw XCSchemeError.missing(property: "BlueprintIdentifier")
-            }
             guard let buildableName = element.attributes["BuildableName"] else {
                 throw XCSchemeError.missing(property: "BuildableName")
             }
@@ -77,22 +74,26 @@ extension XCScheme {
                 throw XCSchemeError.missing(property: "ReferencedContainer")
             }
             self.buildableIdentifier = buildableIdentifier
-            blueprint = .string(blueprintIdentifier)
+            let blueprintIdentifier = element.attributes["BlueprintIdentifier"]
+            self.blueprint = blueprintIdentifier.map(Blueprint.string)
             self.buildableName = buildableName
             self.blueprintName = blueprintName
             self.referencedContainer = referencedContainer
         }
 
         func xmlElement() -> AEXMLElement {
-            AEXMLElement(name: "BuildableReference",
-                         value: nil,
-                         attributes: [
-                             "BuildableIdentifier": buildableIdentifier,
-                             "BlueprintIdentifier": blueprint.string,
-                             "BuildableName": buildableName,
-                             "BlueprintName": blueprintName,
-                             "ReferencedContainer": referencedContainer,
-                         ])
+            var attributes: [String: String] = [
+                "BuildableIdentifier": buildableIdentifier,
+                "BuildableName": buildableName,
+                "BlueprintName": blueprintName,
+                "ReferencedContainer": referencedContainer,
+            ]
+            if let blueprintIdentifier = blueprint?.string {
+                attributes["BlueprintIdentifier"] = blueprintIdentifier
+            }
+            return AEXMLElement(name: "BuildableReference",
+                                value: nil,
+                                attributes: attributes)
         }
 
         // MARK: - Equatable

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -245,6 +245,11 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertNotEqual(runnableA1, remoteRunnableA1)
     }
 
+    func test_schemeWithoutBlueprintIdentifier_canBeCreated() {
+        let subject = try? XCScheme(path: noBlueprintIDPath)
+        XCTAssertNotNil(subject)
+    }
+
     // MARK: - Private
 
     private func assert(scheme: XCScheme) {
@@ -521,6 +526,11 @@ final class XCSchemeIntegrationTests: XCTestCase {
         // Not strictly minimal in the sense that it specifies the least amount of information to be valid,
         // but minimal in the sense it doesn't have most of the standard elements and attributes.
         fixturesPath() + "Schemes/MinimalInformation.xcscheme"
+    }
+
+    /// Path to a scheme with a buildable reference that contains no blueprint identifier
+    private var noBlueprintIDPath: Path {
+        fixturesPath() + "Schemes/NoBlueprintID.xcscheme"
     }
 
     private var watchAppSchemePath: Path {

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -250,6 +250,14 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertNotNil(subject)
     }
 
+    func test_schemeWithoutBlueprintIdentifier_serializesWithoutBlueprintIdentifier() throws {
+        let subject = try XCScheme(path: noBlueprintIDPath)
+        let buildable = try XCTUnwrap(subject.buildAction?.buildActionEntries.first?.buildableReference)
+        let buildableXML = buildable.xmlElement()
+        XCTAssertNotNil(buildableXML.attributes["BlueprintName"])
+        XCTAssertNil(buildableXML.attributes["BlueprintIdentifier"])
+    }
+
     // MARK: - Private
 
     private func assert(scheme: XCScheme) {


### PR DESCRIPTION
Resolves #509 

### Short description 📝
This PR fixes an issue where some schemes cannot be deserialized because a buildable reference does not contain a blueprint identifier.

### Solution 📦
The solution is to make the `blueprint` field optional on `BuildableReference`. The other option I considered was adding a new case to `Blueprint` called `.none`, but I felt simply making the property optional would be more ergonomic.
