### PR TITLE
Fix add group to have correct parent set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allows passing BuildableIdentifier String to BuildableReference initializer [#605](https://github.com/tuist/XcodeProj/pull/605) by [@freddi-kit](https://github.com/freddi-kit)
 
+### Fixed
+
+- Adding group set incorrect parent in case of complex path [#614](https://github.com/tuist/XcodeProj/pull/614) by [@avdyushin](https://github.com/avdyushin)
+
 ## 7.22.0 - Ringui Dingui
 
 ### Added

--- a/Sources/XcodeProj/Objects/Files/PBXGroup.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXGroup.swift
@@ -138,7 +138,7 @@ public extension PBXGroup {
         return groupName.components(separatedBy: "/").reduce(into: [PBXGroup]()) { groups, name in
             let group = groups.last ?? self
             let newGroup = PBXGroup(children: [], sourceTree: .group, name: name, path: options.contains(.withoutFolder) ? nil : name)
-            newGroup.parent = self
+            newGroup.parent = group
             group.childrenReferences.append(newGroup.reference)
             objects.add(object: newGroup)
             groups.append(newGroup)

--- a/Tests/XcodeProjTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/XcodeProjTests/Objects/Files/PBXGroupTests.swift
@@ -39,6 +39,22 @@ final class PBXGroupTests: XCTestCase {
         XCTAssertNotNil(childGroup?.parent)
     }
 
+    func test_addGroup_assignAllParents() {
+        let project = makeEmptyPBXProj()
+        let group = PBXGroup(children: [],
+                             sourceTree: .group,
+                             name: "group")
+        project.add(object: group)
+
+        let expectGroups = ["foo", "bar", "baz"]
+        let createdGroups = try? group.addGroup(named: expectGroups.joined(separator: "/"))
+
+        XCTAssertEqual(3, createdGroups?.count)
+        XCTAssertEqual(createdGroups?[0].parent?.name, "group")
+        XCTAssertEqual(createdGroups?[1].parent?.name, "foo")
+        XCTAssertEqual(createdGroups?[2].parent?.name, "bar")
+    }
+
     func test_addVariantGroup() {
         let project = makeEmptyPBXProj()
         let group = PBXGroup(children: [],


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/613

### Short description 📝
Fixed addGroup method and added unit test for this case

### Solution 📦
Typo?

### Implementation 👩‍💻👨‍💻
`newGroup.parent = group` instead of `self`