### PR TITLE
Fix Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allows passing BuildableIdentifier String to BuildableReference initializer [#605](https://github.com/tuist/XcodeProj/pull/605) by [@freddi-kit](https://github.com/freddi-kit)
 
+### Fixed
+
+- Fixed building on Linux [#615](https://github.com/tuist/XcodeProj/pull/615) by [@yonaskolb](https://github.com/yonaskolb)
+
 ## 7.22.0 - Ringui Dingui
 
 ### Added

--- a/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift
@@ -39,7 +39,7 @@ extension XCScheme {
 
         // MARK: - Equatable
 
-        @objc dynamic func isEqual(to: Any?) -> Bool {
+        func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? SerialAction else { return false }
             return preActions == rhs.preActions &&
                 postActions == rhs.postActions


### PR DESCRIPTION
### Short description 📝
Builds have recently started to fail on Linux. I'm not exactly sure why, must be the newer versions of Swift on CI.
You can see this on master where I re-ran the build https://github.com/tuist/XcodeProj/runs/2593437535
```
/home/runner/work/XcodeProj/XcodeProj/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift:42:10: error: Objective-C interoperability is disabled
        @objc dynamic func isEqual(to: Any?) -> Bool {
```

### Solution 📦
This removes the `@objc dynamic` from Serial action to remove references to ObjC
