### PR TITLE
Fix linux build and autogenerate XCScheme equality

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
           "branch": null,
-          "revision": "502c4d43a6cc9c395d19111e09dc62ad834977b5",
-          "version": "4.6.0"
+          "revision": "8623e73b193386909566a9ca20203e33a09af142",
+          "version": "4.5.0"
         }
       },
       {

--- a/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.4.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 import Foundation
 
 extension PBXAggregateTarget {
@@ -282,6 +281,132 @@ extension XCRemoteSwiftPackageReference {
     }
 }
 
+extension XCScheme.ArchiveAction {
+    /// :nodoc:
+    func isEqual(to rhs: XCScheme.ArchiveAction) -> Bool {
+        if buildConfiguration != rhs.buildConfiguration { return false }
+        if revealArchiveInOrganizer != rhs.revealArchiveInOrganizer { return false }
+        if customArchiveName != rhs.customArchiveName { return false }
+        return super.isEqual(to: rhs)
+    }
+}
+
+extension XCScheme.BuildAction {
+    /// :nodoc:
+    func isEqual(to rhs: XCScheme.BuildAction) -> Bool {
+        if buildActionEntries != rhs.buildActionEntries { return false }
+        if parallelizeBuild != rhs.parallelizeBuild { return false }
+        if buildImplicitDependencies != rhs.buildImplicitDependencies { return false }
+        if runPostActionsOnFailure != rhs.runPostActionsOnFailure { return false }
+        return super.isEqual(to: rhs)
+    }
+}
+
+extension XCScheme.BuildableProductRunnable {
+    /// :nodoc:
+    func isEqual(to rhs: XCScheme.BuildableProductRunnable) -> Bool {
+        return super.isEqual(to: rhs)
+    }
+}
+
+extension XCScheme.LaunchAction {
+    /// :nodoc:
+    func isEqual(to rhs: XCScheme.LaunchAction) -> Bool {
+        if runnable != rhs.runnable { return false }
+        if macroExpansion != rhs.macroExpansion { return false }
+        if selectedDebuggerIdentifier != rhs.selectedDebuggerIdentifier { return false }
+        if selectedLauncherIdentifier != rhs.selectedLauncherIdentifier { return false }
+        if buildConfiguration != rhs.buildConfiguration { return false }
+        if launchStyle != rhs.launchStyle { return false }
+        if askForAppToLaunch != rhs.askForAppToLaunch { return false }
+        if pathRunnable != rhs.pathRunnable { return false }
+        if useCustomWorkingDirectory != rhs.useCustomWorkingDirectory { return false }
+        if ignoresPersistentStateOnLaunch != rhs.ignoresPersistentStateOnLaunch { return false }
+        if debugDocumentVersioning != rhs.debugDocumentVersioning { return false }
+        if debugServiceExtension != rhs.debugServiceExtension { return false }
+        if allowLocationSimulation != rhs.allowLocationSimulation { return false }
+        if locationScenarioReference != rhs.locationScenarioReference { return false }
+        if enableGPUFrameCaptureMode != rhs.enableGPUFrameCaptureMode { return false }
+        if enableGPUValidationMode != rhs.enableGPUValidationMode { return false }
+        if enableAddressSanitizer != rhs.enableAddressSanitizer { return false }
+        if enableASanStackUseAfterReturn != rhs.enableASanStackUseAfterReturn { return false }
+        if enableThreadSanitizer != rhs.enableThreadSanitizer { return false }
+        if stopOnEveryThreadSanitizerIssue != rhs.stopOnEveryThreadSanitizerIssue { return false }
+        if enableUBSanitizer != rhs.enableUBSanitizer { return false }
+        if stopOnEveryUBSanitizerIssue != rhs.stopOnEveryUBSanitizerIssue { return false }
+        if disableMainThreadChecker != rhs.disableMainThreadChecker { return false }
+        if stopOnEveryMainThreadCheckerIssue != rhs.stopOnEveryMainThreadCheckerIssue { return false }
+        if additionalOptions != rhs.additionalOptions { return false }
+        if commandlineArguments != rhs.commandlineArguments { return false }
+        if environmentVariables != rhs.environmentVariables { return false }
+        if language != rhs.language { return false }
+        if region != rhs.region { return false }
+        if launchAutomaticallySubstyle != rhs.launchAutomaticallySubstyle { return false }
+        if storeKitConfigurationFileReference != rhs.storeKitConfigurationFileReference { return false }
+        if customLaunchCommand != rhs.customLaunchCommand { return false }
+        if customLLDBInitFile != rhs.customLLDBInitFile { return false }
+        return super.isEqual(to: rhs)
+    }
+}
+
+extension XCScheme.ProfileAction {
+    /// :nodoc:
+    func isEqual(to rhs: XCScheme.ProfileAction) -> Bool {
+        if buildableProductRunnable != rhs.buildableProductRunnable { return false }
+        if buildConfiguration != rhs.buildConfiguration { return false }
+        if shouldUseLaunchSchemeArgsEnv != rhs.shouldUseLaunchSchemeArgsEnv { return false }
+        if savedToolIdentifier != rhs.savedToolIdentifier { return false }
+        if ignoresPersistentStateOnLaunch != rhs.ignoresPersistentStateOnLaunch { return false }
+        if useCustomWorkingDirectory != rhs.useCustomWorkingDirectory { return false }
+        if debugDocumentVersioning != rhs.debugDocumentVersioning { return false }
+        if askForAppToLaunch != rhs.askForAppToLaunch { return false }
+        if commandlineArguments != rhs.commandlineArguments { return false }
+        if environmentVariables != rhs.environmentVariables { return false }
+        if macroExpansion != rhs.macroExpansion { return false }
+        if enableTestabilityWhenProfilingTests != rhs.enableTestabilityWhenProfilingTests { return false }
+        return super.isEqual(to: rhs)
+    }
+}
+
+extension XCScheme.RemoteRunnable {
+    /// :nodoc:
+    func isEqual(to rhs: XCScheme.RemoteRunnable) -> Bool {
+        if bundleIdentifier != rhs.bundleIdentifier { return false }
+        if remotePath != rhs.remotePath { return false }
+        return super.isEqual(to: rhs)
+    }
+}
+
+extension XCScheme.TestAction {
+    /// :nodoc:
+    func isEqual(to rhs: XCScheme.TestAction) -> Bool {
+        if testables != rhs.testables { return false }
+        if testPlans != rhs.testPlans { return false }
+        if codeCoverageTargets != rhs.codeCoverageTargets { return false }
+        if buildConfiguration != rhs.buildConfiguration { return false }
+        if selectedDebuggerIdentifier != rhs.selectedDebuggerIdentifier { return false }
+        if selectedLauncherIdentifier != rhs.selectedLauncherIdentifier { return false }
+        if shouldUseLaunchSchemeArgsEnv != rhs.shouldUseLaunchSchemeArgsEnv { return false }
+        if codeCoverageEnabled != rhs.codeCoverageEnabled { return false }
+        if onlyGenerateCoverageForSpecifiedTargets != rhs.onlyGenerateCoverageForSpecifiedTargets { return false }
+        if enableAddressSanitizer != rhs.enableAddressSanitizer { return false }
+        if enableASanStackUseAfterReturn != rhs.enableASanStackUseAfterReturn { return false }
+        if enableThreadSanitizer != rhs.enableThreadSanitizer { return false }
+        if enableUBSanitizer != rhs.enableUBSanitizer { return false }
+        if disableMainThreadChecker != rhs.disableMainThreadChecker { return false }
+        if macroExpansion != rhs.macroExpansion { return false }
+        if additionalOptions != rhs.additionalOptions { return false }
+        if commandlineArguments != rhs.commandlineArguments { return false }
+        if environmentVariables != rhs.environmentVariables { return false }
+        if language != rhs.language { return false }
+        if region != rhs.region { return false }
+        if systemAttachmentLifetime != rhs.systemAttachmentLifetime { return false }
+        if userAttachmentLifetime != rhs.userAttachmentLifetime { return false }
+        if customLLDBInitFile != rhs.customLLDBInitFile { return false }
+        return super.isEqual(to: rhs)
+    }
+}
+
 extension XCSwiftPackageProductDependency {
     /// :nodoc:
     func isEqual(to rhs: XCSwiftPackageProductDependency) -> Bool {
@@ -299,3 +424,4 @@ extension XCVersionGroup {
         return super.isEqual(to: rhs)
     }
 }
+

--- a/Sources/XcodeProj/Scheme/XCScheme+ArchiveAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+ArchiveAction.swift
@@ -50,10 +50,7 @@ extension XCScheme {
 
         override func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? ArchiveAction else { return false }
-            return super.isEqual(to: to) &&
-                buildConfiguration == rhs.buildConfiguration &&
-                revealArchiveInOrganizer == rhs.revealArchiveInOrganizer &&
-                customArchiveName == rhs.customArchiveName
+            return isEqual(to: rhs)
         }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -133,11 +133,7 @@ extension XCScheme {
 
         override func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? BuildAction else { return false }
-            return super.isEqual(to: to) &&
-                buildActionEntries == rhs.buildActionEntries &&
-                parallelizeBuild == rhs.parallelizeBuild &&
-                buildImplicitDependencies == rhs.buildImplicitDependencies &&
-                runPostActionsOnFailure == rhs.runPostActionsOnFailure
+            return isEqual(to: rhs)
         }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildableProductRunnable.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildableProductRunnable.swift
@@ -10,5 +10,12 @@ extension XCScheme {
             element.name = "BuildableProductRunnable"
             return element
         }
+
+        override func isEqual(to rhs: Any?) -> Bool {
+            guard let rhs = rhs as? BuildableProductRunnable else {
+                return false
+            }
+            return isEqual(to: rhs)
+        }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -341,40 +341,7 @@ extension XCScheme {
 
         override func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? LaunchAction else { return false }
-            return super.isEqual(to: to) &&
-                runnable == rhs.runnable &&
-                macroExpansion == rhs.macroExpansion &&
-                selectedDebuggerIdentifier == rhs.selectedDebuggerIdentifier &&
-                selectedLauncherIdentifier == rhs.selectedLauncherIdentifier &&
-                buildConfiguration == rhs.buildConfiguration &&
-                launchStyle == rhs.launchStyle &&
-                askForAppToLaunch == rhs.askForAppToLaunch &&
-                pathRunnable == rhs.pathRunnable &&
-                useCustomWorkingDirectory == rhs.useCustomWorkingDirectory &&
-                ignoresPersistentStateOnLaunch == rhs.ignoresPersistentStateOnLaunch &&
-                debugDocumentVersioning == rhs.debugDocumentVersioning &&
-                debugServiceExtension == rhs.debugServiceExtension &&
-                allowLocationSimulation == rhs.allowLocationSimulation &&
-                locationScenarioReference == rhs.locationScenarioReference &&
-                enableGPUFrameCaptureMode == rhs.enableGPUFrameCaptureMode &&
-                enableGPUValidationMode == rhs.enableGPUValidationMode &&
-                enableAddressSanitizer == rhs.enableAddressSanitizer &&
-                enableASanStackUseAfterReturn == rhs.enableASanStackUseAfterReturn &&
-                enableThreadSanitizer == rhs.enableThreadSanitizer &&
-                stopOnEveryThreadSanitizerIssue == rhs.stopOnEveryThreadSanitizerIssue &&
-                enableUBSanitizer == rhs.enableUBSanitizer &&
-                stopOnEveryUBSanitizerIssue == rhs.stopOnEveryUBSanitizerIssue &&
-                disableMainThreadChecker == rhs.disableMainThreadChecker &&
-                stopOnEveryMainThreadCheckerIssue == rhs.stopOnEveryMainThreadCheckerIssue &&
-                additionalOptions == rhs.additionalOptions &&
-                commandlineArguments == rhs.commandlineArguments &&
-                environmentVariables == rhs.environmentVariables &&
-                language == rhs.language &&
-                region == rhs.region &&
-                launchAutomaticallySubstyle == rhs.launchAutomaticallySubstyle &&
-                storeKitConfigurationFileReference == rhs.storeKitConfigurationFileReference &&
-                customLaunchCommand == rhs.customLaunchCommand &&
-                customLLDBInitFile == rhs.customLLDBInitFile
+            return isEqual(to: rhs)
         }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+ProfileAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+ProfileAction.swift
@@ -124,19 +124,7 @@ extension XCScheme {
 
         override func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? ProfileAction else { return false }
-            return super.isEqual(to: to) &&
-                buildableProductRunnable == rhs.buildableProductRunnable &&
-                buildConfiguration == rhs.buildConfiguration &&
-                shouldUseLaunchSchemeArgsEnv == rhs.shouldUseLaunchSchemeArgsEnv &&
-                savedToolIdentifier == rhs.savedToolIdentifier &&
-                ignoresPersistentStateOnLaunch == rhs.ignoresPersistentStateOnLaunch &&
-                useCustomWorkingDirectory == rhs.useCustomWorkingDirectory &&
-                debugDocumentVersioning == rhs.debugDocumentVersioning &&
-                askForAppToLaunch == rhs.askForAppToLaunch &&
-                commandlineArguments == rhs.commandlineArguments &&
-                environmentVariables == rhs.environmentVariables &&
-                macroExpansion == rhs.macroExpansion &&
-                enableTestabilityWhenProfilingTests == rhs.enableTestabilityWhenProfilingTests
+            return isEqual(to: rhs)
         }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+RemoteRunnable.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+RemoteRunnable.swift
@@ -38,18 +38,11 @@ extension XCScheme {
 
         // MARK: - Equatable
 
-        override func isEqual(other: XCScheme.Runnable) -> Bool {
-            guard let other = other as? RemoteRunnable else {
+        override func isEqual(to rhs: Any?) -> Bool {
+            guard let rhs = rhs as? RemoteRunnable else {
                 return false
             }
-
-            return super.isEqual(other: other) &&
-                bundleIdentifier == other.bundleIdentifier &&
-                remotePath == other.remotePath
-        }
-
-        public static func == (lhs: RemoteRunnable, rhs: RemoteRunnable) -> Bool {
-            lhs.isEqual(other: rhs) && rhs.isEqual(other: lhs)
+            return isEqual(to: rhs)
         }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+Runnable.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+Runnable.swift
@@ -1,8 +1,9 @@
+// sourcery:file: skipEquality
 import AEXML
 import Foundation
 
 extension XCScheme {
-    public class Runnable: Equatable {
+    public class Runnable: Equatable, AutoEquatable {
         // MARK: - Attributes
 
         public var runnableDebuggingMode: String
@@ -33,13 +34,14 @@ extension XCScheme {
 
         // MARK: - Equatable
 
-        func isEqual(other: Runnable) -> Bool {
-            runnableDebuggingMode == other.runnableDebuggingMode &&
-                buildableReference == other.buildableReference
+        func isEqual(to rhs: Any?) -> Bool {
+            guard let rhs = rhs as? Runnable else { return false }
+            return runnableDebuggingMode == rhs.runnableDebuggingMode &&
+                buildableReference == rhs.buildableReference
         }
 
         public static func == (lhs: Runnable, rhs: Runnable) -> Bool {
-            lhs.isEqual(other: rhs) && rhs.isEqual(other: lhs)
+            lhs.isEqual(to: rhs) && rhs.isEqual(to: lhs)
         }
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift
@@ -1,8 +1,9 @@
+// sourcery:file: skipEquality
 import AEXML
 import Foundation
 
 extension XCScheme {
-    public class SerialAction: Equatable {
+    public class SerialAction: Equatable, AutoEquatable {
         // MARK: - Attributes
 
         public var preActions: [ExecutionAction]
@@ -39,7 +40,7 @@ extension XCScheme {
 
         // MARK: - Equatable
 
-        @objc dynamic func isEqual(to: Any?) -> Bool {
+        func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? SerialAction else { return false }
             return preActions == rhs.preActions &&
                 postActions == rhs.postActions

--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -232,29 +232,7 @@ extension XCScheme {
 
         override func isEqual(to: Any?) -> Bool {
             guard let rhs = to as? TestAction else { return false }
-            return testables == rhs.testables &&
-                testPlans == rhs.testPlans &&
-                buildConfiguration == rhs.buildConfiguration &&
-                selectedDebuggerIdentifier == rhs.selectedDebuggerIdentifier &&
-                selectedLauncherIdentifier == rhs.selectedLauncherIdentifier &&
-                shouldUseLaunchSchemeArgsEnv == rhs.shouldUseLaunchSchemeArgsEnv &&
-                codeCoverageEnabled == rhs.codeCoverageEnabled &&
-                onlyGenerateCoverageForSpecifiedTargets == onlyGenerateCoverageForSpecifiedTargets &&
-                enableAddressSanitizer == rhs.enableAddressSanitizer &&
-                enableASanStackUseAfterReturn == rhs.enableASanStackUseAfterReturn &&
-                enableThreadSanitizer == rhs.enableThreadSanitizer &&
-                enableUBSanitizer == rhs.enableUBSanitizer &&
-                disableMainThreadChecker == rhs.disableMainThreadChecker &&
-                macroExpansion == rhs.macroExpansion &&
-                additionalOptions == rhs.additionalOptions &&
-                commandlineArguments == rhs.commandlineArguments &&
-                environmentVariables == rhs.environmentVariables &&
-                language == rhs.language &&
-                region == rhs.region &&
-                systemAttachmentLifetime == rhs.systemAttachmentLifetime &&
-                userAttachmentLifetime == rhs.userAttachmentLifetime &&
-                codeCoverageTargets == rhs.codeCoverageTargets &&
-                customLLDBInitFile == rhs.customLLDBInitFile
+            return isEqual(to: rhs)
         }
     }
 }

--- a/Templates/Equality.stencil
+++ b/Templates/Equality.stencil
@@ -13,7 +13,7 @@ extension {{ type.name }} {
         {% endfor %}
         {% for variable in type.computedVariables|annotated:"forceEquality" %}if self.{{ variable.name }} != rhs.{{ variable.name }} { return false }
         {% endfor %}
-        {% if type.inheritedTypes.first == "NSObject" %}return true{% else %}return super.isEqual(to: rhs){% endif %}
+        {% if type.supertype == nil %}return true{% else %}return super.isEqual(to: rhs){% endif %}
     }
 }
 


### PR DESCRIPTION

### Short description 📝

Swift 5.4 changed something that caused the linux build to (correctly) fail to compile an @objc declaration. This change fixes that and uses the same Sourcery generation for XCScheme objects that we use for PBXObjects.

### Solution 📦

As discussed in #585, the only reason for the @objc declaration was to permit swift to override functions from an extension—objc interop is not actually a concern. This change reimplements the equality logic for XCScheme objects to be like PBXObjects: using memberwise equality functions generated by sourcery, and a dynamic override on each XCScheme class that calls into the memberwise function.

Tested the generated interface with these changes:

    swift build -Xswiftc -emit-module-interface -Xswiftc -swift-version -Xswiftc 5

The only change to the interface is that RemoteRunnable now exposes an `==` method:

```diff
+    public static func == (lhs: XcodeProj.XCScheme.RemoteRunnable, rhs: XcodeProj.XCScheme.RemoteRunnable) -> Swift.Bool
```