### PR TITLE
Added new product types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Adding group set incorrect parent in case of complex path [#614](https://github.com/tuist/XcodeProj/pull/614) by [@avdyushin](https://github.com/avdyushin)
+- Added the `com.apple.product-type.driver-extension` and `com.apple.product-type.system-extension` PBXProductType [#618](https://github.com/tuist/XcodeProj/pull/618) by [@vgorloff](https://github.com/vgorloff).
 
 ## 7.23.0 - Bonsai
 ### Added

--- a/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
@@ -29,6 +29,8 @@ public enum PBXProductType: String, Decodable {
     case intentsServiceExtension = "com.apple.product-type.app-extension.intents-service"
     case onDemandInstallCapableApplication = "com.apple.product-type.application.on-demand-install-capable"
     case metalLibrary = "com.apple.product-type.metal-library"
+    case driverExtension = "com.apple.product-type.driver-extension"
+    case systemExtension = "com.apple.product-type.system-extension"
 
     /// Returns the file extension for the given product type.
     public var fileExtension: String? {
@@ -59,6 +61,10 @@ public enum PBXProductType: String, Decodable {
             return "xcframework"
         case .metalLibrary:
             return "metallib"
+        case .systemExtension:
+            return "systemextension"
+        case .driverExtension:
+            return "dext"
         case .none:
             return nil
         }

--- a/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
@@ -94,4 +94,12 @@ final class PBXProductTypeTests: XCTestCase {
     func test_appClip_hasTheRightValue() {
         XCTAssertEqual(PBXProductType.onDemandInstallCapableApplication.rawValue, "com.apple.product-type.application.on-demand-install-capable")
     }
+
+    func test_driverExtension_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.driverExtension.rawValue, "com.apple.product-type.driver-extension")
+    }
+
+    func test_systemExtension_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.systemExtension.rawValue, "com.apple.product-type.driver-extension")
+    }
 }

--- a/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
@@ -100,6 +100,6 @@ final class PBXProductTypeTests: XCTestCase {
     }
 
     func test_systemExtension_hasTheRightValue() {
-        XCTAssertEqual(PBXProductType.systemExtension.rawValue, "com.apple.product-type.driver-extension")
+        XCTAssertEqual(PBXProductType.systemExtension.rawValue, "com.apple.product-type.system-extension")
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/617

### Short description 📝
Added definitions for `com.apple.product-type.driver-extension` and `com.apple.product-type.system-extension`

Here is how `pbxproj` file looks like:

```
80FE40502679519400D7853F /* MyDriver */ = {
	isa = PBXNativeTarget;
	buildConfigurationList = 80FE405D2679519400D7853F /* Build configuration list for PBXNativeTarget "MyDriver" */;
	buildPhases = (
		80FE404C2679519400D7853F /* Headers */,
		80FE404D2679519400D7853F /* Sources */,
		80FE404E2679519400D7853F /* Frameworks */,
		80FE404F2679519400D7853F /* Resources */,
	);
	buildRules = (
	);
	dependencies = (
	);
	name = MyDriver;
	productName = MyDriver;
	productReference = 80FE40512679519400D7853F /* abc.xyz.any.MyDriver.dext */;
	productType = "com.apple.product-type.driver-extension";
};
80FE40632679523400D7853F /* MySysExtension */ = {
	isa = PBXNativeTarget;
	buildConfigurationList = 80FE406E2679523400D7853F /* Build configuration list for PBXNativeTarget "MySysExtension" */;
	buildPhases = (
		80FE40602679523400D7853F /* Sources */,
		80FE40612679523400D7853F /* Frameworks */,
		80FE40622679523400D7853F /* Resources */,
	);
	buildRules = (
	);
	dependencies = (
	);
	name = MySysExtension;
	productName = MySysExtension;
	productReference = 80FE40642679523400D7853F /* abc.xyz.any.xxx.MySysExtension.systemextension */;
	productType = "com.apple.product-type.system-extension";
};
```
