### PR TITLE
Make `runPostActionsOnFailure` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Adding group set incorrect parent in case of complex path [#614](https://github.com/tuist/XcodeProj/pull/614) by [@avdyushin](https://github.com/avdyushin)
 
+### Changed
+
+- **Breaking** Make `runPostActionsOnFailure` optional [#619](https://github.com/tuist/XcodeProj/pull/619) by [@kwridan](https://github.com/kwridan)
+
 ## 7.23.0 - Bonsai
 ### Added
 

--- a/Fixtures/Schemes/RunPostActionsOnFailure.xcscheme
+++ b/Fixtures/Schemes/RunPostActionsOnFailure.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FBDC4A1C26773F25000A2ADA"
+               BuildableName = "AnApp.app"
+               BlueprintName = "AnApp"
+               ReferencedContainer = "container:AnApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FBDC4A1C26773F25000A2ADA"
+            BuildableName = "AnApp.app"
+            BlueprintName = "AnApp"
+            ReferencedContainer = "container:AnApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FBDC4A1C26773F25000A2ADA"
+            BuildableName = "AnApp.app"
+            BlueprintName = "AnApp"
+            ReferencedContainer = "container:AnApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -75,7 +75,7 @@ extension XCScheme {
         public var buildActionEntries: [Entry]
         public var parallelizeBuild: Bool
         public var buildImplicitDependencies: Bool
-        public var runPostActionsOnFailure: Bool
+        public var runPostActionsOnFailure: Bool?
 
         // MARK: - Init
 
@@ -84,7 +84,7 @@ extension XCScheme {
                     postActions: [ExecutionAction] = [],
                     parallelizeBuild: Bool = false,
                     buildImplicitDependencies: Bool = false,
-                    runPostActionsOnFailure: Bool = false) {
+                    runPostActionsOnFailure: Bool? = nil) {
             self.buildActionEntries = buildActionEntries
             self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies
@@ -95,7 +95,7 @@ extension XCScheme {
         override init(element: AEXMLElement) throws {
             parallelizeBuild = element.attributes["parallelizeBuildables"].map { $0 == "YES" } ?? true
             buildImplicitDependencies = element.attributes["buildImplicitDependencies"].map { $0 == "YES" } ?? true
-            runPostActionsOnFailure = element.attributes["runPostActionsOnFailure"].map { $0 == "YES" } ?? false
+            runPostActionsOnFailure = element.attributes["runPostActionsOnFailure"].map { $0 == "YES" }
             buildActionEntries = try element["BuildActionEntries"]["BuildActionEntry"]
                 .all?
                 .map(Entry.init) ?? []
@@ -114,13 +114,18 @@ extension XCScheme {
         // MARK: - XML
 
         func xmlElement() -> AEXMLElement {
+            var attributes = [
+                "parallelizeBuildables": parallelizeBuild.xmlString,
+                "buildImplicitDependencies": buildImplicitDependencies.xmlString,
+            ]
+
+            if let runPostActionsOnFailure = runPostActionsOnFailure {
+                attributes["runPostActionsOnFailure"] = runPostActionsOnFailure.xmlString
+            }
+
             let element = AEXMLElement(name: "BuildAction",
                                        value: nil,
-                                       attributes: [
-                                           "parallelizeBuildables": parallelizeBuild.xmlString,
-                                           "buildImplicitDependencies": buildImplicitDependencies.xmlString,
-                                           "runPostActionsOnFailure": runPostActionsOnFailure.xmlString,
-                                       ])
+                                       attributes: attributes)
             super.writeXML(parent: element)
             let entries = element.addChild(name: "BuildActionEntries")
             buildActionEntries.forEach { entry in

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -245,6 +245,28 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertNotEqual(runnableA1, remoteRunnableA1)
     }
 
+    func test_buildAction_runPostActionsOnFailure() throws {
+        // Given / When
+        let subject = try XCScheme(path: runPostActionsOnFailureSchemePath)
+
+        // Then
+        let buildAction = try XCTUnwrap(subject.buildAction)
+        XCTAssertTrue(buildAction.runPostActionsOnFailure == true)
+    }
+
+    func test_buildAction_runPostActionsOnFailure_serializingAndDeserializing() throws {
+        // Given
+        let scheme = try XCScheme(path: runPostActionsOnFailureSchemePath)
+        let subject = try XCTUnwrap(scheme.buildAction)
+
+        // When
+        let xml = subject.xmlElement()
+        let reconstructedSubject = try XCScheme.BuildAction(element: xml)
+
+        // Then
+        XCTAssertEqual(reconstructedSubject, subject)
+    }
+
     // MARK: - Private
 
     private func assert(scheme: XCScheme) {
@@ -253,7 +275,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         // Build action
         XCTAssertTrue(scheme.buildAction?.parallelizeBuild == true)
         XCTAssertTrue(scheme.buildAction?.buildImplicitDependencies == true)
-        XCTAssertTrue(scheme.buildAction?.runPostActionsOnFailure == false)
+        XCTAssertNil(scheme.buildAction?.runPostActionsOnFailure)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.testing) == true)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.running) == true)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.profiling) == true)
@@ -420,7 +442,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         // Build action
         XCTAssertTrue(scheme.buildAction?.parallelizeBuild == true)
         XCTAssertTrue(scheme.buildAction?.buildImplicitDependencies == true)
-        XCTAssertTrue(scheme.buildAction?.runPostActionsOnFailure == false)
+        XCTAssertNil(scheme.buildAction?.runPostActionsOnFailure)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.testing) == true)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.running) == false)
         XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.profiling) == true)
@@ -525,5 +547,10 @@ final class XCSchemeIntegrationTests: XCTestCase {
 
     private var watchAppSchemePath: Path {
         fixturesPath() + "iOS/AppWithExtensions/AppWithExtensions.xcodeproj/xcshareddata/xcschemes/WatchApp.xcscheme"
+    }
+
+    private var runPostActionsOnFailureSchemePath: Path {
+        // A scheme with the `runPostActionsOnFailure` enabled
+        fixturesPath() + "Schemes/RunPostActionsOnFailure.xcscheme"
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/2991

### Short description 📝

- Generated projects had `runPostActionsOnFailure` set in their schemes by default to `NO`
- Xcode ends up removing this attribute when it's value is `NO` resultting in producing git diffs for any checked in projects that were previously generated

### Solution 📦

To mitigate this, the `runPostActionsOnFailure` option is being changed to an optional one where it's only written in the case it's explicitly defined to a specific value

### Implementation 👩‍💻👨‍💻

- [x] Mark `runPostActionsOnFailure` as optional
- [x] Add **Breaking** changelog entry
