### PR TITLE
Improve performance of commented string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- mprove performance of commented string [#635](https://github.com/tuist/XcodeProj/pull/635) by [@adellibovi](https://github.com/adellibovi)
+- Improve performance of commented string [#635](https://github.com/tuist/XcodeProj/pull/635) by [@adellibovi](https://github.com/adellibovi)
 
 ## 8.0.0 - Amor
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Changed
+
+- mprove performance of commented string [#635](https://github.com/tuist/XcodeProj/pull/635) by [@adellibovi](https://github.com/adellibovi)
+
 ## 8.0.0 - Amor
 ### Fixed
 

--- a/Sources/XcodeProj/Utils/CommentedString.swift
+++ b/Sources/XcodeProj/Utils/CommentedString.swift
@@ -43,7 +43,7 @@ struct CommentedString {
         if string.rangeOfCharacter(from: CommentedString.invalidCharacters) == nil {
             if string.rangeOfCharacter(from: CommentedString.specialCheckCharacters) == nil {
                 return string
-            } else if !string.contains("//")  && !string.contains("___") {
+            } else if !string.contains("//") && !string.contains("___") {
                 return string
             }
         }

--- a/Sources/XcodeProj/Utils/CommentedString.swift
+++ b/Sources/XcodeProj/Utils/CommentedString.swift
@@ -28,49 +28,8 @@ struct CommentedString {
         return invalidSet
     }()
 
-    /// Substrings that cause Xcode to quote the string content.
-    ///
-    /// Matches the strings `___` and `//`.
-    private let invalidStrings: Trie = [
-        "_": ["_": "_"],
-        "/": "/"
-    ]
-
-    /// A tree of characters to efficiently match string prefixes.
-    private enum Trie: ExpressibleByDictionaryLiteral, ExpressibleByUnicodeScalarLiteral {
-        case match
-        case next([(UnicodeScalar, Trie)])
-
-        init(dictionaryLiteral elements: (UnicodeScalar, Trie)...) {
-            self = .next(elements)
-        }
-
-        init(unicodeScalarLiteral value: UnicodeScalar) {
-            self = .next([(value, .match)])
-        }
-
-        /// Accepts a character and mutates to the subtree of strings which match that character. If the character does
-        /// not match, resets to `default`.
-        mutating func match(_ character: UnicodeScalar, orResetTo default: Trie) {
-            switch self {
-            case .match:
-                return
-            case .next(let options):
-                for (key, subtrie) in options where key == character {
-                    self = subtrie
-                    return
-                }
-                self = `default`
-            }
-        }
-
-        var accepted: Bool {
-            switch self {
-            case .match: return true
-            case .next: return false
-            }
-        }
-    }
+    /// Set of characters that are invalid.
+    private static var specialCheckCharacters = CharacterSet(charactersIn: "_/")
 
     /// Returns a valid string for Xcode projects.
     var validString: String {
@@ -81,19 +40,15 @@ struct CommentedString {
         default: break
         }
 
-        var needsQuoting = false
-        var matchingInvalidPrefix: Trie = self.invalidStrings
+        if string.rangeOfCharacter(from: CommentedString.invalidCharacters) == nil {
+            if string.rangeOfCharacter(from: CommentedString.specialCheckCharacters) == nil {
+                return string
+            } else if !string.contains("//")  && !string.contains("___") {
+                return string
+            }
+        }
 
         let escaped = string.reduce(into: "") { escaped, character in
-            quote: if !needsQuoting {
-                for scalar in character.unicodeScalars {
-                    matchingInvalidPrefix.match(scalar, orResetTo: self.invalidStrings)
-                    if matchingInvalidPrefix.accepted || CommentedString.invalidCharacters.contains(scalar) {
-                        needsQuoting = true
-                        break quote
-                    }
-                }
-            }
             // As an optimization, only look at the first scalar. This means we're doing a numeric comparison instead
             // of comparing arbitrary-length characters. This is safe because all our cases are a single scalar.
             switch character.unicodeScalars.first {
@@ -109,10 +64,7 @@ struct CommentedString {
                 escaped.append(character)
             }
         }
-        if needsQuoting {
-            return "\"\(escaped)\""
-        }
-        return escaped
+        return "\"\(escaped)\""
     }
 }
 


### PR DESCRIPTION
### Short description 📝
This PR improves the performance of commented string.

### Solution 📦
Most of the case we do not need to escape, having an early exit saves a lot of copies and allocation, in my case I got the time spent on `validString` from 9s to 1.6s