### PR TITLE
Add CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED to projectAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Added
+
+- `CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED` to default build setting [#641](https://github.com/tuist/XcodeProj/pull/641) by [@flowbe](https://github.com/flowbe)
+
 ### 8.2.0 - Bubbles
 ### Added
 

--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -97,6 +97,7 @@ public class BuildSettingsProvider {
     private static func projectAll() -> BuildSettings {
         [
             "ALWAYS_SEARCH_USER_PATHS": "NO",
+            "CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED": "YES",
             "CLANG_ANALYZER_NONNULL": "YES",
             "CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION": "YES_AGGRESSIVE",
             "CLANG_CXX_LANGUAGE_STANDARD": "gnu++14",


### PR DESCRIPTION
### Short description 📝
As mentioned [here](https://github.com/tuist/tuist/issues/3442), CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED is a recommended setting turned on by default, so we should do the same.