### PR TITLE
Fix Xcode 13 build error

### DIFF
--- a/Sources/XcodeProj/Extensions/Path+Extras.swift
+++ b/Sources/XcodeProj/Extensions/Path+Extras.swift
@@ -24,7 +24,10 @@ extension Path {
     /// - Returns: found directories and files.
     func glob(_ pattern: String) -> [Path] {
         var gt = glob_t()
-        let cPattern = strdup((self + pattern).string)
+        guard let cPattern = strdup((self + pattern).string) else {
+            globfree(&gt)
+            return []
+        }
         defer {
             globfree(&gt)
             free(cPattern)


### PR DESCRIPTION
### Short description 📝
This fixes the build on Xcode 13 RC.
[The similar issue for PathKit.](https://github.com/kylef/PathKit/pull/78)

```
xcodeproj/Sources/XcodeProj/Extensions/Path+Extras.swift:26:18: error: value of optional type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') must be unwrapped to a value of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>')
            free(cPattern)
                 ^
xcodeproj/Sources/XcodeProj/Extensions/Path+Extras.swift:26:18: note: coalesce using '??' to provide a default when the optional value contains 'nil'
            free(cPattern)
                 ^
                          ?? <#default value#>
xcodeproj/Sources/XcodeProj/Extensions/Path+Extras.swift:26:18: note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
            free(cPattern)
                 ^
                         !
xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjects.swift:141:13: warning: using '_' to ignore the result of a Void-returning function is redundant
            _ = self.add(object: $0)
```
### Solution 📦
`strdup` returns an optional. I just add unwrapping for this. 
In case of nil, I will return an empty array which looks like a valid solution.

Note: To solve all issue with Xcode you will need also apply fix for PathKit (link above)
