### PR TITLE
Fix typo in WorkspaceSettings.swift

### DIFF
--- a/Sources/XcodeProj/Project/WorkspaceSettings.swift
+++ b/Sources/XcodeProj/Project/WorkspaceSettings.swift
@@ -68,7 +68,7 @@ public class WorkspaceSettings: Codable, Equatable, Writable {
 
     /// Initializes the settings decoding the values from the plist representation.
     ///
-    /// - Parameter decoder: Propertly list decoder.
+    /// - Parameter decoder: Property list decoder.
     /// - Throws: An error if required attributes are missing or have a wrong type.
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)


### PR DESCRIPTION


### Short description 📝
Propertly -> Property

