### PR TITLE
Added location to TestableReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 🚀 Check out the guidelines [here](https://tuist.io/docs/contribution/changelog-guidelines/)
 
 ## Next
+### Added
+
+- Support for location added to test targets (`TestableReference`) [#654](https://github.com/tuist/XcodeProj/pull/654) by [@KrisRJack](https://github.com/KrisRJack)
 
 ## 8.5.0
 

--- a/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
@@ -10,6 +10,7 @@ extension XCScheme {
         public var randomExecutionOrdering: Bool
         public var useTestSelectionWhitelist: Bool?
         public var buildableReference: BuildableReference
+        public var locationScenarioReference: LocationScenarioReference?
         public var skippedTests: [TestItem]
         public var selectedTests: [TestItem]
 
@@ -19,6 +20,7 @@ extension XCScheme {
                     parallelizable: Bool = false,
                     randomExecutionOrdering: Bool = false,
                     buildableReference: BuildableReference,
+                    locationScenarioReference: LocationScenarioReference? = nil,
                     skippedTests: [TestItem] = [],
                     selectedTests: [TestItem] = [],
                     useTestSelectionWhitelist: Bool? = nil) {
@@ -26,6 +28,7 @@ extension XCScheme {
             self.parallelizable = parallelizable
             self.randomExecutionOrdering = randomExecutionOrdering
             self.buildableReference = buildableReference
+            self.locationScenarioReference = locationScenarioReference
             self.useTestSelectionWhitelist = useTestSelectionWhitelist
             self.selectedTests = selectedTests
             self.skippedTests = skippedTests
@@ -37,6 +40,12 @@ extension XCScheme {
             useTestSelectionWhitelist = element.attributes["useTestSelectionWhitelist"] == "YES"
             randomExecutionOrdering = element.attributes["testExecutionOrdering"] == "random"
             buildableReference = try BuildableReference(element: element["BuildableReference"])
+            
+            if element["LocationScenarioReference"].all?.first != nil {
+                locationScenarioReference = try LocationScenarioReference(element: element["LocationScenarioReference"])
+            } else {
+                locationScenarioReference = nil
+            }
 
             if let selectedTests = element["SelectedTests"]["Test"].all {
                 self.selectedTests = try selectedTests.map(TestItem.init)
@@ -64,6 +73,10 @@ extension XCScheme {
                                        attributes: attributes)
             element.addChild(buildableReference.xmlElement())
 
+            if let locationScenarioReference = locationScenarioReference {
+                element.addChild(locationScenarioReference.xmlElement())
+            }
+            
             if useTestSelectionWhitelist == true {
                 if !selectedTests.isEmpty {
                     let selectedTestsElement = element.addChild(name: "SelectedTests")
@@ -89,6 +102,7 @@ extension XCScheme {
                 lhs.parallelizable == rhs.parallelizable &&
                 lhs.randomExecutionOrdering == rhs.randomExecutionOrdering &&
                 lhs.buildableReference == rhs.buildableReference &&
+                lhs.locationScenarioReference == rhs.locationScenarioReference &&
                 lhs.useTestSelectionWhitelist == rhs.useTestSelectionWhitelist &&
                 lhs.skippedTests == rhs.skippedTests &&
                 lhs.selectedTests == rhs.selectedTests


### PR DESCRIPTION
### Short description 📝
> Added LocationScenarioReference as an option for Test Targets. Images below show how these options are applied in both Xcode and `.xcsheme` file. 

> These changes are necessary for [this issue in XcodeGen](https://github.com/yonaskolb/XcodeGen/issues/1150).



![143057737-d4c2eead-6dfb-4215-a133-e1772d389712](https://user-images.githubusercontent.com/35638500/143620256-014894ae-5a10-46c1-939d-5bf48d387212.png)



<img width="846" alt="143057759-55cf212c-76d0-4689-af56-a1e1e31598b8" src="https://user-images.githubusercontent.com/35638500/143620251-9ed3ad43-4e0d-4f77-9ed0-f6d030c79400.png">


