### PR TITLE
Add docc file type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 ### Added
 
-- Add DocC Xcode File Type (`.docc`) []() by [@Jake-Prickett](https://github.com/Jake-Prickett)
+- Add DocC Xcode File Type (`.docc`) [#660](https://github.com/tuist/XcodeProj/pull/660) by [@Jake-Prickett](https://github.com/Jake-Prickett)
 
 ## 8.6.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 🚀 Check out the guidelines [here](https://tuist.io/docs/contribution/changelog-guidelines/)
 
 ## Next
+### Added
+
+- Add DocC Xcode File Type (`.docc`) []() by [@Jake-Prickett](https://github.com/Jake-Prickett)
 
 ## 8.6.0
 ### Added

--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -124,6 +124,7 @@ public struct Xcode {
         "defs": "sourcecode.mig",
         "dext": "wrapper.driver-extension",
         "dict": "text.plist",
+        "docc": "folder.documentationcatalog",
         "dsym": "wrapper.dsym",
         "dtd": "text.xml",
         "dylan": "sourcecode.dylan",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3650

### Short description 📝
Adds support for including `Docs.docc` files. 

### Solution 📦
Inspected the project file to determine fileType for the new extension.

### Implementation 👩‍💻👨‍💻
Add `docc` and file type to Xcode constants for the project. 
