### PR TITLE
Fix equality checking of dictionaries

### DIFF
--- a/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
@@ -15,7 +15,7 @@ extension PBXBuildFile {
     func isEqual(to rhs: PBXBuildFile) -> Bool {
         if fileReference != rhs.fileReference { return false }
         if productReference != rhs.productReference { return false }
-        if !NSDictionary(dictionary: settings ?? [:]).isEqual(to: rhs.settings ?? [:]) { return false }
+        if !NSDictionary(dictionary: settings ?? [:]).isEqual(NSDictionary(dictionary: rhs.settings ?? [:])) { return false }
         if platformFilter != rhs.platformFilter { return false }
         if buildPhase != rhs.buildPhase { return false }
         return super.isEqual(to: rhs)
@@ -166,8 +166,8 @@ extension PBXProject {
         if projectReferences != rhs.projectReferences { return false }
         if projectRoots != rhs.projectRoots { return false }
         if targetReferences != rhs.targetReferences { return false }
-        if !NSDictionary(dictionary: attributes).isEqual(to: rhs.attributes) { return false }
-        if !NSDictionary(dictionary: targetAttributeReferences).isEqual(to: rhs.targetAttributeReferences) { return false }
+        if !NSDictionary(dictionary: attributes).isEqual(NSDictionary(dictionary: rhs.attributes)) { return false }
+        if !NSDictionary(dictionary: targetAttributeReferences).isEqual(NSDictionary(dictionary: rhs.targetAttributeReferences)) { return false }
         if packageReferences != rhs.packageReferences { return false }
         return super.isEqual(to: rhs)
     }
@@ -257,7 +257,7 @@ extension XCBuildConfiguration {
     /// :nodoc:
     func isEqual(to rhs: XCBuildConfiguration) -> Bool {
         if baseConfigurationReference != rhs.baseConfigurationReference { return false }
-        if !NSDictionary(dictionary: buildSettings).isEqual(to: rhs.buildSettings) { return false }
+        if !NSDictionary(dictionary: buildSettings).isEqual(NSDictionary(dictionary: rhs.buildSettings)) { return false }
         if name != rhs.name { return false }
         return super.isEqual(to: rhs)
     }

--- a/Templates/Equality.stencil
+++ b/Templates/Equality.stencil
@@ -6,7 +6,7 @@ extension {{ type.name }} {
     func isEqual(to rhs: {{ type.name }}) -> Bool {
         {% for variable in type.storedVariables %}
         {% if variable.typeName.dictionary %}
-        if !NSDictionary(dictionary: {{ variable.name}}{% if variable.typeName.isOptional %} ?? [:]{% endif %}).isEqual(to: rhs.{{ variable.name }}{% if variable.typeName.isOptional %} ?? [:]{% endif %}) { return false }
+        if !NSDictionary(dictionary: {{ variable.name}}{% if variable.typeName.isOptional %} ?? [:]{% endif %}).isEqual(NSDictionary(dictionary: rhs.{{ variable.name }}{% if variable.typeName.isOptional %} ?? [:]{% endif %})) { return false }
         {% elif variable|!annotated:"skipEquality" %}
         if {{ variable.name }} != rhs.{{ variable.name }} { return false }
         {% endif %}


### PR DESCRIPTION
### Short description 📝

Dictionary equality checks were only wrapping the lefthand side in `NSDictionary`, which was causing equality to return false unnecessarily.

### Solution 📦

Now the righthand side is wrapped in an `NSDictionary` as well.

### Implementation 👩‍💻👨‍💻

- [x] Updated `Equality.stencil`
- [x] Updated `Equality.generated.swift`
