### PR TITLE
Quiet new warnings from Xcode 13.3

### DIFF
--- a/.github/workflows/xcodeproj.yml
+++ b/.github/workflows/xcodeproj.yml
@@ -61,6 +61,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: GitHub Action for SwiftLint
-        uses: pepibumur/action-swiftlint@0d4afd006bb24e4525b5afcefd4ab5e2537193ac
+        uses: norio-nomura/action-swiftlint@3.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Sources/XcodeProj/Workspace/XCWorkspace.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspace.swift
@@ -28,7 +28,7 @@ public final class XCWorkspace: Writable, Equatable {
 
     /// Initializes a default workspace with a single reference that points to self:
     public convenience init() {
-        let data = XCWorkspaceData(children: [.file(.init(location: ._self("")))])
+        let data = XCWorkspaceData(children: [.file(.init(location: .current("")))])
         self.init(data: data)
     }
 

--- a/Sources/XcodeProj/Workspace/XCWorkspace.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspace.swift
@@ -28,7 +28,7 @@ public final class XCWorkspace: Writable, Equatable {
 
     /// Initializes a default workspace with a single reference that points to self:
     public convenience init() {
-        let data = XCWorkspaceData(children: [.file(.init(location: .self("")))])
+        let data = XCWorkspaceData(children: [.file(.init(location: ._self("")))])
         self.init(data: data)
     }
 

--- a/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
@@ -9,7 +9,7 @@ public enum XCWorkspaceDataElementLocationType {
     case container(String) // "Relative to container"
     case developer(String) // "Relative to Developer Directory"
     case group(String) // "Relative to group"
-    case `self`(String) // Single project workspace in xcodeproj directory
+    case _self(String) // Single project workspace in xcodeproj directory
     case other(String, String)
 
     public var schema: String {
@@ -22,7 +22,7 @@ public enum XCWorkspaceDataElementLocationType {
             return "developer"
         case .group:
             return "group"
-        case .self:
+        case ._self:
             return "self"
         case let .other(schema, _):
             return schema
@@ -39,7 +39,7 @@ public enum XCWorkspaceDataElementLocationType {
             return path
         case let .group(path):
             return path
-        case let .self(path):
+        case let ._self(path):
             return path
         case let .other(_, path):
             return path
@@ -62,7 +62,7 @@ public enum XCWorkspaceDataElementLocationType {
         case "group":
             self = .group(path)
         case "self":
-            self = .self(path)
+            self = ._self(path)
         default:
             self = .other(schema, path)
         }
@@ -86,7 +86,7 @@ extension XCWorkspaceDataElementLocationType: Equatable {
             return lhs == rhs
         case let (.group(lhs), .group(rhs)):
             return lhs == rhs
-        case let (.self(lhs), .self(rhs)):
+        case let (._self(lhs), ._self(rhs)):
             return lhs == rhs
         case let (.other(lhs0, lhs1), .other(rhs0, rhs1)):
             return lhs0 == rhs0 && lhs1 == rhs1

--- a/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
@@ -9,7 +9,7 @@ public enum XCWorkspaceDataElementLocationType {
     case container(String) // "Relative to container"
     case developer(String) // "Relative to Developer Directory"
     case group(String) // "Relative to group"
-    case _self(String) // Single project workspace in xcodeproj directory
+    case current(String) // Single project workspace in xcodeproj directory
     case other(String, String)
 
     public var schema: String {
@@ -22,7 +22,7 @@ public enum XCWorkspaceDataElementLocationType {
             return "developer"
         case .group:
             return "group"
-        case ._self:
+        case .current:
             return "self"
         case let .other(schema, _):
             return schema
@@ -39,7 +39,7 @@ public enum XCWorkspaceDataElementLocationType {
             return path
         case let .group(path):
             return path
-        case let ._self(path):
+        case let .current(path):
             return path
         case let .other(_, path):
             return path
@@ -62,7 +62,7 @@ public enum XCWorkspaceDataElementLocationType {
         case "group":
             self = .group(path)
         case "self":
-            self = ._self(path)
+            self = .current(path)
         default:
             self = .other(schema, path)
         }
@@ -86,7 +86,7 @@ extension XCWorkspaceDataElementLocationType: Equatable {
             return lhs == rhs
         case let (.group(lhs), .group(rhs)):
             return lhs == rhs
-        case let (._self(lhs), ._self(rhs)):
+        case let (.current(lhs), .current(rhs)):
             return lhs == rhs
         case let (.other(lhs0, lhs1), .other(rhs0, rhs1)):
             return lhs0 == rhs0 && lhs1 == rhs1

--- a/Tests/XcodeProjTests/Workspace/XCWorkspaceDataTests.swift
+++ b/Tests/XcodeProjTests/Workspace/XCWorkspaceDataTests.swift
@@ -10,7 +10,7 @@ final class XCWorkspaceDataTests: XCTestCase {
     override func setUp() {
         super.setUp()
         fileRef = XCWorkspaceDataFileRef(
-            location: .self("path")
+            location: ._self("path")
         )
         subject = XCWorkspaceData(children: [])
     }
@@ -26,7 +26,7 @@ final class XCWorkspaceDataIntegrationTests: XCTestCase {
         let path = fixturePath()
         let got = try XCWorkspaceData(path: path)
         if case let XCWorkspaceDataElement.file(location: fileRef) = got.children.first! {
-            XCTAssertEqual(fileRef.location, .self(""))
+            XCTAssertEqual(fileRef.location, ._self(""))
         } else {
             XCTAssertTrue(false, "Expected file reference")
         }
@@ -45,7 +45,7 @@ final class XCWorkspaceDataIntegrationTests: XCTestCase {
             initModel: { try? XCWorkspaceData(path: $0) },
             modify: {
                 $0.children.append(
-                    .group(.init(location: .self("shakira"),
+                    .group(.init(location: ._self("shakira"),
                                  name: "shakira",
                                  children: []))
                 )

--- a/Tests/XcodeProjTests/Workspace/XCWorkspaceDataTests.swift
+++ b/Tests/XcodeProjTests/Workspace/XCWorkspaceDataTests.swift
@@ -10,7 +10,7 @@ final class XCWorkspaceDataTests: XCTestCase {
     override func setUp() {
         super.setUp()
         fileRef = XCWorkspaceDataFileRef(
-            location: ._self("path")
+            location: .current("path")
         )
         subject = XCWorkspaceData(children: [])
     }
@@ -26,7 +26,7 @@ final class XCWorkspaceDataIntegrationTests: XCTestCase {
         let path = fixturePath()
         let got = try XCWorkspaceData(path: path)
         if case let XCWorkspaceDataElement.file(location: fileRef) = got.children.first! {
-            XCTAssertEqual(fileRef.location, ._self(""))
+            XCTAssertEqual(fileRef.location, .current(""))
         } else {
             XCTAssertTrue(false, "Expected file reference")
         }
@@ -45,7 +45,7 @@ final class XCWorkspaceDataIntegrationTests: XCTestCase {
             initModel: { try? XCWorkspaceData(path: $0) },
             modify: {
                 $0.children.append(
-                    .group(.init(location: ._self("shakira"),
+                    .group(.init(location: .current("shakira"),
                                  name: "shakira",
                                  children: []))
                 )

--- a/Tests/XcodeProjTests/Workspace/XCWorkspaceTests.swift
+++ b/Tests/XcodeProjTests/Workspace/XCWorkspaceTests.swift
@@ -19,7 +19,7 @@ final class XCWorkspaceIntegrationTests: XCTestCase {
 
     func test_init_returnsAWorkspaceWithTheCorrectReference() {
         XCTAssertEqual(XCWorkspace().data.children.count, 1)
-        XCTAssertEqual(XCWorkspace().data.children.first, .file(.init(location: .self(""))))
+        XCTAssertEqual(XCWorkspace().data.children.first, .file(.init(location: ._self(""))))
     }
 
     func test_equatable_emptyWorkspacesAreEqual() {

--- a/Tests/XcodeProjTests/Workspace/XCWorkspaceTests.swift
+++ b/Tests/XcodeProjTests/Workspace/XCWorkspaceTests.swift
@@ -19,7 +19,7 @@ final class XCWorkspaceIntegrationTests: XCTestCase {
 
     func test_init_returnsAWorkspaceWithTheCorrectReference() {
         XCTAssertEqual(XCWorkspace().data.children.count, 1)
-        XCTAssertEqual(XCWorkspace().data.children.first, .file(.init(location: ._self(""))))
+        XCTAssertEqual(XCWorkspace().data.children.first, .file(.init(location: .current(""))))
     }
 
     func test_equatable_emptyWorkspacesAreEqual() {


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/672

### Short description 📝

Building the project with Xcode 13.3 produces some new annoying warnings related to the naming of one of the cases on the `XCWorkspaceDataElementLocationType` enum. See https://github.com/tuist/XcodeProj/issues/672 for more details.

### Solution 📦

I renamed `case self(path)` to `case _self(path)`, which silences the warnings. Tests still run successfully as well.

I tried using Xcode's suggestion of changing it to `XCWorkspaceDataElementLocationType.self(path)`, but then a new compiler error is thrown.

I also tried adding backticks to the case name (`XCWorkspaceDataElementLocationType.`self`(path)`, but then the same warning as above is thrown again.
