### PR TITLE
Add `addDependency()` helper method to `PBXAggregateTarget`

### DIFF
--- a/Sources/XcodeProj/Objects/Targets/PBXAggregateTarget.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXAggregateTarget.swift
@@ -15,3 +15,30 @@ extension PBXAggregateTarget: PlistSerializable {
         return try plistValues(proj: proj, isa: PBXAggregateTarget.isa, reference: reference)
     }
 }
+
+// MARK: - Helpers
+
+public extension PBXAggregateTarget {
+    /// Adds a local target dependency to the target.
+    ///
+    /// - Parameter target: dependency target.
+    /// - Returns: target dependency reference.
+    /// - Throws: an error if the dependency cannot be created.
+    func addDependency(target: PBXTarget) throws -> PBXTargetDependency? {
+        let objects = try target.objects()
+        guard let project = objects.projects.first?.value else {
+            return nil
+        }
+        let proxy = PBXContainerItemProxy(containerPortal: .project(project),
+                                          remoteGlobalID: .object(target),
+                                          proxyType: .nativeTarget,
+                                          remoteInfo: target.name)
+        objects.add(object: proxy)
+        let targetDependency = PBXTargetDependency(name: target.name,
+                                                   target: target,
+                                                   targetProxy: proxy)
+        objects.add(object: targetDependency)
+        dependencies.append(targetDependency)
+        return targetDependency
+    }
+}

--- a/Tests/XcodeProjTests/Objects/Targets/PBXAggregateTargetTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXAggregateTargetTests.swift
@@ -27,4 +27,34 @@ final class PBXAggregateTargetTests: XCTestCase {
             "name": "name",
         ]
     }
+
+    func test_addDependency() throws {
+        let objects = PBXObjects(objects: [])
+
+        let configurationList = XCConfigurationList.fixture()
+        let mainGroup = PBXGroup.fixture()
+        objects.add(object: configurationList)
+        objects.add(object: mainGroup)
+
+        let project = PBXProject(name: "Project",
+                                 buildConfigurationList: configurationList,
+                                 compatibilityVersion: "0",
+                                 mainGroup: mainGroup)
+
+        objects.add(object: project)
+        let target = PBXAggregateTarget(name: "Target", buildConfigurationList: nil)
+        let dependency = PBXAggregateTarget(name: "Dependency", buildConfigurationList: nil)
+        objects.add(object: target)
+        objects.add(object: dependency)
+        _ = try target.addDependency(target: dependency)
+        let targetDependency: PBXTargetDependency? = target.dependencyReferences.first?.getObject()
+
+        XCTAssertEqual(targetDependency?.name, "Dependency")
+        XCTAssertEqual(targetDependency?.targetReference, dependency.reference)
+        let containerItemProxy: PBXContainerItemProxy? = targetDependency?.targetProxyReference?.getObject()
+        XCTAssertEqual(containerItemProxy?.containerPortalReference, project.reference)
+        XCTAssertEqual(containerItemProxy?.remoteGlobalID?.uuid, dependency.reference.value)
+        XCTAssertEqual(containerItemProxy?.proxyType, .nativeTarget)
+        XCTAssertEqual(containerItemProxy?.remoteInfo, "Dependency")
+    }
 }


### PR DESCRIPTION
### Short description 📝

The `addDependency()` helper method is useful for more than just `PBXNativeTarget`, such as for `PBXAggregateTarget`.

### Solution 📦

Add a copy of the extension on `PBXNativeTarget` to `PBXAggregateTarget`.

We could maybe instead move the extension to `PBXTarget`? I'm not sure if it's valid there.

