### PR TITLE
Allow for initializing a PBXProj via a direct path

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -52,6 +52,24 @@ public final class PBXProj: Decodable {
         }
     }
 
+    /// Initializes the project with a path to the pbxproj file.
+    ///
+    /// - Parameters:
+    ///   - path: Path to a pbxproj file.
+    public convenience init(path: Path) throws {
+        let pbxproject: PBXProj = try PBXProj.createPBXProj(path: path)
+        var objects: [PBXObject] = []
+        pbxproject.objects.forEach { object in
+            objects.append(object)
+        }
+        self.init(
+            rootObject: pbxproject.rootObject,
+            objectVersion: pbxproject.objectVersion,
+            archiveVersion: pbxproject.archiveVersion,
+            classes: pbxproject.classes,
+            objects: objects)
+    }
+
     // MARK: - Decodable
 
     fileprivate enum CodingKeys: String, CodingKey {
@@ -95,7 +113,7 @@ public final class PBXProj: Decodable {
 
     // MARK: Static Methods
 
-    public static func createPBXProj(path: Path) throws -> PBXProj {
+    private static func createPBXProj(path: Path) throws -> PBXProj {
         let (pbxProjData, pbxProjDictionary) = try PBXProj.readPBXProj(path: path)
         let context = ProjectDecodingContext(
             pbxProjValueReader: { key in

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -109,7 +109,7 @@ public final class PBXProj: Decodable {
         return pbxproj
     }
 
-    internal static func readPBXProj(path: Path) throws -> (Data, [String: Any]) {
+    private static func readPBXProj(path: Path) throws -> (Data, [String: Any]) {
         let plistXML = try Data(contentsOf: path.url)
         var propertyListFormat = PropertyListSerialization.PropertyListFormat.xml
         let serialized = try PropertyListSerialization.propertyList(

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -57,17 +57,28 @@ public final class PBXProj: Decodable {
     /// - Parameters:
     ///   - path: Path to a pbxproj file.
     public convenience init(path: Path) throws {
-        let pbxproject: PBXProj = try PBXProj.createPBXProj(path: path)
-        var objects: [PBXObject] = []
-        pbxproject.objects.forEach { object in
-            objects.append(object)
-        }
+        let pbxproj: PBXProj = try PBXProj.createPBXProj(path: path)
         self.init(
-            rootObject: pbxproject.rootObject,
-            objectVersion: pbxproject.objectVersion,
-            archiveVersion: pbxproject.archiveVersion,
-            classes: pbxproject.classes,
-            objects: objects)
+            rootObject: pbxproj.rootObject,
+            objectVersion: pbxproj.objectVersion,
+            archiveVersion: pbxproj.archiveVersion,
+            classes: pbxproj.classes,
+            objects: pbxproj.objects
+        )
+    }
+
+    private init(
+        rootObject: PBXProject? = nil,
+        objectVersion: UInt = Xcode.LastKnown.objectVersion,
+        archiveVersion: UInt = Xcode.LastKnown.archiveVersion,
+        classes: [String: Any] = [:],
+        objects: PBXObjects
+    ) {
+        self.archiveVersion = archiveVersion
+        self.objectVersion = objectVersion
+        self.classes = classes
+        rootObjectReference = rootObject?.reference
+        self.objects = objects
     }
 
     // MARK: - Decodable

--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -25,7 +25,7 @@ public final class XcodeProj: Equatable {
         guard let pbxprojPath = path.glob("*.pbxproj").first else {
             throw XCodeProjError.pbxprojNotFound(path: path)
         }
-        pbxproj = try PBXProj.createPBXProj(path: pbxprojPath)
+        pbxproj = try PBXProj(path: pbxprojPath)
         let xcworkspacePaths = path.glob("*.xcworkspace")
         if xcworkspacePaths.isEmpty {
             workspace = XCWorkspace()

--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -25,16 +25,7 @@ public final class XcodeProj: Equatable {
         guard let pbxprojPath = path.glob("*.pbxproj").first else {
             throw XCodeProjError.pbxprojNotFound(path: path)
         }
-        let (pbxProjData, pbxProjDictionary) = try XcodeProj.readPBXProj(path: pbxprojPath)
-        let context = ProjectDecodingContext(
-            pbxProjValueReader: { key in
-                pbxProjDictionary[key]
-            }
-        )
-
-        let plistDecoder = XcodeprojPropertyListDecoder(context: context)
-        pbxproj = try plistDecoder.decode(PBXProj.self, from: pbxProjData)
-        try pbxproj.updateProjectName(path: pbxprojPath)
+        pbxproj = try PBXProj.createPBXProj(path: pbxprojPath)
         let xcworkspacePaths = path.glob("*.xcworkspace")
         if xcworkspacePaths.isEmpty {
             workspace = XCWorkspace()
@@ -71,21 +62,6 @@ public final class XcodeProj: Equatable {
             lhs.pbxproj == rhs.pbxproj &&
             lhs.sharedData == rhs.sharedData
     }
-
-    // MARK: - Private
-
-    private static func readPBXProj(path: Path) throws -> (Data, [String: Any]) {
-        let plistXML = try Data(contentsOf: path.url)
-        var propertyListFormat = PropertyListSerialization.PropertyListFormat.xml
-        let serialized = try PropertyListSerialization.propertyList(
-            from: plistXML,
-            options: .mutableContainersAndLeaves,
-            format: &propertyListFormat
-        )
-        // swiftlint:disable:next force_cast
-        let pbxProjDictionary = serialized as! [String: Any]
-        return (plistXML, pbxProjDictionary)
-    }
 }
 
 // MARK: - <Writable>
@@ -117,7 +93,7 @@ extension XcodeProj: Writable {
     /// Returns workspace file path relative to the given path.
     ///
     /// - Parameter path: `.xcodeproj` file path
-    /// - Returns: worspace file path relative to the given path.
+    /// - Returns: workspace file path relative to the given path.
     public static func workspacePath(_ path: Path) -> Path {
         path + "project.xcworkspace"
     }


### PR DESCRIPTION


### Short description 📝
Allows for a pbxproj path to be initiated with a direct path, also
moves some related code to the PBXProj class

### Solution 📦
Simply moves around the code that already exists and opens some ACLs to allow callers of the library to use this code

### Implementation 👩‍💻👨‍💻
N/A
