### PR TITLE
Add `.extensionKitExtension` as the new `PBXProductType`

### DIFF
--- a/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
@@ -12,7 +12,7 @@ public enum PBXProductType: String, Decodable {
     case unitTestBundle = "com.apple.product-type.bundle.unit-test"
     case uiTestBundle = "com.apple.product-type.bundle.ui-testing"
     case appExtension = "com.apple.product-type.app-extension"
-    case extensionKit = "com.apple.product-type.extensionkit-extension"
+    case extensionKitExtension = "com.apple.product-type.extensionkit-extension"
     case commandLineTool = "com.apple.product-type.tool"
     case watchApp = "com.apple.product-type.application.watchapp"
     case watch2App = "com.apple.product-type.application.watchapp2"
@@ -48,7 +48,7 @@ public enum PBXProductType: String, Decodable {
             return "bundle"
         case .unitTestBundle, .uiTestBundle:
             return "xctest"
-        case .appExtension, .extensionKit, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension, .intentsServiceExtension:
+        case .appExtension, .extensionKitExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension, .intentsServiceExtension:
             return "appex"
         case .commandLineTool:
             return nil

--- a/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
@@ -12,6 +12,7 @@ public enum PBXProductType: String, Decodable {
     case unitTestBundle = "com.apple.product-type.bundle.unit-test"
     case uiTestBundle = "com.apple.product-type.bundle.ui-testing"
     case appExtension = "com.apple.product-type.app-extension"
+    case extensionKit = "com.apple.product-type.extensionkit-extension"
     case commandLineTool = "com.apple.product-type.tool"
     case watchApp = "com.apple.product-type.application.watchapp"
     case watch2App = "com.apple.product-type.application.watchapp2"
@@ -47,7 +48,7 @@ public enum PBXProductType: String, Decodable {
             return "bundle"
         case .unitTestBundle, .uiTestBundle:
             return "xctest"
-        case .appExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension, .intentsServiceExtension:
+        case .appExtension, .extensionKit, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension, .intentsServiceExtension:
             return "appex"
         case .commandLineTool:
             return nil

--- a/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
@@ -48,7 +48,8 @@ public enum PBXProductType: String, Decodable {
             return "bundle"
         case .unitTestBundle, .uiTestBundle:
             return "xctest"
-        case .appExtension, .extensionKitExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension, .intentsServiceExtension:
+        case .appExtension, .extensionKitExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension,
+                .intentsServiceExtension:
             return "appex"
         case .commandLineTool:
             return nil

--- a/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
@@ -39,8 +39,8 @@ final class PBXProductTypeTests: XCTestCase {
         XCTAssertEqual(PBXProductType.appExtension.rawValue, "com.apple.product-type.app-extension")
     }
 
-    func test_extensionKit_hasTheRightValue() {
-        XCTAssertEqual(PBXProductType.extensionKit.rawValue, "com.apple.product-type.extensionkit-extension")
+    func test_extensionKitExtension_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.extensionKitExtension.rawValue, "com.apple.product-type.extensionkit-extension")
     }
 
     func test_commandLineTool_hasTheRightValue() {

--- a/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
@@ -39,6 +39,10 @@ final class PBXProductTypeTests: XCTestCase {
         XCTAssertEqual(PBXProductType.appExtension.rawValue, "com.apple.product-type.app-extension")
     }
 
+    func test_extensionKit_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.extensionKit.rawValue, "com.apple.product-type.extensionkit-extension")
+    }
+
     func test_commandLineTool_hasTheRightValue() {
         XCTAssertEqual(PBXProductType.commandLineTool.rawValue, "com.apple.product-type.tool")
     }


### PR DESCRIPTION
Resolves: https://github.com/tuist/XcodeProj/issues/687

### Short description 📝
From Xcode14 beta 1, `com.apple.product-type.extensionkit-extension` was introduced as the new productType.
The new productType is used for a new app extension like AppIntents Extension.

### Solution 📦
Added `.extensionKitExtension` as the new case of `PBXProductType` in this PR, to support the new productType.

### Implementation 👩‍💻👨‍💻
- [x] Added `.extensionKitExtension` as the new case of `PBXProductType`
- [x] Added `fileExtension` of `.extensionKitExtension `
- [x] Added a new UnitTest for `.extensionKitExtension `
