### PR TITLE
Add default target settings for resource bundles

### DIFF
--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -245,6 +245,12 @@ public class BuildSettingsProvider {
             return [
                 "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
             ]
+        case ([.iOS, .watchOS, .tvOS], .bundle):
+            // Assumption here is `.bundle` is used on those platforms for resource bundle targets,
+            // where code signing is not required.
+            return [
+                "CODE_SIGNING_ALLOWED": "NO",
+            ]
         case (.macOS, .framework):
             return [
                 "COMBINE_HIDPI_IMAGES": "YES",

--- a/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
+++ b/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
@@ -236,6 +236,25 @@ class BuildSettingProviderTests: XCTestCase {
         ])
     }
 
+    func test_targetSettings_iOSResourceBundle() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(
+            variant: .debug,
+            platform: .iOS,
+            product: .bundle
+        )
+
+        // Then
+        assertEqualSettings(results, [
+            "CODE_SIGNING_ALLOWED": "NO",
+            "CODE_SIGN_IDENTITY": "iPhone Developer",
+            "SDKROOT": "iphoneos",
+            "SKIP_INSTALL": "YES",
+            "TARGETED_DEVICE_FAMILY": "1,2",
+            "WRAPPER_EXTENSION": "bundle",
+        ])
+    }
+
     // MARK: - Helpers
 
     func assertEqualSettings(_ lhs: BuildSettings, _ rhs: BuildSettings, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION

Resolves: https://github.com/tuist/tuist/issues/4568

### Short description 📝

- On Xcode 14, the default `CODE_SIGNING_ALLOWED` setting has changed to `YES` whereas it used to be `NO` on Xcode 13
- This causes archiving to fail for cases where iOS applications use bundle targets to host resources, as code signing fails
  - Code signing isn't required for resource bundle target (as far as I'm aware)

### Solution 📦

- To mitigate this on Xcode 14 and maintain backwards compatibility with Xcode 13, a new default target setting is being added to keep this set to `NO`

### References 📚

- https://github.com/tuist/tuist/pull/4588
- https://developer.apple.com/forums/thread/708659

Assuming a project that has an iOS resource bundle target called `A_A`, we can examine the resolved settings by Xcode when no settings are specified for `CODE_SIGNING_ALLOWED`

```sh
$ xcrun xcodebuild -showBuildSettings -workspace App.xcworkspace -scheme A_A | grep CODE_SIGN
    AD_HOC_CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_REQUIRED = YES
    CODE_SIGN_CONTEXT_CLASS = XCiPhoneOSCodeSignContext
    CODE_SIGN_IDENTITY = iPhone Developer
    CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES
    EXPANDED_CODE_SIGN_IDENTITY =
    EXPANDED_CODE_SIGN_IDENTITY_NAME =
    __CODE_SIGNING_ALLOWED_appletvos = NO
    __CODE_SIGNING_ALLOWED_iphoneos = NO
    __CODE_SIGNING_ALLOWED_watchos = NO
```

```sh
$ DEVELOPER_DIR=/Applications/Xcode14-beta2.app/Contents/Developer/ xcrun xcodebuild -showBuildSettings -workspace App.xcworkspace -scheme A_A | grep CODE_SIGN
    AD_HOC_CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_ALLOWED = YES
    CODE_SIGNING_REQUIRED = YES
    CODE_SIGN_CONTEXT_CLASS = XCiPhoneOSCodeSignContext
    CODE_SIGN_IDENTITY = iPhone Developer
    CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES
    EXPANDED_CODE_SIGN_IDENTITY =
    EXPANDED_CODE_SIGN_IDENTITY_NAME =
```

### Alternatives

We could alternatively keep this default setting within Tuist's [`DefaultSettingsProvider`](https://github.com/tuist/tuist/blob/main/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift) if we think this isn't generally applicable.
