### PR TITLE
Fix ordering of Scheme toplevel attrs

### DIFF
--- a/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
@@ -92,6 +92,11 @@ let attributesOrder: [String: [String]] = [
         "symbolName",
         "moduleName",
     ],
+    "Scheme": [
+        "LastUpgradeVersion",
+        "wasCreatedForAppExtension",
+        "version"
+    ]
 ]
 
 extension AEXMLElement {

--- a/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
+++ b/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
@@ -161,6 +161,8 @@ class AEXML_XcodeFormatTests: XCTestCase {
                 "wasCreatedForAppExtension": "YES",
                 "LastUpgradeVersion": "1320",
                 "version": "1.7"
+            ]
+        )
     }
 
     func test_RemoteRunnable() {

--- a/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
+++ b/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
@@ -43,6 +43,16 @@ class AEXML_XcodeFormatTests: XCTestCase {
         </TestAction>
         """
 
+    private let expectedSchemeXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Scheme
+           LastUpgradeVersion = "1320"
+           wasCreatedForAppExtension = "YES"
+           version = "1.7">
+        </Scheme>
+        """
+
     func test_BuildAction_attributes_sorted_when_original_sorted() {
         validateAttributes(
             expectedXML: expectedBuildActionXml.cleaned,
@@ -117,6 +127,30 @@ class AEXML_XcodeFormatTests: XCTestCase {
                 "buildConfiguration": "Debug",
                 "customLLDBInitFile": "$(BAZEL_LLDB_INIT)",
                 "selectedLauncherIdentifier": "Xcode.DebuggerFoundation.Launcher.LLDB"
+            ]
+        )
+    }
+
+    func test_Scheme_attributes_sorted_when_original_sorted() {
+        validateAttributes(
+            expectedXML: expectedSchemeXml.cleaned,
+            childName: "Scheme",
+            attributes: [
+                "LastUpgradeVersion": "1320",
+                "wasCreatedForAppExtension": "YES",
+                "version": "1.7"
+            ]
+        )
+    }
+
+    func test_Scheme_attributes_sorted_when_original_unsorted() {
+        validateAttributes(
+            expectedXML: expectedSchemeXml.cleaned,
+            childName: "Scheme",
+            attributes: [
+                "wasCreatedForAppExtension": "YES",
+                "LastUpgradeVersion": "1320",
+                "version": "1.7"
             ]
         )
     }


### PR DESCRIPTION
Fix for incorrect ordering of `Scheme` attrs when
using `wasCreatedForAppExtension` value
