### PR TITLE
Add `launchAutomaticallySubstyle`->`ProfileAction`

### DIFF
--- a/Fixtures/Schemes/RunnableWithoutBuildableReference.xcscheme
+++ b/Fixtures/Schemes/RunnableWithoutBuildableReference.xcscheme
@@ -76,7 +76,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Sources/XcodeProj/Scheme/XCScheme+ProfileAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+ProfileAction.swift
@@ -22,6 +22,7 @@ extension XCScheme {
         public var environmentVariables: [EnvironmentVariable]?
         public var macroExpansion: BuildableReference?
         public var enableTestabilityWhenProfilingTests: Bool
+        public var launchAutomaticallySubstyle: String?
 
         // MARK: - Init
 
@@ -38,7 +39,8 @@ extension XCScheme {
                     askForAppToLaunch: Bool? = nil,
                     commandlineArguments: CommandLineArguments? = nil,
                     environmentVariables: [EnvironmentVariable]? = nil,
-                    enableTestabilityWhenProfilingTests: Bool = true) {
+                    enableTestabilityWhenProfilingTests: Bool = true,
+                    launchAutomaticallySubstyle: String?) {
             self.buildableProductRunnable = buildableProductRunnable
             self.buildConfiguration = buildConfiguration
             self.macroExpansion = macroExpansion
@@ -51,6 +53,7 @@ extension XCScheme {
             self.environmentVariables = environmentVariables
             self.ignoresPersistentStateOnLaunch = ignoresPersistentStateOnLaunch
             self.enableTestabilityWhenProfilingTests = enableTestabilityWhenProfilingTests
+            self.launchAutomaticallySubstyle = launchAutomaticallySubstyle
             super.init(preActions, postActions)
         }
 
@@ -80,6 +83,7 @@ extension XCScheme {
                 self.environmentVariables = try EnvironmentVariable.parseVariables(from: environmentVariables)
             }
             enableTestabilityWhenProfilingTests = element.attributes["enableTestabilityWhenProfilingTests"].map { $0 != "No" } ?? true
+            launchAutomaticallySubstyle = element.attributes["launchAutomaticallySubstyle"]
             try super.init(element: element)
         }
 
@@ -111,6 +115,9 @@ extension XCScheme {
             if let environmentVariables = environmentVariables {
                 element.addChild(EnvironmentVariable.xmlElement(from: environmentVariables))
             }
+            if let launchAutomaticallySubstyle = launchAutomaticallySubstyle {
+                element.attributes["launchAutomaticallySubstyle"] = launchAutomaticallySubstyle
+            }
 
             if let macroExpansion = macroExpansion {
                 let macro = element.addChild(name: "MacroExpansion")
@@ -136,7 +143,8 @@ extension XCScheme {
                 commandlineArguments == rhs.commandlineArguments &&
                 environmentVariables == rhs.environmentVariables &&
                 macroExpansion == rhs.macroExpansion &&
-                enableTestabilityWhenProfilingTests == rhs.enableTestabilityWhenProfilingTests
+                enableTestabilityWhenProfilingTests == rhs.enableTestabilityWhenProfilingTests &&
+                launchAutomaticallySubstyle == rhs.launchAutomaticallySubstyle
         }
     }
 }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -571,6 +571,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertNil(scheme.profileAction?.askForAppToLaunch)
         XCTAssertNil(scheme.profileAction?.commandlineArguments)
         XCTAssertNil(scheme.profileAction?.environmentVariables)
+        XCTAssertEqual(scheme.profileAction?.launchAutomaticallySubstyle, "2")
 
         // Analyze action
         XCTAssertEqual(scheme.analyzeAction?.buildConfiguration, "Debug")


### PR DESCRIPTION
Adds a missing attribute `launchAutomaticallySubstyle` to
`ProfileAction` scheme type. This value will be set
by Xcode if editing an application extension

Resolves https://github.com/tuist/xcodeproj/issues/696
