### PR TITLE
Fix `Testables` element ordering

### DIFF
--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -194,13 +194,14 @@ extension XCScheme {
                 }
             }
 
-            let testablesElement = element.addChild(name: "Testables")
-            testables.forEach { testable in
-                testablesElement.addChild(testable.xmlElement())
-            }
             if let macroExpansion = macroExpansion {
                 let macro = element.addChild(name: "MacroExpansion")
                 macro.addChild(macroExpansion.xmlElement())
+            }
+
+            let testablesElement = element.addChild(name: "Testables")
+            testables.forEach { testable in
+                testablesElement.addChild(testable.xmlElement())
             }
 
             if let commandlineArguments = commandlineArguments {


### PR DESCRIPTION
`Testables` should come after `MacroExpansion` (Xcode expects this and
will edit projects with invalid order).