### PR TITLE
Add `DEAD_CODE_STRIPPING` default project setting

### DIFF
--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -128,6 +128,7 @@ public class BuildSettingsProvider {
             "CLANG_WARN_UNGUARDED_AVAILABILITY": "YES_AGGRESSIVE",
             "CLANG_WARN_UNREACHABLE_CODE": "YES",
             "COPY_PHASE_STRIP": "NO",
+            "DEAD_CODE_STRIPPING": "YES",
             "ENABLE_STRICT_OBJC_MSGSEND": "YES",
             "GCC_C_LANGUAGE_STANDARD": "gnu11",
             "GCC_NO_COMMON_BLOCKS": "YES",


### PR DESCRIPTION
Relates to: https://github.com/tuist/tuist/discussions/4531

### Short description 📝

- As of Xcode 14, `DEAD_CODE_STRIPPING` is now a recommended setting for macOS or iOS with catalyst projects and targets

### Solution 📦

- Add `DEAD_CODE_STRIPPING` as a default project setting
- iOS already had `DEAD_CODE_STRIPPING` enabled as a default in prior Xcode versions, so explicitly setting shouldn't cause a change in behaviour
