### PR TITLE
Fix warning compiling for macOS 13

### DIFF
--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -50,6 +50,7 @@ private extension DataProtocol {
     var hexString: String {
         let hexLen = self.count * 2
         let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: hexLen)
+        ptr.assign(repeating: 0, count: hexLen)
         defer { ptr.deallocate() }
         var offset = 0
 
@@ -60,8 +61,6 @@ private extension DataProtocol {
                 offset += 1
             }
         }
-
-        ptr[Int(offset * 2)] = 0 // Null terminator
 
         return String(cString: ptr)
     }

--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -61,6 +61,8 @@ private extension DataProtocol {
             }
         }
 
+        ptr[Int(offset * 2)] = 0 // Null terminator
+
         return String(cString: ptr)
     }
 

--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -50,6 +50,7 @@ private extension DataProtocol {
     var hexString: String {
         let hexLen = self.count * 2
         let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: hexLen)
+        defer { ptr.deallocate() }
         var offset = 0
 
         self.regions.forEach { (_) in
@@ -60,7 +61,7 @@ private extension DataProtocol {
             }
         }
 
-        return String(bytesNoCopy: ptr, length: hexLen, encoding: .utf8, freeWhenDone: true)!
+        return String(cString: ptr)
     }
 
     func itoh(_ value: UInt8) -> UInt8 {


### PR DESCRIPTION
### Short description 📝

There's a deprecation warning when building with Xcode 14 targeting macOS 13:

```
Sources/XcodeProj/Extensions/String+md5.swift:63:16: warning: 'init(bytesNoCopy:length:encoding:freeWhenDone:)' was deprecated in macOS 13: String does not support no-copy initialization
        return String(bytesNoCopy: ptr, length: hexLen, encoding: .utf8, freeWhenDone: true)!
               ^
```

This is because `String.init(bytesNoCopy:...)` was deprecated in macOS 13: https://developer.apple.com/documentation/swift/string/init(bytesnocopy:length:encoding:freewhendone:)

Further discussion here: https://forums.swift.org/t/does-string-bytesnocopy-copy-bytes/51643/11

### Solution 📦

Use `String.init(cString:)` instead.

### Implementation 👩‍💻👨‍💻

- [x] Use `String.init(cString:)` instead of `String.init(bytesNoCopy:...)`
- [x] Deallocate bytes from pointer after creating the string