### PR TITLE
Implement `Hashable` for `XCScheme.BuildableReference`

### DIFF
--- a/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift
@@ -2,7 +2,7 @@ import AEXML
 import Foundation
 
 extension XCScheme {
-    public final class BuildableReference: Equatable {
+    public final class BuildableReference: Equatable, Hashable {
         // MARK: - Attributes
 
         public var referencedContainer: String
@@ -104,6 +104,15 @@ extension XCScheme {
                 lhs.buildableName == rhs.buildableName &&
                 lhs.blueprint == rhs.blueprint &&
                 lhs.blueprintName == rhs.blueprintName
+        }
+
+        // MARK: - Hashable
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(referencedContainer)
+            hasher.combine(blueprintIdentifier)
+            hasher.combine(buildableName)
+            hasher.combine(blueprintName)
         }
     }
 }

--- a/Tests/XcodeProjTests/Scheme/XCScheme+BuildableReferenceTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCScheme+BuildableReferenceTests.swift
@@ -1,0 +1,24 @@
+@testable import XcodeProj
+import XCTest
+
+final class XCSchemeBuildableReferenceTests: XCTestCase {
+    func test_hash() throws {
+        // Values that are equal must generate the same hash value
+        let aBuildRef = XCScheme.BuildableReference(
+            referencedContainer: "container ref",
+            blueprint: nil,
+            buildableName: "buildable name",
+            blueprintName: "blueprint name"
+        )
+        let bBuildRef = XCScheme.BuildableReference(
+            referencedContainer: "container ref",
+            blueprint: nil,
+            buildableName: "buildable name",
+            blueprintName: "blueprint name"
+        )
+        XCTAssertEqual(aBuildRef, bBuildRef)
+
+        let buildRefs: Set<XCScheme.BuildableReference> = [aBuildRef]
+        XCTAssertTrue(buildRefs.contains(bBuildRef))
+    }
+}


### PR DESCRIPTION
### Short description 📝
Allow `XCScheme.BuildableReference` to be used with `Set` and as a key for `Dictionary`.

### Solution 📦
Implement `Hashable`.

### Implementation 👩‍💻👨‍💻

- [ ] Implemented `Hashable`.
- [ ] Added test to ensure that `Hashable` contract is maintained.
