### PR TITLE
Revert "Fix warning compiling for macOS 13"

### DIFF
--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -50,8 +50,6 @@ private extension DataProtocol {
     var hexString: String {
         let hexLen = self.count * 2
         let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: hexLen)
-        ptr.assign(repeating: 0, count: hexLen)
-        defer { ptr.deallocate() }
         var offset = 0
 
         self.regions.forEach { (_) in
@@ -62,7 +60,7 @@ private extension DataProtocol {
             }
         }
 
-        return String(cString: ptr)
+        return String(bytesNoCopy: ptr, length: hexLen, encoding: .utf8, freeWhenDone: true)!
     }
 
     func itoh(_ value: UInt8) -> UInt8 {


### PR DESCRIPTION
Resolves: https://github.com/tuist/XcodeProj/issues/714

- Reverts tuist/XcodeProj#710 
- Sadly this commit made the references unstable, we can revert and reintroduce once the stability issues have been addressed
- Running the tests repeatedly helps surface the issue
