### PR TITLE
Add accessor for runScript Build Phases on PBXTarget.

### DIFF
--- a/Sources/XcodeProj/Objects/Targets/PBXTarget.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXTarget.swift
@@ -282,4 +282,13 @@ public extension PBXTarget {
             .compactMap { $0 as? PBXCopyFilesBuildPhase }
             .filter { $0.dstSubfolderSpec == .frameworks }
     }
+
+    /// Returns the run script build phases.
+    ///
+    /// - Returns: Run script build phases.
+    func runScriptBuildPhases() -> [PBXShellScriptBuildPhase] {
+        buildPhases
+            .filter { $0.buildPhase == .runScript }
+            .compactMap { $0 as? PBXShellScriptBuildPhase }
+    }
 }

--- a/Tests/XcodeProjTests/Objects/Targets/PBXTargetTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXTargetTests.swift
@@ -85,4 +85,48 @@ final class PBXTargetTests: XCTestCase {
         XCTAssertTrue(embedFrameworkBuildPhases.contains(embedFrameworkBuildPhase1))
         XCTAssertTrue(embedFrameworkBuildPhases.contains(embedFrameworkBuildPhase2))
     }
+
+    func test_runScriptBuildPhases_returnsEmptyIfNoRunScriptBuildPhases() {
+        let notShellScriptBuildPhase1 = PBXFrameworksBuildPhase(
+            files: [],
+            inputFileListPaths: nil,
+            outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+            runOnlyForDeploymentPostprocessing: true
+        )
+        let notShellScriptBuildPhase2 = PBXCopyFilesBuildPhase(
+            dstPath: nil,
+            dstSubfolderSpec: .resources,
+            name: "Embed Frameworks",
+            buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+            files: [],
+            runOnlyForDeploymentPostprocessing: true
+        )
+
+        subject.buildPhases.append(notShellScriptBuildPhase1)
+        subject.buildPhases.append(notShellScriptBuildPhase2)
+
+        let runScriptBuildPhases = subject.runScriptBuildPhases()
+        XCTAssertTrue(runScriptBuildPhases.isEmpty)
+    }
+
+    func test_runScriptBuildPhases_returnsRunScriptBuildPhasesIfPresent() {
+        let otherScriptBuildPhase1 = PBXFrameworksBuildPhase()
+        let runScriptBuildPhase1 = PBXShellScriptBuildPhase(
+            name: "Run Script 1"
+        )
+        let runScriptBuildPhase2 = PBXShellScriptBuildPhase(
+            name: "Run Script 2"
+        )
+        let otherScriptBuildPhase2 = PBXCopyFilesBuildPhase()
+
+        subject.buildPhases.append(otherScriptBuildPhase1)
+        subject.buildPhases.append(runScriptBuildPhase1)
+        subject.buildPhases.append(runScriptBuildPhase2)
+        subject.buildPhases.append(otherScriptBuildPhase2)
+
+        let runScriptBuildPhases = subject.runScriptBuildPhases()
+        XCTAssertEqual(runScriptBuildPhases.count, 2)
+        XCTAssertTrue(runScriptBuildPhases.contains(runScriptBuildPhase1))
+        XCTAssertTrue(runScriptBuildPhases.contains(runScriptBuildPhase2))
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/716

### Short description 📝
`PBXTarget` has a set of accessors for the various types of build phases but is missing one for Run Script.

### Solution 📦
This adds an access with tests.

### Implementation 👩‍💻👨‍💻
- [x] Add accessor
- [x] Add tests
