### PR TITLE
Update Contributing instructions to directly open Package.swift with Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ Want to start using XcodeProj? Start by digging into our [documentation](/Docume
 ## Contributing
 
 1. Git clone the repository `git@github.com:tuist/xcodeproj.git`.
-2. Generate xcodeproj with `swift package generate-xcodeproj`.
-3. Open `XcodeProj.xcodeproj`.
+2. Open `Package.swift` with Xcode.
 
 ## License
 


### PR DESCRIPTION
### Short description 📝
While working on #717, I saw the contributing instructions were out-of-date and used the deprecated SPM command `generate-xcodeproj`. I was able to open, compile and test with Xcode's direct SPM compatibility.

### Solution 📦
Update instructions to use Xcode directly.

### Implementation 👩‍💻👨‍💻
Updated `README.md`.