### PR TITLE
Add shellToInvoke to XCScheme.ExecutionAction

### DIFF
--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -19,7 +19,8 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Build Post-action"
-               scriptText = "echo postbuild">
+               scriptText = "echo postbuild"
+               shellToInvoke = "/bin/sh">
             </ActionContent>
          </ExecutionAction>
       </PostActions>

--- a/Sources/XcodeProj/Scheme/XCScheme+ExecutionAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+ExecutionAction.swift
@@ -9,19 +9,29 @@ extension XCScheme {
 
         public var title: String
         public var scriptText: String
+        public var shellToInvoke: String?
         public var environmentBuildable: BuildableReference?
 
         // MARK: - Init
 
-        public init(scriptText: String, title: String = "Run Script", environmentBuildable: BuildableReference? = nil) {
+        public init(
+            scriptText: String,
+            title: String = "Run Script",
+            shellToInvoke: String? = nil,
+            environmentBuildable: BuildableReference? = nil
+        ) {
             self.scriptText = scriptText
             self.title = title
+            self.shellToInvoke = shellToInvoke
             self.environmentBuildable = environmentBuildable
         }
 
         init(element: AEXMLElement) throws {
             scriptText = element["ActionContent"].attributes["scriptText"] ?? ""
             title = element["ActionContent"].attributes["title"] ?? "Run Script"
+            if let shellToInvoke = element["ActionContent"].attributes["shellToInvoke"] {
+                self.shellToInvoke = shellToInvoke
+            }
             environmentBuildable = try? BuildableReference(element: element["ActionContent"]["EnvironmentBuildable"]["BuildableReference"])
         }
 
@@ -31,12 +41,16 @@ extension XCScheme {
             let element = AEXMLElement(name: "ExecutionAction",
                                        value: nil,
                                        attributes: ["ActionType": ExecutionAction.ActionType])
+            var attributes = [
+                "title": title,
+                "scriptText": scriptText,
+            ]
+            if let shellToInvoke = shellToInvoke {
+                attributes["shellToInvoke"] = shellToInvoke
+            }
             let content = AEXMLElement(name: "ActionContent",
                                        value: nil,
-                                       attributes: [
-                                           "title": title,
-                                           "scriptText": scriptText,
-                                       ])
+                                       attributes: attributes)
             element.addChild(content)
             if let environmentBuildable = environmentBuildable {
                 let environment = content.addChild(name: "EnvironmentBuildable")

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -329,8 +329,10 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.buildAction?.buildActionEntries.first?.buildableReference.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.buildAction?.preActions.first?.title, "Build Pre-action")
         XCTAssertEqual(scheme.buildAction?.preActions.first?.scriptText, "echo prebuild")
+        XCTAssertNil(scheme.buildAction?.preActions.first?.shellToInvoke)
         XCTAssertEqual(scheme.buildAction?.postActions.first?.title, "Build Post-action")
         XCTAssertEqual(scheme.buildAction?.postActions.first?.scriptText, "echo postbuild")
+        XCTAssertEqual(scheme.buildAction?.postActions.first?.shellToInvoke, "/bin/sh")
         // Test action
         XCTAssertEqual(scheme.testAction?.buildConfiguration, "Debug")
         XCTAssertEqual(scheme.testAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")


### PR DESCRIPTION
### Short description 📝
> If a post_actions specifies `shellToInvoke`, this field will be lost after rewriting with XCScheme;

### Solution 📦
> Add property `shellToInvoke` to `XCScheme.ExecutionAction` to fix `shellToInvoke` missing after editing XCProject.

