### PR TITLE
Readme: Add Rugby tool in 'projects using' table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ XcodeProj is a library written in Swift for parsing and working with Xcode proje
 | ProjLint | [github.com/JamitLabs/ProjLint](https://github.com/JamitLabs/ProjLint)                 |
 | XcodeGen | [github.com/yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen)                 |
 | xspm     | [gitlab.com/Pyroh/xspm](https://gitlab.com/Pyroh/xspm)                                 |
+| Rugby    | [github.com/swiftyfinch/Rugby](https://github.com/swiftyfinch/Rugby)                   |
 
 If you are also leveraging XcodeProj in your project, feel free to open a PR to include it in the list above.
 


### PR DESCRIPTION
There's package importing:
https://github.com/swiftyfinch/Rugby/blob/21cd79fb2d8be25772c44c0b27fc8087ea8f9bed/Package.swift#L26

Examples of usage:
https://github.com/swiftyfinch/Rugby/tree/main/Sources/Rugby/Common/XcodeProj