### PR TITLE
Build Tool Plugin Support

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -177,6 +177,7 @@ public final class PBXProject: PBXObject {
     public func addSwiftPackage(repositoryURL: String,
                                 productName: String,
                                 versionRequirement: XCRemoteSwiftPackageReference.VersionRequirement,
+                                plugin: Bool = false,
                                 targetName: String) throws -> XCRemoteSwiftPackageReference {
         let objects = try self.objects()
 
@@ -190,6 +191,7 @@ public final class PBXProject: PBXObject {
         // Product
         let productDependency = try addSwiftPackageProduct(reference: reference,
                                                            productName: productName,
+                                                           plugin: plugin,
                                                            target: target)
 
         // Build file
@@ -212,6 +214,7 @@ public final class PBXProject: PBXObject {
     ///   - addFileReference: Include a file reference to the package (defaults to main group)
     public func addLocalSwiftPackage(path: Path,
                                      productName: String,
+                                     plugin: Bool = false,
                                      targetName: String,
                                      addFileReference: Bool = true) throws -> XCSwiftPackageProductDependency {
         guard path.isRelative else { throw PBXProjError.pathIsAbsolute(path) }
@@ -223,6 +226,7 @@ public final class PBXProject: PBXObject {
         // Product
         let productDependency = try addLocalSwiftPackageProduct(path: path,
                                                                 productName: productName,
+                                                                plugin: plugin,
                                                                 target: target)
 
         // Build file
@@ -402,6 +406,7 @@ extension PBXProject {
     /// Adds package product for remote Swift package
     private func addSwiftPackageProduct(reference: XCRemoteSwiftPackageReference,
                                         productName: String,
+                                        plugin: Bool,
                                         target: PBXTarget) throws -> XCSwiftPackageProductDependency {
         let objects = try self.objects()
 
@@ -410,7 +415,9 @@ extension PBXProject {
         if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.package == reference })?.value {
             productDependency = product
         } else {
-            productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)
+            productDependency = XCSwiftPackageProductDependency(productName: productName,
+                                                                package: reference,
+                                                                plugin: plugin)
             objects.add(object: productDependency)
         }
         target.packageProductDependencies.append(productDependency)
@@ -421,6 +428,7 @@ extension PBXProject {
     /// Adds package product for local Swift package
     private func addLocalSwiftPackageProduct(path: Path,
                                              productName: String,
+                                             plugin: Bool,
                                              target: PBXTarget) throws -> XCSwiftPackageProductDependency {
         let objects = try self.objects()
 
@@ -432,7 +440,7 @@ extension PBXProject {
             }
             productDependency = product.value
         } else {
-            productDependency = XCSwiftPackageProductDependency(productName: productName)
+            productDependency = XCSwiftPackageProductDependency(productName: productName, plugin: plugin)
             objects.add(object: productDependency)
         }
         target.packageProductDependencies.append(productDependency)

--- a/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -24,7 +24,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
 
     public init(productName: String,
                 package: XCRemoteSwiftPackageReference? = nil,
-                plugin: Bool = false) {
+                plugin: Bool) {
         self.productName =  "\(plugin ? "plugin:" : "")\(productName)"
         packageReference = package?.reference
         self.plugin = plugin

--- a/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -17,13 +17,17 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
             packageReference = newValue?.reference
         }
     }
+    
+    let plugin: Bool
 
     // MARK: - Init
 
     public init(productName: String,
-                package: XCRemoteSwiftPackageReference? = nil) {
-        self.productName = productName
+                package: XCRemoteSwiftPackageReference? = nil,
+                plugin: Bool = false) {
+        self.productName =  "\(plugin ? "plugin:" : "")\(productName)"
         packageReference = package?.reference
+        self.plugin = plugin
         super.init()
     }
 
@@ -37,6 +41,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
         } else {
             packageReference = nil
         }
+        plugin = try container.decode(Bool.self, forKey: .plugin)
         try super.init(from: decoder)
     }
 
@@ -57,6 +62,7 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
     fileprivate enum CodingKeys: String, CodingKey {
         case productName
         case package
+        case plugin
     }
 
     override func isEqual(to object: Any?) -> Bool {

--- a/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -41,7 +41,11 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
         } else {
             packageReference = nil
         }
-        plugin = try container.decode(Bool.self, forKey: .plugin)
+        if let plugin = try container.decodeIfPresent(Bool.self, forKey: .plugin) {
+            self.plugin = plugin
+        } else {
+            plugin = false
+        }
         try super.init(from: decoder)
     }
 

--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -98,6 +98,20 @@ final class ReferenceGenerator: ReferenceGenerating {
                 identifiers.append($0.productName)
                 fixReference(for: $0, identifiers: identifiers)
             }
+            
+            // Build Tool Plugins
+            target.dependencies.forEach {
+                guard
+                    let product = $0.product,
+                    product.plugin
+                else {
+                    return
+                }
+                
+                var identifiers = identifiers
+                identifiers.append(product.productName)
+                fixReference(for: product, identifiers: identifiers)
+            }
 
             fixReference(for: target, identifiers: identifiers)
         }

--- a/Tests/XcodeProjTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
+++ b/Tests/XcodeProjTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
@@ -26,7 +26,8 @@ final class XCSwiftPackageProductDependencyTests: XCTestCase {
         let proj = PBXProj()
         let package = XCRemoteSwiftPackageReference(repositoryURL: "repository")
         let subject = XCSwiftPackageProductDependency(productName: "product",
-                                                      package: package)
+                                                      package: package,
+                                                      plugin: false)
 
         // When
         let got = try subject.plistKeyAndValue(proj: proj, reference: "reference")
@@ -43,9 +44,11 @@ final class XCSwiftPackageProductDependencyTests: XCTestCase {
         // Given
         let package = XCRemoteSwiftPackageReference(repositoryURL: "repository")
         let first = XCSwiftPackageProductDependency(productName: "product",
-                                                    package: package)
+                                                    package: package,
+                                                    plugin: false)
         let second = XCSwiftPackageProductDependency(productName: "product",
-                                                     package: package)
+                                                     package: package,
+                                                     plugin: false)
 
         // Then
         XCTAssertEqual(first, second)


### PR DESCRIPTION
### Short description 📝
I'm an avid user of XcodeGen and would like to have Build Tool Plugin support. It's possible to implement this without having to change this project but it leads to temporary identifiers sticking around in the generated project.

More details can be found in the [issue](https://github.com/yonaskolb/XcodeGen/issues/1290) where I documented my research.

### Solution 📦
Adds a flag to XCSwiftPackageProductDependency to indicate that it should be treated as a build tool plugin.

### Implementation 👩‍💻👨‍💻
- Add flag to XCSwiftPackageProductDependency
- Prefix the product name with "plugin:" as this indicates to Xcode that this should be treated as a plugin
- Check if a targets dependencies includes a package product that sets the flag to true
- Fix the package product reference before continuing
