### PR TITLE
Allow specifying `platformFilter` in `PBXBuildFile` init

### DIFF
--- a/Sources/XcodeProj/Objects/BuildPhase/PBXBuildFile.swift
+++ b/Sources/XcodeProj/Objects/BuildPhase/PBXBuildFile.swift
@@ -50,10 +50,12 @@ public final class PBXBuildFile: PBXObject {
     ///   - settings: build file settings.
     public init(file: PBXFileElement? = nil,
                 product: XCSwiftPackageProductDependency? = nil,
-                settings: [String: Any]? = nil) {
+                settings: [String: Any]? = nil,
+                platformFilter: String? = nil) {
         fileReference = file?.reference
         productReference = product?.reference
         self.settings = settings
+        self.platformFilter = platformFilter
         super.init()
     }
 

--- a/Tests/XcodeProjTests/Objects/BuildPhase/PBXBuildFileTests.swift
+++ b/Tests/XcodeProjTests/Objects/BuildPhase/PBXBuildFileTests.swift
@@ -6,4 +6,11 @@ final class PBXBuildFileTests: XCTestCase {
     func test_isa_returnsTheCorrectValue() {
         XCTAssertEqual(PBXBuildFile.isa, "PBXBuildFile")
     }
+
+    func test_platformFilterIsSet() {
+        let pbxBuildFile: PBXBuildFile = PBXBuildFile(
+            platformFilter: "platformFilter"
+        )
+        XCTAssertEqual(pbxBuildFile.platformFilter, "platformFilter")
+    }
 }


### PR DESCRIPTION
- Add the ability to specify the platform filter in the init for `PBXBuildFile` for convenience.