### PR TITLE
🐛 Fix PBXObject Equatable

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXObject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXObject.swift
@@ -60,8 +60,9 @@ public class PBXObject: Hashable, Decodable, Equatable, AutoEquatable {
         lhs.isEqual(to: rhs)
     }
 
-    func isEqual(to _: Any?) -> Bool {
-        true
+    func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXObject else { return false }
+        return rhs.reference == reference
     }
 
     public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION

Resolves https://github.com/tuist/xcodeproj/issues/YYY

### Short description 📝
PBXObject `isEqual`, always returning `true`, doesn't respect Swift Hashable's requirements.
That leads to weird/flaky issues like https://github.com/yonaskolb/XcodeGen/issues/1131

### Solution 📦
Make sure `==` is consistent with `hash`, i.e. same `hashValue` implying `isEqual` being `true`

### Implementation 👩‍💻👨‍💻
- [X] Check how other `isEqual` methods are implemented for consistency across the project
- [X] Implement it according to the `hash()` method, i.e. reference is what needs to be equal
