### PR TITLE
Update XCSharedData Writable conformance to include WorkspaceSettings

### DIFF
--- a/Sources/XcodeProj/Project/WorkspaceSettings.swift
+++ b/Sources/XcodeProj/Project/WorkspaceSettings.swift
@@ -153,3 +153,9 @@ public class WorkspaceSettings: Codable, Equatable, Writable {
         try path.write(data)
     }
 }
+
+extension WorkspaceSettings {
+    static func path(_ path: Path) -> Path {
+        path + "WorkspaceSettings.xcsettings"
+    }
+}

--- a/Sources/XcodeProj/Project/XCSharedData.swift
+++ b/Sources/XcodeProj/Project/XCSharedData.swift
@@ -63,6 +63,7 @@ public final class XCSharedData: Equatable, Writable {
     public func write(path: Path, override: Bool) throws {
         try writeSchemes(path: path, override: override)
         try writeBreakpoints(path: path, override: override)
+        try writeWorkspaceSettings(path: path, override: override)
     }
 
     func writeSchemes(path: Path, override: Bool) throws {
@@ -90,6 +91,20 @@ public final class XCSharedData: Equatable, Writable {
 
         try debuggerPath.mkpath()
         try breakpoints.write(path: XCBreakpointList.path(debuggerPath), override: override)
+    }
+    
+    func writeWorkspaceSettings(path: Path, override: Bool) throws {
+        /**
+         * We don't want to delete this path when `override` is `true` because
+         * that will delete everything in the folder, including schemes and breakpoints.
+         * Instead, just create the path if it doesn't exist and let the `write` method
+         * in `WorkspaceSettings` handle the override.
+         */
+        if !path.exists {
+            try path.mkpath()
+        }
+ 
+        try workspaceSettings?.write(path: WorkspaceSettings.path(path), override: override)
     }
 }
 

--- a/Tests/XcodeProjTests/Project/XcodeProjTests.swift
+++ b/Tests/XcodeProjTests/Project/XcodeProjTests.swift
@@ -24,6 +24,25 @@ final class XcodeProjIntegrationTests: XCTestCase {
         try testReadWriteProducesNoDiff(from: iosProjectPath,
                                         initModel: XcodeProj.init(path:))
     }
+    
+    func test_write_includes_workspace_settings() throws {
+        // Define workspace settings that should be written
+        let workspaceSettings = WorkspaceSettings(buildSystem: .new, derivedDataLocationStyle: .default, autoCreateSchemes: false)
+
+        testWrite(from: iosProjectPath,
+                  initModel: { try? XcodeProj(path: $0) },
+                  modify: { project in
+                      project.sharedData?.workspaceSettings = workspaceSettings
+                      return project
+                  },
+                  assertion: {
+                      /**
+                       * Expect that the workspace settings read from file are equal to the
+                       * workspace settings we expected to write.
+                       */
+                      XCTAssertEqual($1.sharedData?.workspaceSettings, workspaceSettings)
+                  })
+    }
 
     // MARK: - Private
 


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/738

### Short description 📝
> Update `XCSharedData` `Writable` conformance so that `WorkspaceSettings` are wrriten.

### Solution 📦
> There was already a pattern defined for writing `XCSharedData` properties (`schemes` and `breakpoints`), and so I followed the same pattern to write the `workspaceSettings` property.

### Implementation 👩‍💻👨‍💻
> Detail in a checklist the steps that you took to implement the PR.

- [x] Write a test case in `XcodeProjTests` that fails if `XcodeProj.write` doesn’t write all expected files
- [x] Run the test and see that it fails
- [x] Update `XCSharedData` `Writable` conformance to write `WorkspaceSettings`
- [x] Run `XcodeProjTests` again and see that it passes
