### PR TITLE
docs: Add try-catch to getting started

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -57,7 +57,11 @@ import PathKit
 import XcodeProj
 
 let path = Path("/path/to/my/Project.xcodeproj") // Your project path
-let xcodeproj = XcodeProj(path: path)
+do {
+    let xcodeproj = try XcodeProj(path: path)
+} catch {
+    print(error)
+}
 ```
 
 xcodeproj will parse and map the project structure into Swift classes that you can interact with.


### PR DESCRIPTION
Not sure if this was left out on purpose to keep the sample as small as possible but I feel that a getting started document should show code that builds without requiring fixes, even if it is as simple as adding a `try` statement, because it otherwise makes the documentation look sloppy.

(Apologies for not creating an issue first.)