### PR TITLE
docs :: Build Settings Provider

### DIFF
--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -81,7 +81,7 @@ public class BuildSettingsProvider {
 
     /// Returns default build settings that Xcode sets in new projects.
     ///
-    /// - Parameters: variant: build settings variant.
+    /// - Parameters variant: build settings variant.
     /// - Returns: build settings.
     public static func projectDefault(variant: Variant) -> BuildSettings {
         switch variant {

--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -29,8 +29,10 @@ public class BuildSettingsProvider {
     /// - dynamicLibrary: dynamic library.
     /// - application: application.
     /// - bundle: bundle.
-    /// - appExtension: application extension
-    /// - watchExtension: watch extension
+    /// - appExtension: application extension.
+    /// - watchExtension: watch extension.
+    /// - unitTests: unit tests.
+    /// - uiTests: ui tests.
     public enum Product {
         case framework, staticLibrary, dynamicLibrary, application, bundle, appExtension, watchExtension, unitTests, uiTests
     }
@@ -79,6 +81,7 @@ public class BuildSettingsProvider {
 
     /// Returns default build settings that Xcode sets in new projects.
     ///
+    /// - Parameters: variant: build settings variant.
     /// - Returns: build settings.
     public static func projectDefault(variant: Variant) -> BuildSettings {
         switch variant {


### PR DESCRIPTION
Product Document - Missing case
projectDefault Document - Parameter Docs

### Short description 📝
- BuildSettingsProvider file's Missing Documentation

### Solution 📦
- add document in BuildSettingsProvider

### Implementation 👩‍💻👨‍💻
- add document in BuildSettingsProvider

- [x] add case document in Product enum
- [x] add parameter document in projectDefault function
