### PR TITLE
Fix build on Linux by adding explicit types

### DIFF
--- a/Sources/XcodeProj/Extensions/String+Utils.swift
+++ b/Sources/XcodeProj/Extensions/String+Utils.swift
@@ -18,11 +18,11 @@ extension String {
     }
 
     public static func random(length: Int = 20) -> String {
-        let base = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        let base: String = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
         var randomString: String = ""
 
         for _ in 0 ..< length {
-            let randomValue = arc4random_uniform(UInt32(base.count))
+            let randomValue: Int32 = arc4random_uniform(UInt32(base.count))
             randomString += "\(base[base.index(base.startIndex, offsetBy: Int(randomValue))])"
         }
         return randomString

--- a/Sources/XcodeProj/Extensions/String+Utils.swift
+++ b/Sources/XcodeProj/Extensions/String+Utils.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-#if os(Linux)
-    import SwiftGlibc
-
-    public func arc4random_uniform(_ max: UInt32) -> Int32 {
-        (SwiftGlibc.rand() % Int32(max - 1))
-    }
-#endif
-
 extension String {
     public var quoted: String {
         "\"\(self)\""
@@ -22,7 +14,7 @@ extension String {
         var randomString: String = ""
 
         for _ in 0 ..< length {
-            let randomValue: Int32 = arc4random_uniform(UInt32(base.count))
+            let randomValue: UInt32 = arc4random_uniform(UInt32(base.count))
             randomString += "\(base[base.index(base.startIndex, offsetBy: Int(randomValue))])"
         }
         return randomString


### PR DESCRIPTION
Fixes build errors on Linux by adding explicit type annotations.

### Short description 📝
Without this change, building on Linux fails with the following errors:

```
» swift --version            
Swift version 5.7.1-dev (LLVM 7e31b78ab3255fa, Swift 1e80674d67f5505)
Target: x86_64-unknown-linux-gnu
» swift build
[...]
/home/[...]/src/XcodeProj/Sources/XcodeProj/Extensions/String+Utils.swift:25:57: error: ambiguous use of 'count'
            let randomValue = arc4random_uniform(UInt32(base.count))
                                                        ^
Swift.String:6:16: note: found this candidate
    public var count: Int { get }
               ^
Swift.Collection:5:27: note: found this candidate
    @inlinable public var count: Int { get }
[...]
/home/[...]/src/XcodeProj/Sources/XcodeProj/Extensions/String+Utils.swift:25:31: error: ambiguous use of 'arc4random_uniform'
            let randomValue = arc4random_uniform(UInt32(base.count))
                              ^
/home/[...]/src/XcodeProj/Sources/XcodeProj/Extensions/String+Utils.swift:6:17: note: found this candidate
    public func arc4random_uniform(_ max: UInt32) -> Int32 {
                ^
SwiftGlibc.arc4random_uniform:1:13: note: found this candidate
public func arc4random_uniform(_ __upper_bound: __uint32_t) -> __uint32_t
            ^
```

### Solution 📦
Both of these issues arise from non-explicit types. Adding the types fixes these.

The second will only ever arise on Linux because the `arc4random_uniform` candidate is gated by an OS compiler directive check. I'm not sure why the other doesn't block MacOS builds, possible the `Foundation` libraries differ here.