### PR TITLE
Fix typos in `Writable.swift`

### DIFF
--- a/Sources/XcodeProj/Protocols/Writable.swift
+++ b/Sources/XcodeProj/Protocols/Writable.swift
@@ -1,19 +1,19 @@
 import Foundation
 import PathKit
 
-/// Protocol that defines how an entity can be writed into disk
+/// Protocol that defines how an entity can be written to disk
 public protocol Writable {
     /// Writes the object that conforms the protocol.
     ///
     /// - Parameter path: The path to write to
-    /// - Parameter override: True if the content should be overriden if it already exists.
+    /// - Parameter override: True if the content should be overridden if it already exists.
     /// - Throws: writing error if something goes wrong.
     func write(path: Path, override: Bool) throws
 
     /// Writes the object that conforms the protocol.
     ///
     /// - Parameter pathString: The path string to write to
-    /// - Parameter override: True if the content should be overriden if it already exists.
+    /// - Parameter override: True if the content should be overridden if it already exists.
     /// - Throws: writing error if something goes wrong.
     func write(pathString: String, override: Bool) throws
 }


### PR DESCRIPTION
### Short description 📝

Fix typos in `Writable.swift`.

### Solution 📦

Fix typos in `Writable.swift`.

### Implementation 👩‍💻👨‍💻

1. Saw typos
2. Fixed them