### PR TITLE
Add support for Xcode Runtime issue breakpoints

### DIFF
--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -124,5 +124,23 @@
             </Locations>
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+          BreakpointExtensionID = "Xcode.Breakpoint.RuntimeIssueBreakpoint">
+          <BreakpointContent
+              shouldBeEnabled = "Yes"
+              ignoreCount = "0"
+              continueAfterRunningActions = "No"
+              breakpointStackSelectionBehavior = "1">
+              <Actions>
+                  <BreakpointActionProxy
+                      ActionExtensionID = "Xcode.BreakpointAction.AppleScript">
+                      <ActionContent>
+                      </ActionContent>
+                  </BreakpointActionProxy>
+              </Actions>
+              <Locations>
+              </Locations>
+          </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -125,22 +125,22 @@
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
-          BreakpointExtensionID = "Xcode.Breakpoint.RuntimeIssueBreakpoint">
-          <BreakpointContent
-              shouldBeEnabled = "Yes"
-              ignoreCount = "0"
-              continueAfterRunningActions = "No"
-              breakpointStackSelectionBehavior = "1">
-              <Actions>
-                  <BreakpointActionProxy
-                      ActionExtensionID = "Xcode.BreakpointAction.AppleScript">
-                      <ActionContent>
-                      </ActionContent>
-                  </BreakpointActionProxy>
-              </Actions>
-              <Locations>
-              </Locations>
-          </BreakpointContent>
+         BreakpointExtensionID = "Xcode.Breakpoint.RuntimeIssueBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            breakpointStackSelectionBehavior = "1">
+            <Actions>
+               <BreakpointActionProxy
+                  ActionExtensionID = "Xcode.BreakpointAction.AppleScript">
+                  <ActionContent>
+                  </ActionContent>
+               </BreakpointActionProxy>
+            </Actions>
+            <Locations>
+            </Locations>
+         </BreakpointContent>
       </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/Sources/XcodeProj/Project/XCBreakpointList.swift
+++ b/Sources/XcodeProj/Project/XCBreakpointList.swift
@@ -316,7 +316,7 @@ public final class XCBreakpointList: Equatable, Writable {
             case symbolic = "Xcode.Breakpoint.SymbolicBreakpoint"
             case ideConstraintError = "Xcode.Breakpoint.IDEConstraintErrorBreakpoint"
             case ideTestFailure = "Xcode.Breakpoint.IDETestFailureBreakpoint"
-            case runtimeException = "Xcode.Breakpoint.RuntimeIssueBreakpoint"
+            case runtimeIssue = "Xcode.Breakpoint.RuntimeIssueBreakpoint"
         }
 
         // MARK: - Attributes

--- a/Sources/XcodeProj/Project/XCBreakpointList.swift
+++ b/Sources/XcodeProj/Project/XCBreakpointList.swift
@@ -316,6 +316,7 @@ public final class XCBreakpointList: Equatable, Writable {
             case symbolic = "Xcode.Breakpoint.SymbolicBreakpoint"
             case ideConstraintError = "Xcode.Breakpoint.IDEConstraintErrorBreakpoint"
             case ideTestFailure = "Xcode.Breakpoint.IDETestFailureBreakpoint"
+            case runtimeException = "Xcode.Breakpoint.RuntimeIssueBreakpoint"
         }
 
         // MARK: - Attributes

--- a/Tests/XcodeProjTests/Project/XCBreakpointListTests.swift
+++ b/Tests/XcodeProjTests/Project/XCBreakpointListTests.swift
@@ -104,6 +104,17 @@ final class XCBreakpointListIntegrationTests: XCTestCase {
         let ideTestFailureAppleScriptAction = ideTestFailureContent.actions[0]
         XCTAssertEqual(ideTestFailureAppleScriptAction.actionExtensionID, .appleScript)
         XCTAssertNotNil(ideTestFailureAppleScriptAction.actionContent)
+
+        // Runtime exception failure
+        let runtimeException = breakpointList.breakpoints[6]
+        XCTAssertEqual(runtimeException.breakpointExtensionID, .runTimeException)
+        let runtimeExceptionContent = runtimeException.breakpointContent
+        XCTAssertEqual(runtimeExceptionContent.enabled, true)
+        XCTAssertEqual(runtimeExceptionContent.ignoreCount, "0")
+        XCTAssertEqual(runtimeExceptionContent.continueAfterRunningActions, false)
+        let runtimeExceptionAppleScriptAction = runtimeExceptionContent.actions[0]
+        XCTAssertEqual(runtimeExceptionAppleScriptAction.actionExtensionID, .appleScript)
+        XCTAssertNotNil(runtimeExceptionAppleScriptAction.actionContent)
     }
 
     private func fixturePath() -> Path {

--- a/Tests/XcodeProjTests/Project/XCBreakpointListTests.swift
+++ b/Tests/XcodeProjTests/Project/XCBreakpointListTests.swift
@@ -107,7 +107,7 @@ final class XCBreakpointListIntegrationTests: XCTestCase {
 
         // Runtime exception failure
         let runtimeException = breakpointList.breakpoints[6]
-        XCTAssertEqual(runtimeException.breakpointExtensionID, .runTimeException)
+        XCTAssertEqual(runtimeException.breakpointExtensionID, .runtimeException)
         let runtimeExceptionContent = runtimeException.breakpointContent
         XCTAssertEqual(runtimeExceptionContent.enabled, true)
         XCTAssertEqual(runtimeExceptionContent.ignoreCount, "0")

--- a/Tests/XcodeProjTests/Project/XCBreakpointListTests.swift
+++ b/Tests/XcodeProjTests/Project/XCBreakpointListTests.swift
@@ -106,13 +106,13 @@ final class XCBreakpointListIntegrationTests: XCTestCase {
         XCTAssertNotNil(ideTestFailureAppleScriptAction.actionContent)
 
         // Runtime exception failure
-        let runtimeException = breakpointList.breakpoints[6]
-        XCTAssertEqual(runtimeException.breakpointExtensionID, .runtimeException)
-        let runtimeExceptionContent = runtimeException.breakpointContent
-        XCTAssertEqual(runtimeExceptionContent.enabled, true)
-        XCTAssertEqual(runtimeExceptionContent.ignoreCount, "0")
-        XCTAssertEqual(runtimeExceptionContent.continueAfterRunningActions, false)
-        let runtimeExceptionAppleScriptAction = runtimeExceptionContent.actions[0]
+        let runtimeIssue = breakpointList.breakpoints[6]
+        XCTAssertEqual(runtimeIssue.breakpointExtensionID, .runtimeIssue)
+        let runtimeIssueContent = runtimeIssue.breakpointContent
+        XCTAssertEqual(runtimeIssueContent.enabled, true)
+        XCTAssertEqual(runtimeIssueContent.ignoreCount, "0")
+        XCTAssertEqual(runtimeIssueContent.continueAfterRunningActions, false)
+        let runtimeExceptionAppleScriptAction = runtimeIssueContent.actions[0]
         XCTAssertEqual(runtimeExceptionAppleScriptAction.actionExtensionID, .appleScript)
         XCTAssertNotNil(runtimeExceptionAppleScriptAction.actionContent)
     }


### PR DESCRIPTION
### Short description 📝
This PR adds support for Xcode runtime issues breakpoints.
It simply adds a new case to the `BreakpointExtensionID` called `.runtimeException` which can be used to generate breakpoints.

Solution 📦

Add missing case to `BreakpointExtensionID` for generating runtime issue breakpoints.

### Implementation 👩‍💻👨‍💻

- [x] Adds new `BreakpointExtensionID` case to support runtime issue breakpoints
- [x] Expands the `XCBreakpointListTests` to include looking for the runtime exception
- [x] Update the breakpoints fixture to include a runtime issue breakpoint
