### PR TITLE
BuildSettingsProvider: add support for xros

### DIFF
--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -19,7 +19,7 @@ public class BuildSettingsProvider {
     /// - tvOS: tvOS.
     /// - watchOS: watchOS.
     public enum Platform {
-        case iOS, macOS, tvOS, watchOS
+        case iOS, macOS, tvOS, watchOS, visionOS
     }
 
     /// Target product type.
@@ -188,6 +188,11 @@ public class BuildSettingsProvider {
             return [
                 "SDKROOT": "watchos",
                 "TARGETED_DEVICE_FAMILY": "4",
+            ]
+        case .visionOS:
+            return [
+                "SDKROOT": "xros",
+                "TARGETED_DEVICE_FAMILY": "1,2,7",
             ]
         }
     }


### PR DESCRIPTION
### Short description 📝
Adds support for visionOS

### Solution 📦
Added the Platform case and default settings from an xcode project

### Implementation 👩‍💻👨‍💻
- [x] Add visionOS platform
- [x] Created an app in Xcode
- [x] Added visionOS as a device/platform
- [x] Copied the new/different build settings into the dict
