### PR TITLE
Added `Build Tool Plug-ins` support

### DIFF
--- a/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -37,8 +37,14 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
         let repository = decoder.context.objectReferenceRepository
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let rawProductName = try container.decode(String.self, forKey: .productName)
-        productName = rawProductName.replacingOccurrences(of: "plugin:", with: "")
-        isPlugin = productName != rawProductName
+        let pluginPrefix = "plugin:"
+        if rawProductName.hasPrefix(pluginPrefix) {
+            productName = String(rawProductName.dropFirst(pluginPrefix.count))
+            isPlugin = true
+        } else {
+            productName = rawProductName
+            isPlugin = false
+        }
 
         if let packageString: String = try container.decodeIfPresent(.package) {
             packageReference = repository.getOrCreate(reference: packageString, objects: objects)

--- a/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
+++ b/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift
@@ -18,6 +18,11 @@ public class XCSwiftPackageProductDependency: PBXContainerItem, PlistSerializabl
         }
     }
 
+    /// Is it a Plugin.
+    var isPlugin: Bool {
+        productName.hasPrefix("plugin:")
+    }
+
     // MARK: - Init
 
     public init(productName: String,

--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -99,6 +99,15 @@ final class ReferenceGenerator: ReferenceGenerating {
                 fixReference(for: $0, identifiers: identifiers)
             }
 
+            // Build Tool Plug-ins
+            target.dependencies.forEach {
+                guard let product = $0.product, product.isPlugin else { return }
+
+                var identifiers = identifiers
+                identifiers.append(product.productName)
+                fixReference(for: product, identifiers: identifiers)
+            }
+
             fixReference(for: target, identifiers: identifiers)
         }
     }

--- a/Tests/XcodeProjTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
+++ b/Tests/XcodeProjTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
@@ -19,6 +19,25 @@ final class XCSwiftPackageProductDependencyTests: XCTestCase {
         // Then
         XCTAssertEqual(got.productName, "xcodeproj")
         XCTAssertEqual(got.packageReference?.value, "packageReference")
+        XCTAssertEqual(got.isPlugin, false)
+    }
+
+    func test_initAsPlugin() throws {
+        // Given
+        let decoder = XcodeprojPropertyListDecoder()
+        let encoder = PropertyListEncoder()
+        let plist = ["reference": "reference",
+                     "productName": "plugin:xcodeproj",
+                     "package": "packageReference"]
+        let data = try encoder.encode(plist)
+
+        // When
+        let got = try decoder.decode(XCSwiftPackageProductDependency.self, from: data)
+
+        // Then
+        XCTAssertEqual(got.productName, "xcodeproj")
+        XCTAssertEqual(got.packageReference?.value, "packageReference")
+        XCTAssertEqual(got.isPlugin, true)
     }
 
     func test_plistValues() throws {
@@ -39,6 +58,25 @@ final class XCSwiftPackageProductDependencyTests: XCTestCase {
         ]))
     }
 
+    func test_plistValuesAsPlugin() throws {
+        // Given
+        let proj = PBXProj()
+        let package = XCRemoteSwiftPackageReference(repositoryURL: "repository")
+        let subject = XCSwiftPackageProductDependency(productName: "product",
+                                                      package: package,
+                                                      isPlugin: true)
+
+        // When
+        let got = try subject.plistKeyAndValue(proj: proj, reference: "reference")
+
+        // Then
+        XCTAssertEqual(got.value, .dictionary([
+            "isa": "XCSwiftPackageProductDependency",
+            "productName": "plugin:product",
+            "package": .string(.init(package.reference.value, comment: "XCRemoteSwiftPackageReference \"\(package.name ?? "")\"")),
+        ]))
+    }
+
     func test_equal() {
         // Given
         let package = XCRemoteSwiftPackageReference(repositoryURL: "repository")
@@ -53,7 +91,7 @@ final class XCSwiftPackageProductDependencyTests: XCTestCase {
 
     func test_isPlugin() {
         // Given
-        let plugin = XCSwiftPackageProductDependency(productName: "plugin:product")
+        let plugin = XCSwiftPackageProductDependency(productName: "product", isPlugin: true)
 
         // Then
         XCTAssertTrue(plugin.isPlugin)

--- a/Tests/XcodeProjTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
+++ b/Tests/XcodeProjTests/Objects/SwiftPackage/XCSwiftPackageProductDependencyTests.swift
@@ -50,4 +50,20 @@ final class XCSwiftPackageProductDependencyTests: XCTestCase {
         // Then
         XCTAssertEqual(first, second)
     }
+
+    func test_isPlugin() {
+        // Given
+        let plugin = XCSwiftPackageProductDependency(productName: "plugin:product")
+
+        // Then
+        XCTAssertTrue(plugin.isPlugin)
+    }
+
+    func test_isNotPlugin() {
+        // Given
+        let plugin = XCSwiftPackageProductDependency(productName: "product")
+
+        // Then
+        XCTAssertFalse(plugin.isPlugin)
+    }
 }

--- a/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
+++ b/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
@@ -141,7 +141,7 @@ private extension PBXProj {
 
     func makePluginDependency() -> PBXTargetDependency {
         let packageReference = XCRemoteSwiftPackageReference(repositoryURL: "repository")
-        let packageDependency = XCSwiftPackageProductDependency(productName: "plugin:product", package: packageReference)
+        let packageDependency = XCSwiftPackageProductDependency(productName: "product", package: packageReference, isPlugin: true)
         let targetDependency = PBXTargetDependency(product: packageDependency)
         add(object: targetDependency.productReference!.getObject()!)
 


### PR DESCRIPTION
### Short description 📝
This is a continuation of https://github.com/tuist/XcodeProj/pull/733, to support **Build Tool Plug-ins**. (Thanks to @technocidal)

### Solution 📦

Added the difference between plugins and dependencies. Added correction of temporary identifiers for plugins.

### Implementation 👩‍💻👨‍💻

- Now we can separate the `Dependency` from plug-in:
```swift
// file: XCSwiftPackageProductDependency

/// Is it a Plugin.
var isPlugin: Bool {
    productName.hasPrefix("plugin:")
}
```

- After separation, we need to fix TEMP identifiers:
```swift
// file: ReferenceGenerator

// Build Tool Plug-ins
target.dependencies.forEach {
    guard let product = $0.product, product.isPlugin else { return }

    var identifiers = identifiers
    identifiers.append(product.productName)
    fixReference(for: product, identifiers: identifiers)
}
```

- And of course, some tests for classes: `ReferenceGenerator`, `XCSwiftPackageProductDependency`
