### PR TITLE
Get Data representation for `Writable`

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -285,7 +285,7 @@ extension PBXProj: Equatable {
 
 extension PBXProj: Writable {
     public func dataRepresentation(outputSettings: PBXOutputSettings) throws -> Data? {
-        let encoder = PBXProjEncoder(outputSettings: PBXOutputSettings())
+        let encoder = PBXProjEncoder(outputSettings: outputSettings)
         return try encoder.encode(proj: self).data(using: .utf8)
     }
 

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -288,16 +288,16 @@ extension PBXProj: Writable {
         try write(path: path, override: override, outputSettings: PBXOutputSettings())
     }
 
-    public func getStringRepresentation(outputSettings: PBXOutputSettings) throws -> String {
-        let encoder = PBXProjEncoder(outputSettings: outputSettings)
-        return try encoder.encode(proj: self)
-    }
-
     public func write(path: Path, override: Bool, outputSettings: PBXOutputSettings) throws {
-        let output = try getStringRepresentation(outputSettings: outputSettings)
+        let output = try encodeAsString(outputSettings: outputSettings)
         if override, path.exists {
             try path.delete()
         }
         try path.write(output)
+    }
+    
+    public func encodeAsString(outputSettings: PBXOutputSettings) throws -> String {
+        let encoder = PBXProjEncoder(outputSettings: outputSettings)
+        return try encoder.encode(proj: self)
     }
 }

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -288,7 +288,7 @@ extension PBXProj: Writable {
         try write(path: path, override: override, outputSettings: PBXOutputSettings())
     }
 
-    public func getStringRepresentation(outputSettings: PBXOutputSettings) throws -> String {
+    public func getStringRepresentation(outputSettings: PBXOutputSettings = PBXOutputSettings()) throws -> String {
         let encoder = PBXProjEncoder(outputSettings: outputSettings)
         return try encoder.encode(proj: self)
     }

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -288,7 +288,7 @@ extension PBXProj: Writable {
         try write(path: path, override: override, outputSettings: PBXOutputSettings())
     }
 
-    public func getStringRepresentation(outputSettings: PBXOutputSettings = PBXOutputSettings()) throws -> String {
+    public func getStringRepresentation(outputSettings: PBXOutputSettings) throws -> String {
         let encoder = PBXProjEncoder(outputSettings: outputSettings)
         return try encoder.encode(proj: self)
     }

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -284,20 +284,27 @@ extension PBXProj: Equatable {
 // MARK: - Writable
 
 extension PBXProj: Writable {
+    public func dataRepresentation(outputSettings: PBXOutputSettings) throws -> Data? {
+        let encoder = PBXProjEncoder(outputSettings: PBXOutputSettings())
+        return try encoder.encode(proj: self).data(using: .utf8)
+    }
+
+    public func dataRepresentation() throws -> Data? {
+        let encoder = PBXProjEncoder(outputSettings: PBXOutputSettings())
+        return try encoder.encode(proj: self).data(using: .utf8)
+    }
+    
     public func write(path: Path, override: Bool) throws {
         try write(path: path, override: override, outputSettings: PBXOutputSettings())
     }
 
     public func write(path: Path, override: Bool, outputSettings: PBXOutputSettings) throws {
-        let output = try encodeAsString(outputSettings: outputSettings)
+        guard let output = try dataRepresentation(outputSettings: outputSettings) else {
+            return
+        }
         if override, path.exists {
             try path.delete()
         }
         try path.write(output)
-    }
-    
-    public func encodeAsString(outputSettings: PBXOutputSettings) throws -> String {
-        let encoder = PBXProjEncoder(outputSettings: outputSettings)
-        return try encoder.encode(proj: self)
     }
 }

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -288,9 +288,13 @@ extension PBXProj: Writable {
         try write(path: path, override: override, outputSettings: PBXOutputSettings())
     }
 
-    public func write(path: Path, override: Bool, outputSettings: PBXOutputSettings) throws {
+    public func getStringRepresentation(outputSettings: PBXOutputSettings) throws -> String {
         let encoder = PBXProjEncoder(outputSettings: outputSettings)
-        let output = try encoder.encode(proj: self)
+        return try encoder.encode(proj: self)
+    }
+
+    public func write(path: Path, override: Bool, outputSettings: PBXOutputSettings) throws {
+        let output = try getStringRepresentation(outputSettings: outputSettings)
         if override, path.exists {
             try path.delete()
         }

--- a/Sources/XcodeProj/Project/WorkspaceSettings.swift
+++ b/Sources/XcodeProj/Project/WorkspaceSettings.swift
@@ -144,13 +144,23 @@ public class WorkspaceSettings: Codable, Equatable, Writable {
     /// - Parameter override: True if the content should be overriden if it already exists.
     /// - Throws: writing error if something goes wrong.
     public func write(path: Path, override: Bool) throws {
-        let encoder = PropertyListEncoder()
-        encoder.outputFormat = .xml
-        let data = try encoder.encode(self)
+        guard let data = try dataRepresentation() else {
+            return
+        }
         if override, path.exists {
             try path.delete()
         }
         try path.write(data)
+    }
+    
+    /// Get the workspace settings.
+    ///
+    /// - Throws: reading error if something goes wrong.
+    public func dataRepresentation() throws -> Data? {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        let data = try encoder.encode(self)
+        return data
     }
 }
 

--- a/Sources/XcodeProj/Project/XCBreakpointList.swift
+++ b/Sources/XcodeProj/Project/XCBreakpointList.swift
@@ -403,6 +403,15 @@ public final class XCBreakpointList: Equatable, Writable {
     // MARK: - Writable
 
     public func write(path: Path, override: Bool) throws {
+        let document = getAEXMLDocument()
+        
+        if override, path.exists {
+            try path.delete()
+        }
+        try path.write(document.xmlXcodeFormat)
+    }
+
+    private func getAEXMLDocument() -> AEXMLDocument {
         let document = AEXMLDocument()
         var schemeAttributes: [String: String] = [:]
         schemeAttributes["type"] = type
@@ -412,11 +421,11 @@ public final class XCBreakpointList: Equatable, Writable {
         let breakpoints = AEXMLElement(name: "Breakpoints", value: nil, attributes: [:])
         self.breakpoints.map { $0.xmlElement() }.forEach { breakpoints.addChild($0) }
         bucket.addChild(breakpoints)
+        return document
+    }
 
-        if override, path.exists {
-            try path.delete()
-        }
-        try path.write(document.xmlXcodeFormat)
+    public func dataRepresentation() throws -> Data? {
+        getAEXMLDocument().xmlXcodeFormat.data(using: .utf8)
     }
 
     // MARK: - Equatable

--- a/Sources/XcodeProj/Protocols/Writable.swift
+++ b/Sources/XcodeProj/Protocols/Writable.swift
@@ -16,6 +16,11 @@ public protocol Writable {
     /// - Parameter override: True if the content should be overridden if it already exists.
     /// - Throws: writing error if something goes wrong.
     func write(pathString: String, override: Bool) throws
+
+    /// Gets the data representation of the object that conforms to the protocol.
+    ///
+    /// - Throws: error if encoding to Data fails.
+    func dataRepresentation() throws -> Data?
 }
 
 extension Writable {
@@ -23,4 +28,6 @@ extension Writable {
         let path = Path(pathString)
         try write(path: path, override: override)
     }
+
+    public func dataRepresentation() throws -> Data? { nil }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme.swift
@@ -83,6 +83,18 @@ public final class XCScheme: Writable, Equatable {
     // MARK: - Writable
 
     public func write(path: Path, override: Bool) throws {
+        let document = getAEXMLDocument()
+        if override, path.exists {
+            try path.delete()
+        }
+        try path.write(document.xmlXcodeFormat)
+    }
+    
+    public func dataRepresentation() throws -> Data? {
+        getAEXMLDocument().xmlXcodeFormat.data(using: .utf8)
+    }
+    
+    private func getAEXMLDocument() -> AEXMLDocument {
         let document = AEXMLDocument()
         var schemeAttributes: [String: String] = [:]
         schemeAttributes["LastUpgradeVersion"] = lastUpgradeVersion
@@ -109,10 +121,7 @@ public final class XCScheme: Writable, Equatable {
         if let wasCreatedForAppExtension = wasCreatedForAppExtension {
             scheme.attributes["wasCreatedForAppExtension"] = wasCreatedForAppExtension.xmlString
         }
-        if override, path.exists {
-            try path.delete()
-        }
-        try path.write(document.xmlXcodeFormat)
+        return document
     }
 
     // MARK: - Equatable

--- a/Sources/XcodeProj/Scheme/XCSchemeManagement.swift
+++ b/Sources/XcodeProj/Scheme/XCSchemeManagement.swift
@@ -138,9 +138,21 @@ public struct XCSchemeManagement: Codable, Equatable, Writable {
             try path.delete()
         }
 
+        let encoder = getEncoder()
+        try encoder.encode(self).write(to: path.url)
+    }
+    
+    /// Gets the data representation of the property list representation of the object.
+    ///
+    /// - Throws: Error if encoding fails.
+    public func dataRepresentation() throws -> Data? {
+        return try getEncoder().encode(self)
+    }
+
+    private func getEncoder() -> PropertyListEncoder {
         let encoder = PropertyListEncoder()
         encoder.outputFormat = .xml
-        try encoder.encode(self).write(to: path.url)
+        return encoder
     }
 
     // MARK: - Codable

--- a/Sources/XcodeProj/Utils/XCConfig.swift
+++ b/Sources/XcodeProj/Utils/XCConfig.swift
@@ -143,14 +143,23 @@ extension XCConfig {
 
 extension XCConfig: Writable {
     public func write(path: Path, override: Bool) throws {
-        var content = ""
-        content.append(writeIncludes())
-        content.append("\n")
-        content.append(writeBuildSettings())
+        let content = getContent()
         if override, path.exists {
             try path.delete()
         }
         try path.write(content)
+    }
+    
+    public func dataRepresentation() throws -> Data? {
+        getContent().data(using: .utf8)
+    }
+    
+    private func getContent() -> String {
+        var content = ""
+        content.append(writeIncludes())
+        content.append("\n")
+        content.append(writeBuildSettings())
+        return content
     }
 
     private func writeIncludes() -> String {

--- a/Sources/XcodeProj/Workspace/XCWorkspace.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspace.swift
@@ -67,6 +67,10 @@ public final class XCWorkspace: Writable, Equatable {
         try dataPath.mkpath()
         try data.write(path: dataPath)
     }
+    
+    public func dataRepresentation() throws -> Data? {
+        self.data.rawContents().data(using: .utf8)
+    }
 
     // MARK: - Equatable
 

--- a/Sources/XcodeProj/Workspace/XCWorkspaceData.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspaceData.swift
@@ -55,6 +55,10 @@ extension XCWorkspaceData: Writable {
         }
         try path.write(rawXml)
     }
+    
+    public func dataRepresentation() throws -> Data? {
+        rawContents().data(using: .utf8)
+    }
 }
 
 // MARK: - XCWorkspaceDataElement AEXMLElement decoding and encoding


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/786

### Short description 📝
> Added an option to get the pbxproj's String representation.
I want to modify a `pbxproj` in memory to add it to an in-memory archive later.
This is needed because we are making a server-side Swift application.
Since it is a server-side application, it would be great to get the modified `pbxproj` without any extra disk I/O operations.
The current APIs can only achieve this by first writing the `pbxproj` to disk.

### Solution 📦
> Added a function inside the `PBXProj` extension, which can be used to get the String representation of the `pbxproj` file.
Also refactored the code to use the above function for better code reuse.

### Implementation 👩‍💻👨‍💻
```
extension PBXProj: Writable {
    public func write(path: Path, override: Bool) throws {
        try write(path: path, override: override, outputSettings: PBXOutputSettings())
    }

    public func write(path: Path, override: Bool, outputSettings: PBXOutputSettings) throws {
        let output = try encodeAsString(outputSettings: outputSettings)
        if override, path.exists {
            try path.delete()
        }
        try path.write(output)
    }
    
    public func encodeAsString(outputSettings: PBXOutputSettings) throws -> String {
        let encoder = PBXProjEncoder(outputSettings: outputSettings)
        return try encoder.encode(proj: self)
    }
}
```
