### PR TITLE
Add otf font files to known file types

### DIFF
--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -234,6 +234,7 @@ public struct Xcode {
         "nib~": "wrapper.nib",
         "nqc": "sourcecode.nqc",
         "o": "compiled.mach-o.objfile",
+        "otf": "file",
         "octest": "wrapper.cfbundle",
         "p": "sourcecode.pascal",
         "pas": "sourcecode.pascal",


### PR DESCRIPTION
### Short description 📝

Generated project files with `otf` font files were producing diffs when using Xcode due those files not having a `lastKnownFileType` set.

### Solution 📦

- The `allExtensions` dictionary is used to map known file type extensions to `lastKnownFileType` in the pbxproj
- Adding `otf` font files to the list
🛠️
### Test Plan 

- Add any otf font file to Xcode manually
- Examine the pbxproj and verify `file` is used as the `lastKnonwFileType`
- Read and write the project using `XcodeProj`
- Verify no diffs
