### PR TITLE
Add preferredScreenCaptureFormat to XCScheme.TestAcion

### DIFF
--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -46,6 +46,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      preferredScreenCaptureFormat = "screenshots"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <PreActions>

--- a/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
@@ -38,6 +38,7 @@ let attributesOrder: [String: [String]] = [
         "shouldUseLaunchSchemeArgsEnv",
         "disableMainThreadChecker",
         "region",
+        "preferredScreenCaptureFormat",
         "codeCoverageEnabled",
         "onlyGenerateCoverageForSpecifiedTargets",
     ],

--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -7,6 +7,10 @@ extension XCScheme {
         public enum AttachmentLifetime: String {
             case keepAlways, keepNever
         }
+        
+        public enum ScreenCaptureFormat: String {
+            case screenshots, screenRecording
+        }
 
         // MARK: - Static
 
@@ -35,6 +39,7 @@ extension XCScheme {
         public var language: String?
         public var region: String?
         public var systemAttachmentLifetime: AttachmentLifetime?
+        public var preferredScreenCaptureFormat: ScreenCaptureFormat?
         public var userAttachmentLifetime: AttachmentLifetime?
         public var customLLDBInitFile: String?
 
@@ -63,6 +68,7 @@ extension XCScheme {
                     language: String? = nil,
                     region: String? = nil,
                     systemAttachmentLifetime: AttachmentLifetime? = nil,
+                    preferredScreenCaptureFormat: ScreenCaptureFormat? = nil,
                     userAttachmentLifetime: AttachmentLifetime? = nil,
                     customLLDBInitFile: String? = nil) {
             self.buildConfiguration = buildConfiguration
@@ -86,6 +92,7 @@ extension XCScheme {
             self.language = language
             self.region = region
             self.systemAttachmentLifetime = systemAttachmentLifetime
+            self.preferredScreenCaptureFormat = preferredScreenCaptureFormat
             self.userAttachmentLifetime = userAttachmentLifetime
             self.customLLDBInitFile = customLLDBInitFile
             super.init(preActions, postActions)
@@ -137,6 +144,8 @@ extension XCScheme {
 
             systemAttachmentLifetime = element.attributes["systemAttachmentLifetime"]
                 .flatMap(AttachmentLifetime.init(rawValue:))
+            preferredScreenCaptureFormat = element.attributes["preferredScreenCaptureFormat"]
+                .flatMap(ScreenCaptureFormat.init(rawValue:))
             userAttachmentLifetime = element.attributes["userAttachmentLifetime"]
                 .flatMap(AttachmentLifetime.init(rawValue:))
             customLLDBInitFile = element.attributes["customLLDBInitFile"]
@@ -177,6 +186,14 @@ extension XCScheme {
                 attributes["disableMainThreadChecker"] = disableMainThreadChecker.xmlString
             }
             attributes["systemAttachmentLifetime"] = systemAttachmentLifetime?.rawValue
+            
+            switch preferredScreenCaptureFormat {
+            case .screenshots:
+                attributes["preferredScreenCaptureFormat"] = preferredScreenCaptureFormat?.rawValue
+            case .none, .screenRecording:
+                break
+            }
+            
             if case .keepAlways? = userAttachmentLifetime {
                 attributes["userAttachmentLifetime"] = userAttachmentLifetime?.rawValue
             }
@@ -253,6 +270,7 @@ extension XCScheme {
                 language == rhs.language &&
                 region == rhs.region &&
                 systemAttachmentLifetime == rhs.systemAttachmentLifetime &&
+                preferredScreenCaptureFormat == rhs.preferredScreenCaptureFormat &&
                 userAttachmentLifetime == rhs.userAttachmentLifetime &&
                 codeCoverageTargets == rhs.codeCoverageTargets &&
                 customLLDBInitFile == rhs.customLLDBInitFile

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -343,6 +343,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.testAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(scheme.testAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(scheme.testAction?.shouldUseLaunchSchemeArgsEnv, true)
+        XCTAssertEqual(scheme.testAction?.preferredScreenCaptureFormat, .screenshots)
         XCTAssertEqual(scheme.testAction?.codeCoverageEnabled, true)
         XCTAssertEqual(scheme.testAction?.onlyGenerateCoverageForSpecifiedTargets, true)
         XCTAssertEqual(scheme.testAction?.testables.first?.skipped, false)


### PR DESCRIPTION
### Short description 📝
- Xcode 15 supports automatic screen recordings for UI tests.
- From [Xcode 15 beta Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#New-Features-in-Xcode-15-Beta):
> XCTest now supports automatic screen recordings in addition to screenshots. Screen recordings allow for a fine-grained view of what happened during a test run, which can be meaningful to investigate UI test failures. Screen recordings are enabled by default (in favor of screenshots). They can be disabled in the test plan or the scheme’s Test action options.
- Available options are:
  - Screenshots - prior to Xcode 15 is was the only available format
  - Screen Recording - new feature of Xcode 15
- It can be configured in the scheme test action options
   <details><summary> New option screenshot </summary>
   <img width="928" alt="Screenshot 2023-09-01 at 17 21 35" src="https://github.com/tuist/XcodeProj/assets/5187973/e1848a46-e881-474c-a7b3-03f9a24e25ce">
   </details>

### Solution 📦
- To support this new option it was added to `XCScheme.TestAcion`

### Implementation 👩‍💻👨‍💻
- Add new enum `ScreenCaptureFormat` with supported capture formats
- Add new optional property of the `ScreenCaptureFormat` type  to `XCScheme.TestAcion`
- Update tests

### Notes 📝
- The new option is ignored by Xcode 14.x and prior
- `Screen Recording` is the default format. As such `preferredScreenCaptureFormat` is omitted in xcscheme when `Screen Recording` is selected.
