### PR TITLE
Create `PBXProj` class from the Data reprentation of a `pbxproj` file

### DIFF
--- a/Sources/XcodeProj/Errors/Errors.swift
+++ b/Sources/XcodeProj/Errors/Errors.swift
@@ -183,6 +183,7 @@ enum PBXProjError: Error, CustomStringConvertible, Equatable {
     case pathIsAbsolute(Path)
     case multipleLocalPackages(productName: String)
     case multipleRemotePackages(productName: String)
+    case malformed
     var description: String {
         switch self {
         case let .notFound(path):
@@ -201,6 +202,8 @@ enum PBXProjError: Error, CustomStringConvertible, Equatable {
             return "Found multiple top-level packages named \(productName)"
         case let .multipleRemotePackages(productName: productName):
             return "Can not resolve dependency \(productName) - conflicting version requirements"
+        case .malformed:
+            return "The .pbxproj is malformed."
         }
     }
 }

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -80,9 +80,10 @@ public final class PBXProj: Decodable {
             format: &propertyListFormat
         )
 
-        // swiftlint:disable:next force_cast
-        let pbxProjDictionary = serialized as! [String: Any]
-            
+        guard let pbxProjDictionary = serialized as? [String: Any] else {
+            throw PBXProjError.malformed
+        }
+
         let context = ProjectDecodingContext(
             pbxProjValueReader: { key in
                 pbxProjDictionary[key]
@@ -180,8 +181,11 @@ public final class PBXProj: Decodable {
             options: .mutableContainersAndLeaves,
             format: &propertyListFormat
         )
-        // swiftlint:disable:next force_cast
-        let pbxProjDictionary = serialized as! [String: Any]
+
+        guard let pbxProjDictionary = serialized as? [String: Any] else {
+            throw PBXProjError.malformed
+        }
+
         return (plistXML, pbxProjDictionary)
     }
 }

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -66,6 +66,41 @@ public final class PBXProj: Decodable {
             objects: pbxproj.objects
         )
     }
+    
+    /// Initializes the project with the data representation of pbxproj file.
+    ///
+    /// - Parameters:
+    ///   - data: data representation of pbxproj file.
+    public convenience init(data: Data) throws {
+        var propertyListFormat = PropertyListSerialization.PropertyListFormat.xml
+
+        let serialized = try PropertyListSerialization.propertyList(
+            from: data,
+            options: .mutableContainersAndLeaves,
+            format: &propertyListFormat
+        )
+
+        // swiftlint:disable:next force_cast
+        let pbxProjDictionary = serialized as! [String: Any]
+            
+        let context = ProjectDecodingContext(
+            pbxProjValueReader: { key in
+                pbxProjDictionary[key]
+            }
+        )
+
+        let plistDecoder = XcodeprojPropertyListDecoder(context: context)
+        let pbxproj: PBXProj = try plistDecoder.decode(PBXProj.self, from: data)
+
+        self.init(
+            rootObject: pbxproj.rootObject,
+            objectVersion: pbxproj.objectVersion,
+            archiveVersion: pbxproj.archiveVersion,
+            classes: pbxproj.classes,
+            objects: pbxproj.objects
+        )
+    }
+
 
     private init(
         rootObject: PBXProject? = nil,

--- a/Sources/XcodeProj/Objects/Project/PBXProj.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProj.swift
@@ -101,7 +101,6 @@ public final class PBXProj: Decodable {
         )
     }
 
-
     private init(
         rootObject: PBXProject? = nil,
         objectVersion: UInt = Xcode.LastKnown.objectVersion,

--- a/Tests/XcodeProjTests/Project/XcodeProjTests.swift
+++ b/Tests/XcodeProjTests/Project/XcodeProjTests.swift
@@ -25,17 +25,18 @@ final class XcodeProjIntegrationTests: XCTestCase {
                                         initModel: XcodeProj.init(path:))
     }
     
-    func test_initialize_PBXProj_with_data() {
-        let pbxprojPath = iosProjectPath.url.appendingPathComponent("project.pbxproj")
-        
-        if let pbxprojStringRepresentation = try? String(contentsOf: pbxprojPath) {
-            let pbxprojData = Data(pbxprojStringRepresentation.utf8)
-            
-            XCTAssertNotNil(try? PBXProj(data: pbxprojData))
-            return
-        }
+    func test_initialize_PBXProj_with_data() throws {
+        // Given
+        let pbxprojPath = iosProjectPath + "project.pbxproj"
+        let pbxprojFromDisk = try PBXProj(path: pbxprojPath)
+        let pbxprojData = try Data(contentsOf: pbxprojPath.url)
 
-        XCTFail()
+        // When
+        let pbxprojFromData = try PBXProj(data: pbxprojData)
+        try pbxprojFromData.updateProjectName(path: pbxprojPath)
+
+        // Then
+        XCTAssertEqual(pbxprojFromData, pbxprojFromDisk)
     }
     
     func test_write_includes_workspace_settings() throws {

--- a/Tests/XcodeProjTests/Project/XcodeProjTests.swift
+++ b/Tests/XcodeProjTests/Project/XcodeProjTests.swift
@@ -25,6 +25,19 @@ final class XcodeProjIntegrationTests: XCTestCase {
                                         initModel: XcodeProj.init(path:))
     }
     
+    func test_initialize_PBXProj_with_data() {
+        let pbxprojPath = iosProjectPath.url.appendingPathComponent("project.pbxproj")
+        
+        if let pbxprojStringRepresentation = try? String(contentsOf: pbxprojPath) {
+            let pbxprojData = Data(pbxprojStringRepresentation.utf8)
+            
+            XCTAssertNotNil(try? PBXProj(data: pbxprojData))
+            return
+        }
+
+        XCTFail()
+    }
+    
     func test_write_includes_workspace_settings() throws {
         // Define workspace settings that should be written
         let workspaceSettings = WorkspaceSettings(buildSystem: .new, derivedDataLocationStyle: .default, autoCreateSchemes: false)


### PR DESCRIPTION
https://github.com/tuist/XcodeProj/issues/793

### Short description 📝
> This change adds a convenience initializer to PBXProj so that it can be initialized from the data representation of a pbxproj file.
The current APIs can create a PBXProj class when the path to a `pbxproj` file is provided.
I want to initialize the PBXProj file from the data representation of a `pbxproj` stored inside an in-memory archive.
This is needed because we are making a server-side Swift application and want to minimize disk operations.

### Solution 📦
> Added a convenience initializer to `PBXProj` extension that we can create a `PBXProj` instance using the data representation of a `pbxproj` file.

### Implementation 👩‍💻👨‍💻
```
/// Initializes the project with the data representation of pbxproj file.
///
/// - Parameters:
///   - data: data representation of pbxproj file.
public convenience init(data: Data) throws {
    var propertyListFormat = PropertyListSerialization.PropertyListFormat.xml

    let serialized = try PropertyListSerialization.propertyList(
        from: data,
        options: .mutableContainersAndLeaves,
        format: &propertyListFormat
    )

    // swiftlint:disable:next force_cast
    let pbxProjDictionary = serialized as! [String: Any]
        
    let context = ProjectDecodingContext(
        pbxProjValueReader: { key in
            pbxProjDictionary[key]
        }
    )

    let plistDecoder = XcodeprojPropertyListDecoder(context: context)
    let pbxproj: PBXProj = try plistDecoder.decode(PBXProj.self, from: data)

    self.init(
        rootObject: pbxproj.rootObject,
        objectVersion: pbxproj.objectVersion,
        archiveVersion: pbxproj.archiveVersion,
        classes: pbxproj.classes,
        objects: pbxproj.objects
    )
}
```
