### PR TITLE
Fix issue that multiple products of the same package cannot be added

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -440,7 +440,7 @@ extension PBXProject {
 
         let productDependency: XCSwiftPackageProductDependency
         // Avoid duplication
-        if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.package == reference })?.value {
+        if let product = objects.swiftPackageProductDependencies.first(where: { $0.value.package == reference && $0.value.productName == productName })?.value {
             productDependency = product
         } else {
             productDependency = XCSwiftPackageProductDependency(productName: productName, package: reference)

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -192,13 +192,16 @@ final class PBXProjectTests: XCTestCase {
                                                                productName: "Product",
                                                                versionRequirement: .branch("main"),
                                                                targetName: secondTarget.name)
-
+        _ = try project.addSwiftPackage(repositoryURL: "url",
+                                        productName: "Product2",
+                                        versionRequirement: .branch("main"),
+                                        targetName: target.name)
         // Then
         XCTAssertEqual(packageProduct, secondPackageProduct)
         XCTAssertEqual(project.remotePackages.count, 1)
-        XCTAssertEqual(target.packageProductDependencies, secondTarget.packageProductDependencies)
+        XCTAssert(target.packageProductDependencies.contains(secondTarget.packageProductDependencies))
         XCTAssertNotEqual(buildPhase.files?.first?.hashValue, secondBuildPhase.files?.first?.hashValue)
-        XCTAssertEqual(objects.swiftPackageProductDependencies.count, 1)
+        XCTAssertEqual(objects.swiftPackageProductDependencies.count, 2)
 
         XCTAssertThrowsSpecificError(try project.addSwiftPackage(repositoryURL: "url",
                                                                  productName: "Product",

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -192,14 +192,16 @@ final class PBXProjectTests: XCTestCase {
                                                                productName: "Product",
                                                                versionRequirement: .branch("main"),
                                                                targetName: secondTarget.name)
-        _ = try project.addSwiftPackage(repositoryURL: "url",
-                                        productName: "Product2",
-                                        versionRequirement: .branch("main"),
-                                        targetName: target.name)
+        let thirdPackageProduct = try project.addSwiftPackage(repositoryURL: "url",
+                                                              productName: "Product2",
+                                                              versionRequirement: .branch("main"),
+                                                              targetName: target.name)
         // Then
         XCTAssertEqual(packageProduct, secondPackageProduct)
+        XCTAssertEqual(packageProduct, thirdPackageProduct)
         XCTAssertEqual(project.remotePackages.count, 1)
-        XCTAssert(target.packageProductDependencies.contains(secondTarget.packageProductDependencies))
+        XCTAssertEqual(target.packageProductDependencies.count, 2)
+        XCTAssertEqual(secondTarget.packageProductDependencies.count, 1)
         XCTAssertNotEqual(buildPhase.files?.first?.hashValue, secondBuildPhase.files?.first?.hashValue)
         XCTAssertEqual(objects.swiftPackageProductDependencies.count, 2)
 
@@ -208,6 +210,12 @@ final class PBXProjectTests: XCTestCase {
                                                                  versionRequirement: .branch("second-main"),
                                                                  targetName: secondTarget.name),
                                      PBXProjError.multipleRemotePackages(productName: "Product"))
+
+        XCTAssertThrowsSpecificError(try project.addSwiftPackage(repositoryURL: "url",
+                                                                 productName: "Product2",
+                                                                 versionRequirement: .branch("second-main"),
+                                                                 targetName: target.name),
+                                     PBXProjError.multipleRemotePackages(productName: "Product2"))
     }
 
     func test_addLocalSwiftPackage_duplication() throws {


### PR DESCRIPTION

### Short description 📝
Currently, it does not seem to be possible to add two products from a single package using:
```
public func addSwiftPackage(repositoryURL: String,
                            productName: String,
                            versionRequirement: XCRemoteSwiftPackageReference.VersionRequirement,
                            targetName: String) throws -> XCRemoteSwiftPackageReference
```
This is because the duplicate check only takes the reference into account. It should also take the productName into account to make sure that a duplicate *can* exist of the same reference when the productName is different.

### Solution 📦
Add the productName check to the if-test. No other solutions were considered.

### Implementation 👩‍💻👨‍💻

- [ x] Add duplicate check
- [ x] Fix unit tests
