### PR TITLE
Fix issue that it is not possible to remove a remote package

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -154,8 +154,8 @@ public final class PBXProject: PBXObject {
         }
     }
 
-    private func setPackageReferences<T: PBXContainerItem>(_ references: [T]) {
-        let newReferences = references.references()
+    private func setPackageReferences<T: PBXContainerItem>(_ packages: [T]) {
+        let newReferences = packages.references()
         var finalReferences: [PBXObjectReference] = packageReferences?.filter { !($0.getObject() is T) } ?? []
         for reference in newReferences {
             if !finalReferences.contains(reference) {

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -137,14 +137,7 @@ public final class PBXProject: PBXObject {
     /// Remote Swift packages.
     public var remotePackages: [XCRemoteSwiftPackageReference] {
         set {
-            var finalReferences: [PBXObjectReference] = packageReferences ?? []
-            let newReferences = newValue.references()
-            for reference in newReferences {
-                if !finalReferences.contains(reference) {
-                    finalReferences.append(reference)
-                }
-            }
-            packageReferences = finalReferences
+            setPackageReferences(newValue)
         }
         get {
             packageReferences?.objects() ?? []
@@ -154,18 +147,22 @@ public final class PBXProject: PBXObject {
     /// Local Swift packages.
     public var localPackages: [XCLocalSwiftPackageReference] {
         set {
-            var finalReferences: [PBXObjectReference] = packageReferences ?? []
-            let newReferences = newValue.references()
-            for reference in newReferences {
-                if !finalReferences.contains(reference) {
-                    finalReferences.append(reference)
-                }
-            }
-            packageReferences = finalReferences
+            setPackageReferences(newValue)
         }
         get {
             packageReferences?.objects() ?? []
         }
+    }
+
+    private func setPackageReferences<T: PBXContainerItem>(_ references: [T]) {
+        let newReferences = references.references()
+        var finalReferences: [PBXObjectReference] = packageReferences?.filter { !($0.getObject() is T) } ?? []
+        for reference in newReferences {
+            if !finalReferences.contains(reference) {
+                finalReferences.append(reference)
+            }
+        }
+        packageReferences = finalReferences
     }
 
     /// Sets the attributes for the given target.

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -102,6 +102,46 @@ final class PBXProjectTests: XCTestCase {
                                      PBXProjError.frameworksBuildPhaseNotFound(targetName: target.name))
     }
 
+    func test_removeRemotePackage() throws {
+        // Given
+        let objects = PBXObjects(objects: [])
+
+        let buildPhase = PBXFrameworksBuildPhase(
+            files: [],
+            inputFileListPaths: nil,
+            outputFileListPaths: nil, buildActionMask: PBXBuildPhase.defaultBuildActionMask,
+            runOnlyForDeploymentPostprocessing: true
+        )
+        let target = PBXNativeTarget(name: "Target",
+                                     buildConfigurationList: nil,
+                                     buildPhases: [buildPhase])
+        objects.add(object: target)
+
+        let configurationList = XCConfigurationList.fixture()
+        let mainGroup = PBXGroup.fixture()
+        objects.add(object: configurationList)
+        objects.add(object: mainGroup)
+
+        let project = PBXProject(name: "Project",
+                                 buildConfigurationList: configurationList,
+                                 compatibilityVersion: "0",
+                                 mainGroup: mainGroup,
+                                 targets: [target])
+
+        objects.add(object: project)
+
+        let _ = try project.addSwiftPackage(repositoryURL: "url",
+                                            productName: "Product",
+                                            versionRequirement: .branch("main"),
+                                            targetName: "Target")
+
+        // When
+        project.remotePackages.removeFirst()
+
+        // Then
+        XCTAssert(project.remotePackages.isEmpty)
+    }
+
     func test_addSwiftPackage() throws {
         // Given
         let objects = PBXObjects(objects: [])


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/802

### Implementation 👩‍💻👨‍💻
It checks that only the references are kept that are not part of the current type. 
This is done by getting the object of the reference and checking the type of this reference.

- [ x] Fix issue
- [ x] Add unit test
