### PR TITLE
XCScheme string initializer

### DIFF
--- a/Sources/XcodeProj/Scheme/XCScheme.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme.swift
@@ -80,6 +80,10 @@ public final class XCScheme: Writable, Equatable {
         self.wasCreatedForAppExtension = wasCreatedForAppExtension
     }
 
+    public convenience init(pathString: String) throws {
+        try self.init(path: Path(pathString))
+    }
+
     // MARK: - Writable
 
     public func write(path: Path, override: Bool) throws {


### PR DESCRIPTION
### Short description 📝
The `XcodeProj` type has a convenience initializer that takes a string. Really is convenient, because it hides the PathKit dependency from callers. But `XCScheme` lacks a similar initializer. I'd love one!

### Solution 📦
### Implementation 👩‍💻👨‍💻

I just copied in the solution from `XcodeProj` 😅

I had a look, and found no tests that use the `XcodeProj` method, so I went with that too. But happy to do more if needed!
