### PR TITLE
Add precompiled header extension to headersExtensions for adding .pch…

### DIFF
--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -60,7 +60,7 @@ public struct Xcode {
     public static let inheritedKeywords = ["${inherited}", "$(inherited)"]
 
     /// Header files extensions.
-    public static let headersExtensions = [".h", ".hh", ".hpp", ".ipp", ".tpp", ".hxx", ".def", ".inl", ".inc"]
+    public static let headersExtensions = [".h", ".hh", ".hpp", ".ipp", ".tpp", ".hxx", ".def", ".inl", ".inc", ".pch"]
 
     /// Supported values.
     public struct Supported {


### PR DESCRIPTION
… to public header section by tuist

Resolves https://github.com/tuist/tuist/issues/5878 

### Short description 📝
Here I described the problem https://github.com/tuist/tuist/issues/5878 

### Solution 📦
> add .pch extension to headersExtensions

