### PR TITLE
Fix deprecation warning when targeting macOS 13

### DIFF
--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -49,18 +49,18 @@ private let char0 = UInt8(UnicodeScalar("0").value)
 private extension DataProtocol {
     var hexString: String {
         let hexLen = self.count * 2
-        let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: hexLen)
+        var hexChars = [UInt8](repeating: 0, count: hexLen)
         var offset = 0
 
         self.regions.forEach { (_) in
             for i in self {
-                ptr[Int(offset * 2)] = itoh((i >> 4) & 0xF)
-                ptr[Int(offset * 2 + 1)] = itoh(i & 0xF)
+                hexChars[Int(offset * 2)] = itoh((i >> 4) & 0xF)
+                hexChars[Int(offset * 2 + 1)] = itoh(i & 0xF)
                 offset += 1
             }
         }
 
-        return String(bytesNoCopy: ptr, length: hexLen, encoding: .utf8, freeWhenDone: true)!
+        return String(bytes: hexChars, encoding: .utf8)!
     }
 
     func itoh(_ value: UInt8) -> UInt8 {


### PR DESCRIPTION
Another attempt at https://github.com/tuist/XcodeProj/pull/710

### Short description 📝
Fixes this deprecation warning when targeting macOS 13:

```
Sources/XcodeProj/Extensions/String+md5.swift:63:16: warning: 'init(bytesNoCopy:length:encoding:freeWhenDone:)' was deprecated in macOS 13: String does not support no-copy initialization
        return String(bytesNoCopy: ptr, length: hexLen, encoding: .utf8, freeWhenDone: true)!
```

### Solution 📦
I cherry-picked an [updated version from swift-crypto](https://github.com/apple/swift-crypto/blob/606608da0875e3dee07cb37da3b38585420db111/Sources/Crypto/Util/PrettyBytes.swift#L40-L54)

### Implementation 👩‍💻👨‍💻
- [x] Applied cherry pick
- [x] `swift test`
