### PR TITLE
Add Privacy Manifest in 'Projects Using' README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ XcodeProj is a library written in Swift for parsing and working with Xcode proje
 | Tuist           | [github.com/tuist/tuist](https://github.com/tuist/tuist)                                     |
 | XcodeGen        | [github.com/yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen)                       |
 | xspm            | [gitlab.com/Pyroh/xspm](https://gitlab.com/Pyroh/xspm)                                       |
+| Privacy Manifest| [github.com/stelabouras/privacy-manifest](https://github.com/stelabouras/privacy-manifest)   |
 
 If you are also leveraging XcodeProj in your project, feel free to open a PR to include it in the list above.
 


### PR DESCRIPTION
### Short description 📝

Adds my Privacy Manifest CLI tool [^1] in the list of open-source projects using the XcodeProj library.

[^1]: https://github.com/stelabouras/privacy-manifest