### PR TITLE
Adopt Strict Concurrency checking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,9 @@ let package = Package(
                 dependencies: [
                     .product(name: "PathKit", package: "PathKit"),
                     .product(name: "AEXML", package: "AEXML"),
+                ],
+                swiftSettings: [
+                  .enableExperimentalFeature("StrictConcurrency")
                 ]),
         .testTarget(name: "XcodeProjTests", dependencies: ["XcodeProj"]),
     ]

--- a/Sources/XcodeProj/Errors/Errors.swift
+++ b/Sources/XcodeProj/Errors/Errors.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+@preconcurrency import PathKit
 
 // MARK: - Xcodeproj
 
@@ -8,7 +8,7 @@ import PathKit
 /// - notFound: the project cannot be found.
 /// - pbxProjNotFound: the .pbxproj file couldn't be found inside the project folder.
 /// - xcworkspaceNotFound: the workspace cannot be found at the given path.
-public enum XCodeProjError: Error, CustomStringConvertible {
+public enum XCodeProjError: Error, CustomStringConvertible, Sendable {
     case notFound(path: Path)
     case pbxprojNotFound(path: Path)
     case xcworkspaceNotFound(path: Path)

--- a/Sources/XcodeProj/Extensions/Path+Extras.swift
+++ b/Sources/XcodeProj/Extensions/Path+Extras.swift
@@ -4,11 +4,15 @@ import PathKit
 
 // MARK: - Path extras.
 
+
+
+func systemGlob(_ pattern: UnsafePointer<CChar>!, _ flags: Int32, _ errfunc: (@convention(c) (UnsafePointer<CChar>?, Int32) -> Int32)!, _ vector_ptr: UnsafeMutablePointer<glob_t>!) -> Int32 {
 #if os(macOS)
-let systemGlob = Darwin.glob
+    return Darwin.glob(pattern, flags, errfunc, vector_ptr)
 #else
-let systemGlob = Glibc.glob
+    return Glibc.glob(pattern, flags, errfunc, vector_ptr)
 #endif
+}
 
 extension Path {
     /// Creates a directory

--- a/Sources/XcodeProj/Objects/Files/PBXGroup.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXGroup.swift
@@ -90,7 +90,7 @@ public class PBXGroup: PBXFileElement {
 // MARK: - Helpers
 
 /// Options passed when adding new groups.
-public struct GroupAddingOptions: OptionSet {
+public struct GroupAddingOptions: OptionSet, Sendable {
     /// Raw value.
     public let rawValue: Int
 

--- a/Sources/XcodeProj/Project/WorkspaceSettings.swift
+++ b/Sources/XcodeProj/Project/WorkspaceSettings.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+@preconcurrency import PathKit
 
 public enum WorkspaceSettingsError: Error, Sendable {
     /// thrown when the settings file was not found.

--- a/Sources/XcodeProj/Project/WorkspaceSettings.swift
+++ b/Sources/XcodeProj/Project/WorkspaceSettings.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PathKit
 
-public enum WorkspaceSettingsError: Error {
+public enum WorkspaceSettingsError: Error, Sendable {
     /// thrown when the settings file was not found.
     case notFound(path: Path)
 }

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -5,11 +5,11 @@ import PathKit
 extension XCScheme {
     public final class BuildAction: SerialAction {
         public final class Entry: Equatable {
-            public enum BuildFor {
+            public enum BuildFor: Sendable {
                 case running, testing, profiling, archiving, analyzing
-                public static var `default`: [BuildFor] = [.running, .testing, .archiving, .analyzing]
-                public static var indexing: [BuildFor] = [.testing, .analyzing, .archiving]
-                public static var testOnly: [BuildFor] = [.testing, .analyzing]
+                public static let `default`: [BuildFor] = [.running, .testing, .archiving, .analyzing]
+                public static let indexing: [BuildFor] = [.testing, .analyzing, .archiving]
+                public static let testOnly: [BuildFor] = [.testing, .analyzing]
             }
 
             // MARK: - Attributes

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -5,20 +5,20 @@ import PathKit
 extension XCScheme {
     // swiftlint:disable:next type_body_length
     public final class LaunchAction: SerialAction {
-        public enum Style: String {
+        public enum Style: String, Sendable {
             case auto = "0"
             case wait = "1"
             case custom = "2"
         }
 
-        public enum GPUFrameCaptureMode: String {
+        public enum GPUFrameCaptureMode: String, Sendable {
             case autoEnabled = "0"
             case metal = "1"
             case openGL = "2"
             case disabled = "3"
         }
 
-        public enum GPUValidationMode: String {
+        public enum GPUValidationMode: String, Sendable {
             case enabled = "0"
             case disabled = "1"
             case extended = "2"

--- a/Sources/XcodeProj/Scheme/XCScheme.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme.swift
@@ -2,7 +2,7 @@ import AEXML
 import Foundation
 import PathKit
 
-public enum XCSchemeError: Error, CustomStringConvertible {
+public enum XCSchemeError: Error, CustomStringConvertible, Sendable {
     case notFound(path: Path)
     case missing(property: String)
 

--- a/Sources/XcodeProj/Scheme/XCScheme.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme.swift
@@ -1,6 +1,6 @@
 import AEXML
 import Foundation
-import PathKit
+@preconcurrency import PathKit
 
 public enum XCSchemeError: Error, CustomStringConvertible, Sendable {
     case notFound(path: Path)

--- a/Sources/XcodeProj/Scheme/XCSchemeManagement.swift
+++ b/Sources/XcodeProj/Scheme/XCSchemeManagement.swift
@@ -1,7 +1,7 @@
 import Foundation
-import PathKit
+@preconcurrency import PathKit
 
-public enum XCSchemeManagementError: Error, Equatable, LocalizedError, CustomStringConvertible {
+public enum XCSchemeManagementError: Error, Equatable, LocalizedError, CustomStringConvertible, Sendable {
     /// Thrown when the user tries to initialize a XCSchemeManagement instace passing a path to a file that doesn't exist.
     case notFound(path: Path)
     

--- a/Sources/XcodeProj/Utils/CommentedString.swift
+++ b/Sources/XcodeProj/Utils/CommentedString.swift
@@ -19,7 +19,7 @@ struct CommentedString {
     }
 
     /// Set of characters that are invalid.
-    private static var invalidCharacters: CharacterSet = {
+    private static let invalidCharacters: CharacterSet = {
         var invalidSet = CharacterSet(charactersIn: "_$")
         invalidSet.insert(charactersIn: UnicodeScalar(".") ... UnicodeScalar("9"))
         invalidSet.insert(charactersIn: UnicodeScalar("A") ... UnicodeScalar("Z"))
@@ -29,7 +29,7 @@ struct CommentedString {
     }()
 
     /// Set of characters that are invalid.
-    private static var specialCheckCharacters = CharacterSet(charactersIn: "_/")
+    private static let specialCheckCharacters = CharacterSet(charactersIn: "_/")
 
     /// Returns a valid string for Xcode projects.
     var validString: String {

--- a/Sources/XcodeProj/Utils/Decoders.swift
+++ b/Sources/XcodeProj/Utils/Decoders.swift
@@ -44,7 +44,7 @@ class ProjectDecodingContext {
 
 extension CodingUserInfoKey {
     /// Context user info key.
-    static var context: CodingUserInfoKey = CodingUserInfoKey(rawValue: "context")!
+    static let context: CodingUserInfoKey = CodingUserInfoKey(rawValue: "context")!
 }
 
 /// Xcodeproj JSON decoder.

--- a/Sources/XcodeProj/Utils/XCConfig.swift
+++ b/Sources/XcodeProj/Utils/XCConfig.swift
@@ -97,9 +97,9 @@ final class XCConfigParser {
     }
 
     // swiftlint:disable:next force_try
-    private static var includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
+    private static let includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
     // swiftlint:disable:next force_try
-    private static var settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*?\"?)\\s*(?:;\\s*)?(?=$|\\/\\/)", options: [])
+    private static let settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*?\"?)\\s*(?:;\\s*)?(?=$|\\/\\/)", options: [])
 }
 
 // MARK: - XCConfig Extension (Equatable)


### PR DESCRIPTION
- Convert `var` to `let` for structured concurrency
- Add Sendable conformance to types triggering warnings
- Add strict concurrency checking to package
- Annotation `PathKit` imports with `@preconcurrency`
- Convert to a global funciton to avoid shared global state.

Resolves https://github.com/tuist/xcodeproj/issues/YYY

### Short description 📝
> Describe here the purpose of your PR.

### Solution 📦
> Describe the solution you came up with and the reasons that led you to that solution. If you thought about other solutions don't forget about mentioning them.

### Implementation 👩‍💻👨‍💻
> Detail in a checklist the steps that you took to implement the PR.

- [ ] Step 1
- [ ] Step 2
