### PR TITLE
Update comment to reflect productNameWithExtension() and others

### DIFF
--- a/Sources/XcodeProj/Objects/Targets/PBXTarget.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXTarget.swift
@@ -63,8 +63,6 @@ public class PBXTarget: PBXContainerItem {
     public var productName: String?
 
     /// Target product reference.
-    ///
-    /// This property's value may differ from the value displayed in Xcode if the product name is specified through build settings.
     var productReference: PBXObjectReference?
 
     /// Target product.

--- a/Sources/XcodeProj/Objects/Targets/PBXTarget.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXTarget.swift
@@ -58,9 +58,13 @@ public class PBXTarget: PBXContainerItem {
     public var name: String
 
     /// Target product name.
+    ///
+    /// This property's value may differ from the value displayed in Xcode if the product name is specified through build settings.
     public var productName: String?
 
     /// Target product reference.
+    ///
+    /// This property's value may differ from the value displayed in Xcode if the product name is specified through build settings.
     var productReference: PBXObjectReference?
 
     /// Target product.
@@ -218,6 +222,8 @@ public class PBXTarget: PBXContainerItem {
 
 public extension PBXTarget {
     /// Returns the product name with the extension joined with a period.
+    ///
+    /// This property's value may differ from the value displayed in Xcode if the product name is specified through build settings.
     ///
     /// - Returns: product name with extension.
     func productNameWithExtension() -> String? {


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/820

### Short description 📝

Based on my experience using XcodeProj, I found it confusing that the value of `productNameWithExtension()` and others could be different from the value displayed in Xcode.

### Solution 📦

Based on the discussion on the issue, we agreed to improve the comment on the given methods.

### Implementation 👩‍💻👨‍💻

I added the comments to the methods that are obviously affected. In case there are other methods, I can update them as well.
