### PR TITLE
Add `buildArchitectures` to XCScheme+BuildAction

### DIFF
--- a/Fixtures/Schemes/BuildArchitectures.xcscheme
+++ b/Fixtures/Schemes/BuildArchitectures.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93E9E330FC2CE7458D9C925F"
+               BuildableName = "App.app"
+               BlueprintName = "App"
+               ReferencedContainer = "container:App.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "99DCC7BD0ABB09C467644299"
+               BuildableName = "AppTests.xctest"
+               BlueprintName = "AppTests"
+               ReferencedContainer = "container:App.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93E9E330FC2CE7458D9C925F"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93E9E330FC2CE7458D9C925F"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
@@ -13,6 +13,7 @@ let attributesOrder: [String: [String]] = [
     "BuildAction": [
         "parallelizeBuildables",
         "buildImplicitDependencies",
+        "buildArchitectures",
         "runPostActionsOnFailure",
     ],
     "BuildActionEntry": [

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -71,7 +71,6 @@ extension XCScheme {
         }
 
         public enum Architecture {
-            /// A default value.
             case matchRunDestination
             case universal
             case useTargetSettings

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -72,7 +72,7 @@ extension XCScheme {
 
         public enum Architecture {
             /// A default value.
-            case matchRunDestination // (Apple recommended: default)
+            case matchRunDestination
             case universal
             case useTargetSettings
 

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -88,7 +88,7 @@ extension XCScheme {
 
             /// Creates a new instance from the given xml string.
             ///
-            /// For undefined value, initialized as `matchRunDestination`.
+            /// For undefined value, initialized as `useTargetSettings` since the XML element is removed.
             fileprivate init(_ xmlString: String) {
                 switch xmlString {
                 case "Automatic":
@@ -96,7 +96,7 @@ extension XCScheme {
                 case "All":
                     self = .universal
                 default:
-                    self = .matchRunDestination
+                    self = .useTargetSettings
                 }
             }
         }
@@ -117,7 +117,7 @@ extension XCScheme {
                     parallelizeBuild: Bool = false,
                     buildImplicitDependencies: Bool = false,
                     runPostActionsOnFailure: Bool? = nil,
-                    buildArchitectures: Architectures = .matchRunDestination) {
+                    buildArchitectures: Architectures = .useTargetSettings) {
             self.buildActionEntries = buildActionEntries
             self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -70,7 +70,7 @@ extension XCScheme {
             }
         }
 
-        public enum Architecture {
+        public enum Architectures {
             case matchRunDestination
             case universal
             case useTargetSettings
@@ -107,7 +107,7 @@ extension XCScheme {
         public var parallelizeBuild: Bool
         public var buildImplicitDependencies: Bool
         public var runPostActionsOnFailure: Bool?
-        public var buildArchitectures: Architecture
+        public var buildArchitectures: Architectures
 
         // MARK: - Init
 
@@ -117,7 +117,7 @@ extension XCScheme {
                     parallelizeBuild: Bool = false,
                     buildImplicitDependencies: Bool = false,
                     runPostActionsOnFailure: Bool? = nil,
-                    buildArchitectures: Architecture = .matchRunDestination) {
+                    buildArchitectures: Architectures = .matchRunDestination) {
             self.buildActionEntries = buildActionEntries
             self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies
@@ -133,7 +133,7 @@ extension XCScheme {
             buildActionEntries = try element["BuildActionEntries"]["BuildActionEntry"]
                 .all?
                 .map(Entry.init) ?? []
-            buildArchitectures = element.attributes["buildArchitectures"].map { Architecture($0) } ?? .useTargetSettings
+            buildArchitectures = element.attributes["buildArchitectures"].map { Architectures($0) } ?? .useTargetSettings
             try super.init(element: element)
         }
 

--- a/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
+++ b/Tests/XcodeProjTests/Extensions/AEXML+XcodeFormatTests.swift
@@ -16,6 +16,7 @@ class AEXML_XcodeFormatTests: XCTestCase {
         <BuildAction
            parallelizeBuildables = "YES"
            buildImplicitDependencies = "NO"
+           buildArchitectures = "Automatic"
            runPostActionsOnFailure = "YES">
         </BuildAction>
         """
@@ -73,8 +74,9 @@ class AEXML_XcodeFormatTests: XCTestCase {
             childName: "BuildAction",
             attributes: [
                 "parallelizeBuildables": "YES",
-                "runPostActionsOnFailure": "YES",
                 "buildImplicitDependencies": "NO",
+                "buildArchitectures": "Automatic",
+                "runPostActionsOnFailure": "YES",
             ]
         )
     }
@@ -87,6 +89,7 @@ class AEXML_XcodeFormatTests: XCTestCase {
                 "buildImplicitDependencies": "NO",
                 "parallelizeBuildables": "YES",
                 "runPostActionsOnFailure": "YES",
+                "buildArchitectures": "Automatic",
             ]
         )
     }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -331,6 +331,37 @@ final class XCSchemeIntegrationTests: XCTestCase {
         // Then
         XCTAssertEqual(reconstructedSubject, subject)
     }
+    
+    func test_buildAction_buildArchitectures() throws {
+        // Given / When
+        let subject = try XCScheme(path: buildArchitecturesSchemePath)
+
+        // Then
+        let buildAction = try XCTUnwrap(subject.buildAction)
+        XCTAssertTrue(buildAction.buildArchitectures == .matchRunDestination)
+    }
+    
+    func test_buildAction_buildArchitectures_whenXMLElementDoesNotExist() throws {
+        // Given / When
+        let subject = try XCScheme(path: minimalSchemePath)
+
+        // Then
+        let buildAction = try XCTUnwrap(subject.buildAction)
+        XCTAssertTrue(buildAction.buildArchitectures == .useTargetSettings)
+    }
+    
+    func test_buildAction_buildArchitectures_serializingAndDeserializing() throws {
+        // Given
+        let scheme = try XCScheme(path: buildArchitecturesSchemePath)
+        let subject = try XCTUnwrap(scheme.buildAction)
+
+        // When
+        let xml = subject.xmlElement()
+        let reconstructedSubject = try XCScheme.BuildAction(element: xml)
+
+        // Then
+        XCTAssertEqual(reconstructedSubject, subject)
+    }
 
     // MARK: - Private
 
@@ -742,5 +773,10 @@ final class XCSchemeIntegrationTests: XCTestCase {
     private var runPostActionsOnFailureSchemePath: Path {
         // A scheme with the `runPostActionsOnFailure` enabled
         fixturesPath() + "Schemes/RunPostActionsOnFailure.xcscheme"
+    }
+    
+    /// A scheme that `buildArchitectures` is specified "Automatic".
+    private var buildArchitecturesSchemePath: Path {
+        fixturesPath() + "Schemes/BuildArchitectures.xcscheme"
     }
 }


### PR DESCRIPTION
This PR is related to https://github.com/tuist/tuist/issues/6003

### Short description 📝
It makes enable to set `Override Architectures` option of build action.

### Solution 📦
I observed the changes in the `xcscheme` file as I changed the `Override Architectures` option. After that, I decided to add the attribute in a similar way to the existing implementation of `buildImplicitDependencies` and `runPostActionsOnFailure`.

### Implementation 👩‍💻👨‍💻
- Add an enum to represent the `Override Architectures` option.
- Add `buildArchitectures` property in `XCScheme.BuildAction`.
- Add and Update tests