### PR TITLE
Fix attributes assignment in Metal Diagnostics Options of LaunchAction

### DIFF
--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -276,10 +276,10 @@ extension XCScheme {
                 attributes["enableGPUShaderValidationMode"] = gpuShaderValidationModeEnableValue
             }
             if showGraphicsOverview {
-                attributes["showGraphicsOverview"] = showGraphicsOverview.xmlString
+                attributes["showGraphicsOverview"] = "Yes"
             }
             if logGraphicsOverview {
-                attributes["logGraphicsOverview"] = showGraphicsOverview.xmlString
+                attributes["logGraphicsOverview"] = "Yes"
             }
             if enableAddressSanitizer {
                 attributes["enableAddressSanitizer"] = enableAddressSanitizer.xmlString


### PR DESCRIPTION
I have made a mistake in https://github.com/tuist/XcodeProj/pull/828

### Short description 📝
In my previous PR, I mistakenly set the attributes "showGraphicsOverview" and "logGraphicsOverview" to the value of .xmlString. This was incorrect, as these two fields, unlike others, should contain values in the form of "Yes" or "No" instead of the values returned from .xmlString, which are "YES" and "NO".

Currently, I have changed it to:
```swift
if showGraphicsOverview {
    attributes["showGraphicsOverview"] = "Yes"
}
if logGraphicsOverview {
    attributes["logGraphicsOverview"] = "Yes"
}
```
Is this approach acceptable, or should we consider creating a new property, such as .xmlStringCapitalized? Alternatively, do you have a better suggestion?

This PR is related to https://github.com/tuist/tuist/pull/6537