### PR TITLE
chore: disable the renovatebot dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Renovatebot, the tool that we use to auto-update dependencies, creates an [issue](https://github.com/tuist/XcodeProj/issues/768) with a dashboard, which we are not using. This PR disables it.