### PR TITLE
fix: error: ambiguous use of 'arc4random_uniform' on Linux distros

### DIFF
--- a/Sources/XcodeProj/Extensions/String+Utils.swift
+++ b/Sources/XcodeProj/Extensions/String+Utils.swift
@@ -15,7 +15,7 @@ public extension String {
 
         for _ in 0 ..< length {
             let randomValue = Int.random(in: 0..<base.count)
-            randomString += "\(base[base.index(base.startIndex, offsetBy: Int(randomValue))])"
+            randomString += "\(base[base.index(base.startIndex, offsetBy: randomValue)])"
         }
         return randomString
     }

--- a/Sources/XcodeProj/Extensions/String+Utils.swift
+++ b/Sources/XcodeProj/Extensions/String+Utils.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-#if os(Linux)
-    import SwiftGlibc
-
-    public func arc4random_uniform(_ max: UInt32) -> Int32 {
-        SwiftGlibc.rand() % Int32(max - 1)
-    }
-#endif
-
 public extension String {
     var quoted: String {
         "\"\(self)\""
@@ -22,7 +14,7 @@ public extension String {
         var randomString = ""
 
         for _ in 0 ..< length {
-            let randomValue = arc4random_uniform(UInt32(base.count))
+            let randomValue = Int.random(in: 0..<base.count)
             randomString += "\(base[base.index(base.startIndex, offsetBy: Int(randomValue))])"
         }
         return randomString

--- a/Sources/XcodeProj/Extensions/String+Utils.swift
+++ b/Sources/XcodeProj/Extensions/String+Utils.swift
@@ -14,7 +14,7 @@ public extension String {
         var randomString = ""
 
         for _ in 0 ..< length {
-            let randomValue = Int.random(in: 0..<base.count)
+            let randomValue = Int.random(in: 0 ..< base.count)
             randomString += "\(base[base.index(base.startIndex, offsetBy: randomValue)])"
         }
         return randomString


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/845

### Short description 📝
To fix bug when compiling xcodegen on linux distros using swift 5.10.1

### Solution 📦
I got rid of the arc4random_uniform method and used the TYPE.random method (`Int.random(in: 0..<base.count`)

I also got rid of the overwrite on arc4random_uniform that would happen when linux distros were being used as the TYPE.random method works with linux distros

### Implementation 👩‍💻👨‍💻

- [ ] Made Changes
- [ ] Pulled Changes into XcodeGen branch
- [ ] Tested Changes in XcodeGen branch on linux distro and confirmed it could now compile and work correctly
