### PR TITLE
feat: make `PBXProject.compatibilityVersion` optional and add `PBXProject.preferredProjectObjectVersion` to support Xcode 16

### DIFF
--- a/.github/.commitlint.rules.js
+++ b/.github/.commitlint.rules.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'header-max-length': 200
+  }
+}

--- a/.github/.commitlint.rules.js
+++ b/.github/.commitlint.rules.js
@@ -1,5 +1,5 @@
 module.exports = {
   rules: {
-    'header-max-length': [200]
+    'header-max-length': [2, 'always', 200],
   }
 }

--- a/.github/.commitlint.rules.js
+++ b/.github/.commitlint.rules.js
@@ -1,5 +1,5 @@
 module.exports = {
   rules: {
-    'header-max-length': 200
+    'header-max-length': [200]
   }
 }

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -16,5 +16,6 @@ jobs:
       - uses: CondeNast/conventional-pull-request-action@v0.2.0
         with:
           commitTitleMatch: false
+          commitlintRulesPath: ".github/.commitlint.rules.js"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -21,7 +21,7 @@ public final class PBXProject: PBXObject {
     }
 
     /// A string representation of the XcodeCompatibilityVersion.
-    public var compatibilityVersion: String
+    public var compatibilityVersion: String?
 
     /// The region of development.
     public var developmentRegion: String?
@@ -300,7 +300,7 @@ public final class PBXProject: PBXObject {
     ///   - targetAttributes: project target's attributes.
     public init(name: String,
                 buildConfigurationList: XCConfigurationList,
-                compatibilityVersion: String,
+                compatibilityVersion: String?,
                 mainGroup: PBXGroup,
                 developmentRegion: String? = nil,
                 hasScannedForEncodings: Int = 0,
@@ -359,7 +359,7 @@ public final class PBXProject: PBXObject {
         name = try (container.decodeIfPresent(.name)) ?? ""
         let buildConfigurationListReference: String = try container.decode(.buildConfigurationList)
         self.buildConfigurationListReference = referenceRepository.getOrCreate(reference: buildConfigurationListReference, objects: objects)
-        compatibilityVersion = try container.decode(.compatibilityVersion)
+        compatibilityVersion = try container.decodeIfPresent(.compatibilityVersion)
         developmentRegion = try container.decodeIfPresent(.developmentRegion)
         let hasScannedForEncodingsString: String? = try container.decodeIfPresent(.hasScannedForEncodings)
         hasScannedForEncodings = hasScannedForEncodingsString.flatMap { Int($0) } ?? 0
@@ -482,7 +482,9 @@ extension PBXProject: PlistSerializable {
         let buildConfigurationListCommentedString = CommentedString(buildConfigurationListReference.value,
                                                                     comment: buildConfigurationListComment)
         dictionary["buildConfigurationList"] = .string(buildConfigurationListCommentedString)
-        dictionary["compatibilityVersion"] = .string(CommentedString(compatibilityVersion))
+        if let compatibilityVersion {
+            dictionary["compatibilityVersion"] = .string(CommentedString(compatibilityVersion))
+        }
         if let developmentRegion {
             dictionary["developmentRegion"] = .string(CommentedString(developmentRegion))
         }

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -23,6 +23,9 @@ public final class PBXProject: PBXObject {
     /// A string representation of the XcodeCompatibilityVersion.
     public var compatibilityVersion: String?
 
+    /// An int representation of the PreferredProjectObjectVersion.
+    public var preferredProjectObjectVersion: Int?
+
     /// The region of development.
     public var developmentRegion: String?
 
@@ -286,6 +289,7 @@ public final class PBXProject: PBXObject {
     ///   - name: xcodeproj's name.
     ///   - buildConfigurationList: project build configuration list.
     ///   - compatibilityVersion: project compatibility version.
+    ///   - preferredProjectObjectVersion: preferred project object version
     ///   - mainGroup: project main group.
     ///   - developmentRegion: project has development region.
     ///   - hasScannedForEncodings: project has scanned for encodings.
@@ -301,6 +305,7 @@ public final class PBXProject: PBXObject {
     public init(name: String,
                 buildConfigurationList: XCConfigurationList,
                 compatibilityVersion: String?,
+                preferredProjectObjectVersion: Int?,
                 mainGroup: PBXGroup,
                 developmentRegion: String? = nil,
                 hasScannedForEncodings: Int = 0,
@@ -316,6 +321,7 @@ public final class PBXProject: PBXObject {
         self.name = name
         buildConfigurationListReference = buildConfigurationList.reference
         self.compatibilityVersion = compatibilityVersion
+        self.preferredProjectObjectVersion = preferredProjectObjectVersion
         mainGroupReference = mainGroup.reference
         self.developmentRegion = developmentRegion
         self.hasScannedForEncodings = hasScannedForEncodings
@@ -338,6 +344,7 @@ public final class PBXProject: PBXObject {
         case name
         case buildConfigurationList
         case compatibilityVersion
+        case preferredProjectObjectVersion
         case developmentRegion
         case hasScannedForEncodings
         case knownRegions
@@ -360,6 +367,7 @@ public final class PBXProject: PBXObject {
         let buildConfigurationListReference: String = try container.decode(.buildConfigurationList)
         self.buildConfigurationListReference = referenceRepository.getOrCreate(reference: buildConfigurationListReference, objects: objects)
         compatibilityVersion = try container.decodeIfPresent(.compatibilityVersion)
+        preferredProjectObjectVersion = try container.decodeIfPresent(.preferredProjectObjectVersion)
         developmentRegion = try container.decodeIfPresent(.developmentRegion)
         let hasScannedForEncodingsString: String? = try container.decodeIfPresent(.hasScannedForEncodings)
         hasScannedForEncodings = hasScannedForEncodingsString.flatMap { Int($0) } ?? 0
@@ -496,6 +504,9 @@ extension PBXProject: PlistSerializable {
         }
         let mainGroupObject: PBXGroup? = mainGroupReference.getObject()
         dictionary["mainGroup"] = .string(CommentedString(mainGroupReference.value, comment: mainGroupObject?.fileName()))
+        if let preferredProjectObjectVersion {
+            dictionary["preferredProjectObjectVersion"] = .string(CommentedString(preferredProjectObjectVersion.description))
+        }
         if let productsGroupReference {
             let productRefGroupObject: PBXGroup? = productsGroupReference.getObject()
             dictionary["productRefGroup"] = .string(CommentedString(productsGroupReference.value,

--- a/Tests/XcodeProjTests/Objects/Files/PBXContainerItemProxyTests.swift
+++ b/Tests/XcodeProjTests/Objects/Files/PBXContainerItemProxyTests.swift
@@ -20,7 +20,7 @@ final class PBXContainerItemProxyTests: XCTestCase {
 
     func test_maintains_remoteID() {
         let target = PBXNativeTarget(name: "")
-        let project = PBXProject(name: "", buildConfigurationList: XCConfigurationList(), compatibilityVersion: "", mainGroup: PBXGroup())
+        let project = PBXProject(name: "", buildConfigurationList: XCConfigurationList(), compatibilityVersion: "", preferredProjectObjectVersion: nil, mainGroup: PBXGroup())
         let containerProxy = PBXContainerItemProxy(containerPortal: .project(project), remoteGlobalID: .object(target))
 
         XCTAssertEqual(target.uuid, containerProxy.remoteGlobalID?.uuid)

--- a/Tests/XcodeProjTests/Objects/Files/PBXFileElementTests.swift
+++ b/Tests/XcodeProjTests/Objects/Files/PBXFileElementTests.swift
@@ -54,6 +54,7 @@ final class PBXFileElementTests: XCTestCase {
         let project = PBXProject(name: "ProjectName",
                                  buildConfigurationList: XCConfigurationList(),
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup)
 
         let objects = PBXObjects(objects: [project, mainGroup, fileref, group])
@@ -109,6 +110,7 @@ final class PBXFileElementTests: XCTestCase {
         let project = PBXProject(name: "ProjectName",
                                  buildConfigurationList: XCConfigurationList(),
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: rootGroup)
 
         let objects = PBXObjects(objects: [fileref, nestedGroup, rootGroup, project])

--- a/Tests/XcodeProjTests/Objects/Files/PBXGroupTests.swift
+++ b/Tests/XcodeProjTests/Objects/Files/PBXGroupTests.swift
@@ -18,6 +18,7 @@ final class PBXGroupTests: XCTestCase {
         let pbxProject = PBXProject(name: "ProjectName",
                                     buildConfigurationList: XCConfigurationList(),
                                     compatibilityVersion: "0",
+                                    preferredProjectObjectVersion: nil,
                                     mainGroup: group)
         project.add(object: pbxProject)
 
@@ -139,6 +140,7 @@ final class PBXGroupTests: XCTestCase {
         let pbxProject = PBXProject(name: "ProjectName",
                                     buildConfigurationList: XCConfigurationList(),
                                     compatibilityVersion: "0",
+                                    preferredProjectObjectVersion: nil,
                                     mainGroup: group)
         project.add(object: pbxProject)
 
@@ -163,6 +165,7 @@ final class PBXGroupTests: XCTestCase {
         let pbxProject = PBXProject(name: "ProjectName",
                                     buildConfigurationList: XCConfigurationList(),
                                     compatibilityVersion: "0",
+                                    preferredProjectObjectVersion: nil,
                                     mainGroup: group)
         project.add(object: pbxProject)
 
@@ -186,6 +189,7 @@ final class PBXGroupTests: XCTestCase {
         let pbxProject = PBXProject(name: "ProjectName",
                                     buildConfigurationList: XCConfigurationList(),
                                     compatibilityVersion: "0",
+                                    preferredProjectObjectVersion: nil,
                                     mainGroup: group)
         project.add(object: pbxProject)
 

--- a/Tests/XcodeProjTests/Objects/Project/PBXProject+Fixtures.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProject+Fixtures.swift
@@ -10,6 +10,7 @@ extension PBXProject {
         PBXProject(name: name,
                    buildConfigurationList: buildConfigurationList,
                    compatibilityVersion: compatibilityVersion,
+                   preferredProjectObjectVersion: nil,
                    mainGroup: mainGroup)
     }
 }

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -12,6 +12,7 @@ final class PBXProjectTests: XCTestCase {
         let project = PBXProject(name: "",
                                  buildConfigurationList: XCConfigurationList(),
                                  compatibilityVersion: "",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: PBXGroup(),
                                  attributes: ["LastUpgradeCheck": "0940"],
                                  targetAttributes: [target: ["TestTargetID": "123"]])
@@ -54,6 +55,7 @@ final class PBXProjectTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup,
                                  targets: [target])
 
@@ -89,6 +91,7 @@ final class PBXProjectTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup,
                                  targets: [target])
 
@@ -125,6 +128,7 @@ final class PBXProjectTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup,
                                  targets: [target])
 
@@ -165,6 +169,7 @@ final class PBXProjectTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup,
                                  targets: [target])
 
@@ -218,6 +223,7 @@ final class PBXProjectTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup,
                                  targets: [target, secondTarget])
 
@@ -292,6 +298,7 @@ final class PBXProjectTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup,
                                  targets: [target, secondTarget])
 

--- a/Tests/XcodeProjTests/Objects/Targets/PBXAggregateTargetTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXAggregateTargetTests.swift
@@ -39,6 +39,7 @@ final class PBXAggregateTargetTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup)
 
         objects.add(object: project)

--- a/Tests/XcodeProjTests/Objects/Targets/PBXNativeTargetTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXNativeTargetTests.swift
@@ -40,6 +40,7 @@ final class PBXNativeTargetTests: XCTestCase {
         let project = PBXProject(name: "Project",
                                  buildConfigurationList: configurationList,
                                  compatibilityVersion: "0",
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup)
 
         objects.add(object: project)

--- a/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
+++ b/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
@@ -94,6 +94,7 @@ private extension PBXProj {
         let project = PBXProject(name: "test",
                                  buildConfigurationList: XCConfigurationList.fixture(),
                                  compatibilityVersion: Xcode.Default.compatibilityVersion,
+                                 preferredProjectObjectVersion: nil,
                                  mainGroup: mainGroup)
 
         add(object: mainGroup)


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/837

### Short description 📝
This PR will make `compatibilityVersion` optional. Since Xcode 16 this field isn't present anymore.
Also I added `preferredProjectObjectVersion` that is also part if Xcode 16 changes.

### Solution 📦
I'm new to this. So I tried to see if there was ny "16.0" in a fresh and newly created Xcode project, so see if it was renamed.
Could not find any. So I made it optional, so we can decode Xcode 16 projects.

### Implementation 👩‍💻👨‍💻
- Made the field optional and added `preferredProjectObjectVersion`
- Did run the branch against a local project and it worked