### PR TITLE
sort project references as xcode16

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
@@ -476,39 +476,16 @@ final class PBXProjEncoder {
         }
 
         for project in projects {
-            do {
-                project.projectReferences = try project.projectReferences.sorted(by: { lhs, rhs in
-                    guard let lProjectRef = lhs["ProjectRef"] else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let lFile: PBXFileElement = lProjectRef.getObject() else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let rProjectRef = rhs["ProjectRef"] else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let rFile: PBXFileElement = rProjectRef.getObject() else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let lName = lFile.name else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let rName = rFile.name else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-
-                    return lName.compare(rName, options: .caseInsensitive) == .orderedAscending
-                })
-            } catch {
-                print("Unable to sort as Xcode 16 do: \(error)")
-                // actually we could do even fatalError here
-                // but it could be too brave for common repository
-                // fatalError("\(error)")
-            }
+            /// The project references are sorted alphabetically based on the name of the project it's being referenced.
+            project.projectReferences = project.projectReferences.sorted(by: { lhs, rhs in
+                let lProjectRef = lhs["ProjectRef"]!
+                let lFile: PBXFileElement = lProjectRef.getObject()!
+                let rProjectRef = rhs["ProjectRef"]!
+                let rFile: PBXFileElement = rProjectRef.getObject()!
+                let lName = lFile.name!
+                let rName = rFile.name!
+                return lName.compare(rName, options: .caseInsensitive) == .orderedAscending
+            })
         }
     }
-}
-
-private enum Errors: Error {
-    case unexpectedPbxProj(_ id: Int = #line)
 }

--- a/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
@@ -501,7 +501,9 @@ final class PBXProjEncoder {
                 })
             } catch {
                 print("Unable to sort as Xcode 16 do: \(error)")
-                fatalError("\(error)")
+                // actually we could do even fatalError here
+                // but it could be too brave for common repository
+                // fatalError("\(error)")
             }
         }
     }

--- a/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
@@ -54,6 +54,7 @@ final class PBXProjEncoder {
         sort(buildPhases: proj.objects.resourcesBuildPhases, outputSettings: outputSettings)
         sort(buildPhases: proj.objects.sourcesBuildPhases, outputSettings: outputSettings)
         sort(navigatorGroups: proj.objects.groups, outputSettings: outputSettings)
+        sortProjectReferences(for: proj.projects, outputSettings: outputSettings)
 
         var output = [String]()
         var stateHolder = StateHolder()
@@ -468,4 +469,44 @@ final class PBXProjEncoder {
             navigatorGroups.values.forEach { $0.children = $0.children.sorted(by: sort) }
         }
     }
+
+    private func sortProjectReferences(for projects: [PBXProject], outputSettings: PBXOutputSettings) {
+        guard outputSettings.projReferenceFormat == .xcode else {
+            return
+        }
+
+        for project in projects {
+            do {
+                project.projectReferences = try project.projectReferences.sorted(by: { lhs, rhs in
+                    guard let lProjectRef = lhs["ProjectRef"] else {
+                        throw Errors.unexpectedPbxProj()
+                    }
+                    guard let lFile: PBXFileElement = lProjectRef.getObject() else {
+                        throw Errors.unexpectedPbxProj()
+                    }
+                    guard let rProjectRef = rhs["ProjectRef"] else {
+                        throw Errors.unexpectedPbxProj()
+                    }
+                    guard let rFile: PBXFileElement = rProjectRef.getObject() else {
+                        throw Errors.unexpectedPbxProj()
+                    }
+                    guard let lName = lFile.name else {
+                        throw Errors.unexpectedPbxProj()
+                    }
+                    guard let rName = rFile.name else {
+                        throw Errors.unexpectedPbxProj()
+                    }
+
+                    return lName.compare(rName, options: .caseInsensitive) == .orderedAscending
+                })
+            } catch {
+                print("Unable to sort as Xcode 16 do: \(error)")
+                fatalError("\(error)")
+            }
+        }
+    }
+}
+
+private enum Errors: Error {
+    case unexpectedPbxProj(_ id: Int = #line)
 }

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
@@ -328,6 +328,8 @@ class PBXProjEncoderTests: XCTestCase {
         line = lines.validate(line: "/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */", after: line)
     }
 
+    // MARK: - Projects
+
     // MARK: - Build phases
 
     func test_build_phase_sources_unsorted_when_iOSProject() throws {


### PR DESCRIPTION
### Short description 📝

If project saved with XcodeProj then opening it with Xcode 16 generate some changes. So we could respect Xcode 16 sorting by sorting our result with the same way.

### Solution 📦

Do the same sorting as Xcode 16 do

----

NB! This PR based on other fix so please merge this PR first https://github.com/tuist/XcodeProj/pull/865