### PR TITLE
Add handling for Swift Testing Only Parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,12 @@ object.
 ## References 📚
 
 - [Xcode Project File Format](http://www.monobjc.net/xcode-project-file-format.html)
-- [A brief look at the Xcode project format](http://danwright.info/blog/2010/10/xcode-pbxproject-files/)
 - [pbexplorer](https://github.com/mjmsmith/pbxplorer)
 - [pbxproj identifiers](https://pewpewthespells.com/blog/pbxproj_identifiers.html)
 - [mob-pbxproj](https://github.com/kronenthaler/mod-pbxproj)
 - [Xcodeproj](https://github.com/CocoaPods/Xcodeproj)
 - [Nanaimo](https://github.com/CocoaPods/Nanaimo)
 - [Facebook Buck](https://buckbuild.com/javadoc/com/facebook/buck/apple/xcode/xcodeproj/package-summary.html)
-- [Swift Package Manager - Xcodeproj](https://github.com/apple/swift-package-manager/tree/main/Sources/Xcodeproj)
 
 ## Contributing
 

--- a/Sources/XcodeProj/Scheme/XCScheme+Parallelization.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+Parallelization.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum Parallelization: String {
+  case swiftTestingOnly
+  case all
+  case none
+}

--- a/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
@@ -37,12 +37,11 @@ public extension XCScheme {
         init(element: AEXMLElement) throws {
             skipped = element.attributes["skipped"] == "YES"
           
-              if let parallelizableValue = element.attributes["parallelizable"] {
-                parallelization = parallelizableValue == "YES" ? .all : .none
-              } else {
-                  parallelization = .swiftTestingOnly
-              }
-          
+            if let parallelizableValue = element.attributes["parallelizable"] {
+              parallelization = parallelizableValue == "YES" ? .all : .none
+            } else {
+                parallelization = .swiftTestingOnly
+            }
           
             useTestSelectionWhitelist = element.attributes["useTestSelectionWhitelist"] == "YES"
             randomExecutionOrdering = element.attributes["testExecutionOrdering"] == "random"

--- a/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
@@ -38,7 +38,7 @@ public extension XCScheme {
             skipped = element.attributes["skipped"] == "YES"
           
             if let parallelizableValue = element.attributes["parallelizable"] {
-              parallelization = parallelizableValue == "YES" ? .all : .none
+                parallelization = parallelizableValue == "YES" ? .all : .none
             } else {
                 parallelization = .swiftTestingOnly
             }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -68,7 +68,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
     func test_write_testableReferenceDefaultAttributesValuesAreOmitted() {
         let reference = XCScheme.TestableReference(
             skipped: false,
-            parallelizable: false,
+            parallelization: .swiftTestingOnly,
             randomExecutionOrdering: false,
             buildableReference: XCScheme.BuildableReference(
                 referencedContainer: "",
@@ -88,7 +88,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
     func test_write_testableReferenceAttributesValues() {
         let reference = XCScheme.TestableReference(
             skipped: false,
-            parallelizable: true,
+            parallelization: .all,
             randomExecutionOrdering: true,
             buildableReference: XCScheme.BuildableReference(
                 referencedContainer: "",
@@ -106,12 +106,34 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(subject.attributes["useTestSelectionWhitelist"], "YES")
         XCTAssertEqual(subject.attributes["testExecutionOrdering"], "random")
     }
+  
+  func test_write_testableReferenceAttributesValuesForSwiftTesting() {
+      let reference = XCScheme.TestableReference(
+          skipped: false,
+          parallelization: .swiftTestingOnly,
+          randomExecutionOrdering: true,
+          buildableReference: XCScheme.BuildableReference(
+              referencedContainer: "",
+              blueprint: PBXObject(),
+              buildableName: "",
+              blueprintName: ""
+          ),
+          skippedTests: [],
+          selectedTests: [],
+          useTestSelectionWhitelist: true
+      )
+      let subject = reference.xmlElement()
+      XCTAssertEqual(subject.attributes["skipped"], "NO")
+      XCTAssertNil(subject.attributes["parallelizable"])
+      XCTAssertEqual(subject.attributes["useTestSelectionWhitelist"], "YES")
+      XCTAssertEqual(subject.attributes["testExecutionOrdering"], "random")
+  }
 
     func test_write_testableReferenceSelectedTests() {
         // Given
         let reference = XCScheme.TestableReference(
             skipped: false,
-            parallelizable: true,
+            parallelization: .all,
             randomExecutionOrdering: true,
             buildableReference: XCScheme.BuildableReference(
                 referencedContainer: "",
@@ -397,7 +419,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.testAction?.codeCoverageEnabled, true)
         XCTAssertEqual(scheme.testAction?.onlyGenerateCoverageForSpecifiedTargets, true)
         XCTAssertEqual(scheme.testAction?.testables.first?.skipped, false)
-        XCTAssertEqual(scheme.testAction?.testables.first?.parallelizable, false)
+        XCTAssertEqual(scheme.testAction?.testables.first?.parallelization, .swiftTestingOnly)
         XCTAssertEqual(scheme.testAction?.testables.first?.randomExecutionOrdering, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.useTestSelectionWhitelist, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableIdentifier, "primary")


### PR DESCRIPTION
Related to [this Tuist issue](https://github.com/tuist/tuist/issues/6827)

### Short description 📝
This PR introduces XcodeProj Parallelization handling for the new Swift Testing option. This will enable us to expose the option to Tuist `TestingOptions` allowing users to specify the option they need, as the default handling in Xcode 16 for Parallelization is going to benefit the few users who have adopted Swift Testing.

I also removed two dead links from the References section as I was going through the reading material.

### Solution 📦
From changing the values manually in a real project, I gathered:

> Parallelization off in Xcode ->"parallelizable" : false,
Parallelization on in Xcode ->"parallelizable" : true,
Parallelization Swift Testing Only in Xcode -> no value.

With guidance from @fortmarek , I updated the handling of the attributes to cover each individual case. 

I've set it as draft as I need guidance on how to prove this handling outside of unit tests. Please let me know what I could be missing and how to verify the output. Thanks.

### Implementation 👩‍💻👨‍💻

- [x] Introduce enums to cover the three unique cases
- [x] Add handling for each case from.
- [x] Update tests to handle each case.
