### PR TITLE
[WIP]: Add support for `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ XcodeProj is a library written in Swift for parsing and working with Xcode proje
 | XcodeGen        | [github.com/yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen)                       |
 | xspm            | [gitlab.com/Pyroh/xspm](https://gitlab.com/Pyroh/xspm)                                       |
 | Privacy Manifest| [github.com/stelabouras/privacy-manifest](https://github.com/stelabouras/privacy-manifest)   |
+| Function        | [github.com/fxnai/fxnios](https://github.com/fxnai/fxnios)                                   | 
 
 If you are also leveraging XcodeProj in your project, feel free to open a PR to include it in the list above.
 

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedBuildFileExceptionSet.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedBuildFileExceptionSet.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Class representing an element that may contain other elements.
-public class PBXFileSystemSynchronizedBuildFileExceptionSet: PBXObject, PlistSerializable {
+public class PBXFileSystemSynchronizedBuildFileExceptionSet: PBXFileSystemSynchronizedExceptionSet, PlistSerializable {
     // MARK: - Attributes
 
     /// A list of relative paths to children subfolders for which exceptions are applied.

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedExceptionSet.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedExceptionSet.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public class PBXFileSystemSynchronizedExceptionSet: PBXObject { }

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public class PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet: PBXFileSystemSynchronizedExceptionSet, PlistSerializable {
+    
+    // MARK: - Attributes
+
+    /// A list of relative paths to children subfolders for which exceptions are applied.
+    public var membershipExceptions: [String]?
+  
+    /// Build phase that this exception set applies to.
+    public var buildPhase: PBXBuildPhase! {
+        get {
+            buildPhaseReference.getObject() as? PBXBuildPhase
+        }
+        set {
+            buildPhaseReference = newValue.reference
+        }
+    }
+
+    /// Attributes by relative path.
+    /// Every item in the list is the relative path inside the root synchronized group.
+    /// For example `RemoveHeadersOnCopy` and  `CodeSignOnCopy`.
+    public var attributesByRelativePath: [String: [String]]?
+    
+    var buildPhaseReference: PBXObjectReference
+  
+    // MARK: - Init
+  
+    public init(
+        buildPhase: PBXBuildPhase,
+        membershipExceptions: [String]?,
+        attributesByRelativePath: [String: [String]]?
+    ) {
+        buildPhaseReference = buildPhase.reference
+        self.membershipExceptions = membershipExceptions
+        self.attributesByRelativePath = attributesByRelativePath
+        super.init()
+    }
+  
+    // MARK: - Decodable
+    fileprivate enum CodingKeys: String, CodingKey {
+        case buildPhase
+        case membershipExceptions
+        case attributesByRelativePath
+    }
+  
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let referenceRepository = decoder.context.objectReferenceRepository
+        let objects = decoder.context.objects
+        let buildPhaseReference: String = try container.decode(.buildPhase)
+        self.buildPhaseReference = referenceRepository.getOrCreate(reference: buildPhaseReference, objects: objects)
+        membershipExceptions = try container.decodeIfPresent(.membershipExceptions)
+        attributesByRelativePath = try container.decodeIfPresent(.attributesByRelativePath)
+        try super.init(from: decoder)
+    }
+  
+    // MARK: - Equatable
+
+    override func isEqual(to object: Any?) -> Bool {
+        guard let rhs = object as? PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet else {
+            return false
+        }
+        return isEqual(to: rhs)
+    }
+  
+    // MARK: - PlistSerializable
+
+    func plistKeyAndValue(proj _: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
+        var dictionary: [CommentedString: PlistValue] = [:]
+        dictionary["isa"] = .string(CommentedString(type(of: self).isa))
+        if let membershipExceptions {
+            dictionary["membershipExceptions"] = .array(membershipExceptions.map { .string(CommentedString($0)) })
+        }
+        if let attributesByRelativePath {
+            dictionary["attributesByRelativePath"] = .dictionary(Dictionary(uniqueKeysWithValues: attributesByRelativePath.map { key, value in
+                (CommentedString(key), .array(value.map { .string(CommentedString($0)) }))
+            }))
+        }
+        dictionary["buildPhase"] = .string(CommentedString(buildPhase.reference.value, comment: buildPhase.name() ?? "CopyFiles"))
+        return (key: CommentedString(reference, comment: "PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet"), value: .dictionary(dictionary))
+    }
+}

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
@@ -12,7 +12,7 @@ public class PBXFileSystemSynchronizedRootGroup: PBXFileElement {
 
     /// It returns a list of exception objects that override the configuration for some children
     /// in the synchronized root group.
-    public var exceptions: [PBXFileSystemSynchronizedBuildFileExceptionSet]? {
+    public var exceptions: [PBXFileSystemSynchronizedExceptionSet]? {
         set {
             exceptionsReferences = newValue?.references()
         }
@@ -47,7 +47,7 @@ public class PBXFileSystemSynchronizedRootGroup: PBXFileElement {
                 tabWidth: UInt? = nil,
                 wrapsLines: Bool? = nil,
                 explicitFileTypes: [String: String] = [:],
-                exceptions: [PBXFileSystemSynchronizedBuildFileExceptionSet] = [],
+                exceptions: [PBXFileSystemSynchronizedExceptionSet] = [],
                 explicitFolders: [String] = []) {
         self.explicitFileTypes = explicitFileTypes
         exceptionsReferences = exceptions.references()
@@ -88,9 +88,9 @@ public class PBXFileSystemSynchronizedRootGroup: PBXFileElement {
     override func plistKeyAndValue(proj: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = try super.plistKeyAndValue(proj: proj, reference: reference).value.dictionary ?? [:]
         dictionary["isa"] = .string(CommentedString(type(of: self).isa))
-        if let exceptionsReferences, !exceptionsReferences.isEmpty {
-            dictionary["exceptions"] = .array(exceptionsReferences.map { exceptionReference in
-                .string(CommentedString(exceptionReference.value, comment: "PBXFileSystemSynchronizedBuildFileExceptionSet"))
+        if let exceptions, !exceptions.isEmpty {
+            dictionary["exceptions"] = .array(exceptions.map { exception in
+                .string(CommentedString(exception.reference.value, comment: type(of: exception).isa))
             })
         }
         if let explicitFileTypes {

--- a/Sources/XcodeProj/Objects/Project/PBXObjectParser.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXObjectParser.swift
@@ -72,6 +72,8 @@ final class PBXObjectParser {
             return try decoder.decode(PBXFileSystemSynchronizedRootGroup.self, from: data)
         case PBXFileSystemSynchronizedBuildFileExceptionSet.isa:
             return try decoder.decode(PBXFileSystemSynchronizedBuildFileExceptionSet.self, from: data)
+        case PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.isa:
+            return try decoder.decode(PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.self, from: data)
         default:
             throw PBXObjectError.unknownElement(isa)
         }

--- a/Sources/XcodeProj/Objects/Project/PBXObjects.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXObjects.swift
@@ -144,6 +144,13 @@ class PBXObjects: Equatable {
     var fileSystemSynchronizedBuildFileExceptionSets: [PBXObjectReference: PBXFileSystemSynchronizedBuildFileExceptionSet] {
         lock.whileLocked { _fileSystemSynchronizedBuildFileExceptionSets }
     }
+  
+    private var _fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet: [PBXObjectReference: PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet] = [:]
+    var fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet: [PBXObjectReference: PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet] {
+        lock.whileLocked { _fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet }
+    }
+  
+  
 
     // XCSwiftPackageProductDependency
 
@@ -185,7 +192,8 @@ class PBXObjects: Equatable {
             lhs.swiftPackageProductDependencies == rhs._swiftPackageProductDependencies &&
             lhs.remoteSwiftPackageReferences == rhs.remoteSwiftPackageReferences &&
             lhs.fileSystemSynchronizedRootGroups == rhs.fileSystemSynchronizedRootGroups &&
-            lhs.fileSystemSynchronizedBuildFileExceptionSets == rhs.fileSystemSynchronizedBuildFileExceptionSets
+            lhs.fileSystemSynchronizedBuildFileExceptionSets == rhs.fileSystemSynchronizedBuildFileExceptionSets &&
+            lhs.fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet == rhs.fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet
     }
 
     // MARK: - Helpers
@@ -232,6 +240,7 @@ class PBXObjects: Equatable {
         case let object as XCSwiftPackageProductDependency: _swiftPackageProductDependencies[objectReference] = object
         case let object as PBXFileSystemSynchronizedRootGroup: _fileSystemSynchronizedRootGroups[objectReference] = object
         case let object as PBXFileSystemSynchronizedBuildFileExceptionSet: _fileSystemSynchronizedBuildFileExceptionSets[objectReference] = object
+        case let object as PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet: _fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet[objectReference] = object
         default: fatalError("Unhandled PBXObject type for \(object), this is likely a bug / todo")
         }
     }
@@ -296,6 +305,8 @@ class PBXObjects: Equatable {
             return _fileSystemSynchronizedRootGroups.remove(at: index).value
         } else if let index = fileSystemSynchronizedBuildFileExceptionSets.index(forKey: reference) {
             return _fileSystemSynchronizedBuildFileExceptionSets.remove(at: index).value
+        } else if let index = fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.index(forKey: reference) {
+            return _fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.remove(at: index).value
         }
 
         return nil
@@ -362,6 +373,8 @@ class PBXObjects: Equatable {
         } else if let object = fileSystemSynchronizedRootGroups[reference] {
             return object
         } else if let object = fileSystemSynchronizedBuildFileExceptionSets[reference] {
+            return object
+        } else if let object = fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet[reference] {
             return object
         } else {
             return nil
@@ -456,5 +469,6 @@ extension PBXObjects {
         swiftPackageProductDependencies.values.forEach(closure)
         fileSystemSynchronizedRootGroups.values.forEach(closure)
         fileSystemSynchronizedBuildFileExceptionSets.values.forEach(closure)
+        fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.values.forEach(closure)
     }
 }

--- a/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
@@ -119,6 +119,12 @@ final class PBXProjEncoder {
                   outputSettings: outputSettings,
                   stateHolder: &stateHolder,
                   to: &output)
+        try write(section: "PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet",
+                  proj: proj,
+                  objects: proj.objects.fileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet,
+                  outputSettings: outputSettings,
+                  stateHolder: &stateHolder,
+                  to: &output)
         try write(section: "PBXFileSystemSynchronizedRootGroup",
                   proj: proj,
                   objects: proj.objects.fileSystemSynchronizedRootGroups,

--- a/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
@@ -322,3 +322,12 @@ extension PBXFileSystemSynchronizedBuildFileExceptionSet {
         return super.isEqual(to: rhs)
     }
 }
+
+extension PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet {
+    /// :nodoc:
+    func isEqual(to rhs: PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet) -> Bool {
+        if membershipExceptions != rhs.membershipExceptions { return false }
+        if buildPhaseReference != rhs.buildPhaseReference { return false }
+        return super.isEqual(to: rhs)
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/838

### Short description 📝
This PR adds support for `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet` in Xcode 16.

### Solution 📦
It builds upon https://github.com/tuist/XcodeProj/pull/827 .

### Implementation 👩‍💻👨‍💻
- [x] Add `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet` type and support for deserializing from a `.pbxproj` file.
- [x] Update `PBXFileSystemSynchronizedRootGroup.exceptions` field type to abstract base `PBXFileSystemSynchronizedExceptionSet` type to cover `PBXFileSystemSynchronizedBuildFileExceptionSet`.
- [x] Add support for setting and serializing `PBXFileSystemSynchronizedRootGroup.exception`.
- [ ] Add tests.
