### PR TITLE
refactor: align ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES with the Xcode default

### DIFF
--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -72,10 +72,6 @@ public class BuildSettingsProvider {
             buildSettings.merge(targetSwiftSettings(product: product), uniquingKeysWith: { $1 })
         }
 
-        if let platform, let product, let swift, swift == true {
-            buildSettings.merge(targetSwiftSettings(platform: platform, product: product), uniquingKeysWith: { $1 })
-        }
-
         return buildSettings
     }
 

--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -373,10 +373,6 @@ public class BuildSettingsProvider {
 
     private static func targetSwiftSettings(platform: Platform, product: Product) -> BuildSettings {
         switch (platform, product) {
-        case (.watchOS, .application):
-            return [
-                "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
-            ]
         default:
             return [:]
         }

--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -370,13 +370,6 @@ public class BuildSettingsProvider {
             return [:]
         }
     }
-
-    private static func targetSwiftSettings(platform: Platform, product: Product) -> BuildSettings {
-        switch (platform, product) {
-        default:
-            return [:]
-        }
-    }
 }
 
 // Overloading `~=` enables customizing switch statement pattern matching

--- a/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
+++ b/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
@@ -135,7 +135,6 @@ class BuildSettingProviderTests: XCTestCase {
 
         // Then
         assertEqualSettings(results, [
-            "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "ENABLE_PREVIEWS": "YES",
             "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks"],


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6989

### Short description 📝
I modified BuildSettingsProvider.swift to resolve issue 6989 of tuist/tuist.
Removed the settings for ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES so that tuist always followed the default settings of Xcode.
Please see [this issue](https://github.com/tuist/tuist/issues/6989).

### Solution 📦
tuist/tuist depends on local XcodeProj. Modified local XcodeProj and then test at fixtures/workspace_with_test_locale.

### Implementation 👩‍💻👨‍💻

- [ ] ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES is set to xcode default setting when watchOS application 
