### PR TITLE
fix: Infinite recursion and Incorrect deprecation notice in PathRunnable

### DIFF
--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -48,7 +48,7 @@ public extension XCScheme {
                 runnable as? PathRunnable
             }
             set {
-                self.pathRunnable = newValue
+                self.runnable = newValue
             }
         }
 

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -87,7 +87,6 @@ public extension XCScheme {
 
         // MARK: - Init
 
-        @available(*, deprecated, message: "Use the init() that consolidates pathRunnable and runnable into a single parameter.")
         public init(runnable: Runnable?,
                     buildConfiguration: String,
                     preActions: [ExecutionAction] = [],
@@ -170,6 +169,7 @@ public extension XCScheme {
             super.init(preActions, postActions)
         }
 
+        @available(*, deprecated, message: "Use the init() that consolidates pathRunnable and runnable into a single parameter.")
         public convenience init(
             pathRunnable: PathRunnable?,
             buildConfiguration: String,

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -48,7 +48,7 @@ public extension XCScheme {
                 runnable as? PathRunnable
             }
             set {
-                self.runnable = newValue
+                runnable = newValue
             }
         }
 

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -96,7 +96,6 @@ public extension XCScheme {
                     selectedLauncherIdentifier: String = XCScheme.defaultLauncher,
                     launchStyle: Style = .auto,
                     askForAppToLaunch: Bool? = nil,
-                    pathRunnable _: PathRunnable? = nil,
                     customWorkingDirectory: String? = nil,
                     useCustomWorkingDirectory: Bool = false,
                     ignoresPersistentStateOnLaunch: Bool = false,
@@ -171,7 +170,7 @@ public extension XCScheme {
 
         @available(*, deprecated, message: "Use the init() that consolidates pathRunnable and runnable into a single parameter.")
         public convenience init(
-            pathRunnable: PathRunnable?,
+            runnable: Runnable?,
             buildConfiguration: String,
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
@@ -180,6 +179,7 @@ public extension XCScheme {
             selectedLauncherIdentifier: String = XCScheme.defaultLauncher,
             launchStyle: Style = .auto,
             askForAppToLaunch: Bool? = nil,
+            pathRunnable: PathRunnable?,
             customWorkingDirectory: String? = nil,
             useCustomWorkingDirectory: Bool = false,
             ignoresPersistentStateOnLaunch: Bool = false,
@@ -222,7 +222,6 @@ public extension XCScheme {
                 selectedLauncherIdentifier: selectedLauncherIdentifier,
                 launchStyle: launchStyle,
                 askForAppToLaunch: askForAppToLaunch,
-                pathRunnable: pathRunnable,
                 customWorkingDirectory: customWorkingDirectory,
                 useCustomWorkingDirectory: useCustomWorkingDirectory,
                 ignoresPersistentStateOnLaunch: ignoresPersistentStateOnLaunch,


### PR DESCRIPTION
### Short description 📝
A recent [pull request](https://github.com/tuist/XcodeProj/pull/883) that modified `LaunchAction` introduced two issues into the class:
1. The setter for the `pathRunnable` property causes infinite recursion
2. The deprecation notice was attached to the wrong init

### Solution 📦
1. I fixed the infinite recursion in the `pathRunnable` setter by having it modify the backing `runnable` property instead of having it accidentally call itself.
2. I moved the deprecation notice to the init that still accepts a `PathRunnable` and removed it from the init that accepts a generic `Runnable`.
