### PR TITLE
feat: add path to XcodeProj and XCWorkspace

### DIFF
--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -8,8 +8,8 @@ public final class XcodeProj: Equatable {
     /// Project workspace
     public var workspace: XCWorkspace
 
-    /// The  path to the `.xcodeproj` directory.
-    private let projectPath: Path?
+    /// The path to the `.xcodeproj` directory.
+    public let path: Path?
 
     /// .pbxproj representation
     public var pbxproj: PBXProj
@@ -46,7 +46,7 @@ public final class XcodeProj: Equatable {
             .glob("*.xcuserdatad")
             .compactMap { try? XCUserData(path: $0) }
 
-        projectPath = path
+        self.path = path
         self.pbxproj = pbxproj
         self.workspace = workspace
         self.sharedData = sharedData
@@ -68,12 +68,12 @@ public final class XcodeProj: Equatable {
                 pbxproj: PBXProj,
                 sharedData: XCSharedData? = nil,
                 userData: [XCUserData] = [],
-                projectPath: Path? = nil) {
+                path: Path? = nil) {
         self.workspace = workspace
         self.pbxproj = pbxproj
         self.sharedData = sharedData
         self.userData = userData
-        self.projectPath = projectPath
+        self.path = path
     }
 
     // MARK: - Equatable
@@ -83,7 +83,7 @@ public final class XcodeProj: Equatable {
             lhs.pbxproj == rhs.pbxproj &&
             lhs.sharedData == rhs.sharedData &&
             lhs.userData == rhs.userData &&
-            lhs.projectPath == rhs.projectPath
+            lhs.path == rhs.path
     }
 }
 

--- a/Sources/XcodeProj/Project/XcodeProj.swift
+++ b/Sources/XcodeProj/Project/XcodeProj.swift
@@ -8,6 +8,9 @@ public final class XcodeProj: Equatable {
     /// Project workspace
     public var workspace: XCWorkspace
 
+    /// The  path to the `.xcodeproj` directory.
+    private let projectPath: Path?
+
     /// .pbxproj representation
     public var pbxproj: PBXProj
 
@@ -43,6 +46,7 @@ public final class XcodeProj: Equatable {
             .glob("*.xcuserdatad")
             .compactMap { try? XCUserData(path: $0) }
 
+        projectPath = path
         self.pbxproj = pbxproj
         self.workspace = workspace
         self.sharedData = sharedData
@@ -63,11 +67,13 @@ public final class XcodeProj: Equatable {
     public init(workspace: XCWorkspace,
                 pbxproj: PBXProj,
                 sharedData: XCSharedData? = nil,
-                userData: [XCUserData] = []) {
+                userData: [XCUserData] = [],
+                projectPath: Path? = nil) {
         self.workspace = workspace
         self.pbxproj = pbxproj
         self.sharedData = sharedData
         self.userData = userData
+        self.projectPath = projectPath
     }
 
     // MARK: - Equatable
@@ -76,7 +82,8 @@ public final class XcodeProj: Equatable {
         lhs.workspace == rhs.workspace &&
             lhs.pbxproj == rhs.pbxproj &&
             lhs.sharedData == rhs.sharedData &&
-            lhs.userData == rhs.userData
+            lhs.userData == rhs.userData &&
+            lhs.projectPath == rhs.projectPath
     }
 }
 

--- a/Sources/XcodeProj/Workspace/XCWorkspace.swift
+++ b/Sources/XcodeProj/Workspace/XCWorkspace.swift
@@ -6,6 +6,9 @@ public final class XCWorkspace: Writable, Equatable {
     /// Workspace data
     public var data: XCWorkspaceData
 
+    /// The path to the `.xcworkspace` directory.
+    public let path: Path?
+
     // MARK: - Init
 
     /// Initializes the workspace with the path where the workspace is.
@@ -15,14 +18,14 @@ public final class XCWorkspace: Writable, Equatable {
     /// - Parameter path: .xcworkspace path.
     /// - Throws: throws an error if the workspace cannot be initialized.
     public convenience init(path: Path) throws {
-        if !path.exists {
+        guard path.exists else {
             throw XCWorkspaceError.notFound(path: path)
         }
         let xcworkspaceDataPaths = path.glob("*.xcworkspacedata")
-        if xcworkspaceDataPaths.isEmpty {
-            self.init()
+        if let xcworkspaceDataPath = xcworkspaceDataPaths.first {
+            try self.init(data: XCWorkspaceData(path: xcworkspaceDataPath), path: path)
         } else {
-            try self.init(data: XCWorkspaceData(path: xcworkspaceDataPaths.first!))
+            self.init()
         }
     }
 
@@ -44,8 +47,10 @@ public final class XCWorkspace: Writable, Equatable {
     ///
     /// - Parameters:
     ///   - data: workspace data.
-    public init(data: XCWorkspaceData) {
+    ///   - path: .xcworkspace path.
+    public init(data: XCWorkspaceData, path: Path? = nil) {
         self.data = data
+        self.path = path
     }
 
     // MARK: - Writable
@@ -75,6 +80,6 @@ public final class XCWorkspace: Writable, Equatable {
     // MARK: - Equatable
 
     public static func == (lhs: XCWorkspace, rhs: XCWorkspace) -> Bool {
-        lhs.data == rhs.data
+        lhs.data == rhs.data && lhs.path == rhs.path
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeGraph/pull/87#discussion_r1892498684

### Short description 📝
This PR introduces an optional `projectPath` property to `XcodeProj`, allowing the project to be initialized and managed without requiring a file system path. It maintains full backward compatibility for existing users while offering more flexibility for in-memory project constructions or integrations with path management logic outside of `XcodeProj`.

### Solution 📦
The `projectPath` property is now optional. When loading from a file system path, `projectPath` is set automatically. If users create `XcodeProj` instances in memory using the new initializer, `projectPath` can remain `nil`. This approach preserves existing behavior while enabling new use cases, such as working with `XcodeProj` in environments where a project might not yet exist on disk.

### Implementation 👩‍💻👨‍💻
- [x] Introduce `projectPath: Path?` as an optional property in `XcodeProj`.
- [x] Update `init(path:)` to set `projectPath` when loading from disk.
- [x] Add a new initializer that allows creating `XcodeProj` instances without a `projectPath`.
- [x] Include `projectPath` in the equality check to distinguish between projects referencing different directories.
- [x] Retain backward compatibility and do not alter existing file loading or writing behavior.