### PR TITLE
fix: ensure that file references are fixed for filesystem synchronized root groups

### DIFF
--- a/Sources/XcodeProj/Utils/ReferenceGenerator.swift
+++ b/Sources/XcodeProj/Utils/ReferenceGenerator.swift
@@ -139,6 +139,8 @@ final class ReferenceGenerator: ReferenceGenerating {
             guard let childFileElement: PBXFileElement = child.getObject() else { return }
             if let childGroup = childFileElement as? PBXGroup {
                 try generateGroupReferences(childGroup, identifiers: identifiers)
+            } else if let childSynchronizedRootGroup = childFileElement as? PBXFileSystemSynchronizedRootGroup {
+                try generateSynchronizedRootGroupReferences(childSynchronizedRootGroup, identifiers: identifiers)
             } else if let childFileReference = childFileElement as? PBXFileReference {
                 try generateFileReference(childFileReference, identifiers: identifiers)
             } else if let childReferenceProxy = childFileElement as? PBXReferenceProxy {
@@ -159,6 +161,21 @@ final class ReferenceGenerator: ReferenceGenerating {
         }
 
         fixReference(for: fileReference, identifiers: identifiers)
+    }
+
+    /// Generates the reference for a synchronized root group object.
+    ///
+    /// - Parameters:
+    ///   - synchronizedRootGroup: synchronized root group instance.
+    ///   - identifiers: list of identifiers.
+    private func generateSynchronizedRootGroupReferences(_ synchronizedRootGroup: PBXFileSystemSynchronizedRootGroup,
+                                                         identifiers: [String]) throws {
+        var identifiers = identifiers
+        if let groupName = synchronizedRootGroup.fileName() {
+            identifiers.append(groupName)
+        }
+
+        fixReference(for: synchronizedRootGroup, identifiers: identifiers)
     }
 
     /// Generates the reference for a configuration list object.

--- a/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
+++ b/Tests/XcodeProjTests/Utils/ReferenceGeneratorTests.swift
@@ -189,7 +189,7 @@ private extension PBXProj {
                                      productName: "MyApp.app",
                                      productType: .application)
         add(object: target)
-      return target
+        return target
     }
 
     func makeSynchronizedRootGroup() -> PBXFileSystemSynchronizedRootGroup {


### PR DESCRIPTION
### Short description 📝
Noticed that when building projects with the new filesystem synchronized root groups that I wasn't seeing references fixed correctly. This seems like an oversight to #827, which had tests for decoding / encoding and for equality testing but none for this in particular.

### Solution 📦
This adds an additional check to `ReferenceGenerator` for any filesystem synchronized root groups starting from the main group, or recursively any children.

### Implementation 👩‍💻👨‍💻

- [x] Implemented a change to `ReferenceGenerator` fixing any filesystem synchronized root group object references 
- [x] Added a new test to `ReferenceGeneratorTests` to ensure that this is working correctly.
