### PR TITLE
fix: add missing BuildSettingsProvider for visionOS

### DIFF
--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -247,6 +247,10 @@ public class BuildSettingsProvider {
                 "SKIP_INSTALL": "YES",
                 "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks"],
             ]
+        case (.visionOS, .application):
+            [
+                "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks"],
+            ]
         case (.iOS, .framework):
             [
                 "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
@@ -264,6 +268,10 @@ public class BuildSettingsProvider {
         case (.watchOS, .framework):
             [
                 "APPLICATION_EXTENSION_API_ONLY": "YES",
+                "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
+            ]
+        case (.visionOS, .framework):
+            [
                 "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
             ]
         case ([.iOS, .tvOS, .watchOS], .staticLibrary):
@@ -317,7 +325,7 @@ public class BuildSettingsProvider {
                     "@executable_path/../../../../Frameworks",
                 ],
             ]
-        case ([.iOS, .tvOS], [.unitTests, .uiTests]):
+        case ([.iOS, .tvOS, .visionOS], [.unitTests, .uiTests]):
             [
                 "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
             ]

--- a/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
+++ b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift
@@ -188,6 +188,7 @@ public class BuildSettingsProvider {
         case .visionOS:
             [
                 "SDKROOT": "xros",
+                "CODE_SIGN_IDENTITY": "iPhone Developer",
                 "TARGETED_DEVICE_FAMILY": "1,2,7",
             ]
         }
@@ -274,7 +275,7 @@ public class BuildSettingsProvider {
             [
                 "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
             ]
-        case ([.iOS, .tvOS, .watchOS], .staticLibrary):
+        case ([.iOS, .tvOS, .watchOS, .visionOS], .staticLibrary):
             [
                 "OTHER_LDFLAGS": "-ObjC",
                 "SKIP_INSTALL": "YES",
@@ -296,7 +297,7 @@ public class BuildSettingsProvider {
                 "COMBINE_HIDPI_IMAGES": "YES",
                 "INSTALL_PATH": "$(LOCAL_LIBRARY_DIR)/Bundles",
             ]
-        case ([.iOS, .tvOS], .appExtension):
+        case ([.iOS, .tvOS, .visionOS], .appExtension):
             [
                 "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@executable_path/../../Frameworks"],
             ]

--- a/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
+++ b/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
@@ -146,6 +146,60 @@ class BuildSettingProviderTests: XCTestCase {
         ])
     }
 
+    func test_targetSettings_visionOSAplication() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .release,
+                                                          platform: .visionOS,
+                                                          product: .application,
+                                                          swift: true)
+
+        // Then
+        assertEqualSettings(results, [
+            "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
+            "ENABLE_PREVIEWS": "YES",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+            ],
+            "SDKROOT": "xros",
+            "SWIFT_COMPILATION_MODE": "wholemodule",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+            "TARGETED_DEVICE_FAMILY": "1,2,7",
+        ])
+    }
+
+    func test_targetSettings_visionOSFramework() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .release,
+                                                          platform: .visionOS,
+                                                          product: .framework,
+                                                          swift: true)
+
+        // Then
+        assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "",
+            "CURRENT_PROJECT_VERSION": "1",
+            "DEFINES_MODULE": "YES",
+            "DYLIB_COMPATIBILITY_VERSION": "1",
+            "DYLIB_CURRENT_VERSION": "1",
+            "DYLIB_INSTALL_NAME_BASE": "@rpath",
+            "INSTALL_PATH": "$(LOCAL_LIBRARY_DIR)/Frameworks",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@loader_path/Frameworks",
+            ],
+            "PRODUCT_NAME": "$(TARGET_NAME:c99extidentifier)",
+            "SDKROOT": "xros",
+            "SKIP_INSTALL": "YES",
+            "SWIFT_COMPILATION_MODE": "wholemodule",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+            "TARGETED_DEVICE_FAMILY": "1,2,7",
+            "VERSIONING_SYSTEM": "apple-generic",
+            "VERSION_INFO_PREFIX": "",
+        ])
+    }
+
     func test_targetSettings_iOSUnitTests() {
         // Given / When
         let results = BuildSettingsProvider.targetDefault(variant: .debug,
@@ -233,6 +287,50 @@ class BuildSettingProviderTests: XCTestCase {
             "SWIFT_COMPILATION_MODE": "singlefile",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "TARGETED_DEVICE_FAMILY": "3",
+        ])
+    }
+
+    func test_targetSettings_visionOSUnitTests() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .debug,
+                                                          platform: .visionOS,
+                                                          product: .unitTests,
+                                                          swift: true)
+
+        // Then
+        assertEqualSettings(results, [
+            "SDKROOT": "xros",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@loader_path/Frameworks",
+            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["$(inherited)", "DEBUG"],
+            "SWIFT_COMPILATION_MODE": "singlefile",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+            "TARGETED_DEVICE_FAMILY": "1,2,7",
+        ])
+    }
+
+    func test_targetSettings_visionOSUITests() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .debug,
+                                                          platform: .visionOS,
+                                                          product: .uiTests,
+                                                          swift: true)
+
+        // Then
+        assertEqualSettings(results, [
+            "SDKROOT": "xros",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@loader_path/Frameworks",
+            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["$(inherited)", "DEBUG"],
+            "SWIFT_COMPILATION_MODE": "singlefile",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+            "TARGETED_DEVICE_FAMILY": "1,2,7",
         ])
     }
 

--- a/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
+++ b/Tests/XcodeProjTests/Utils/BuildSettingsProviderTests.swift
@@ -146,6 +146,61 @@ class BuildSettingProviderTests: XCTestCase {
         ])
     }
 
+    func test_targetSettings_watchOSFramework() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .release,
+                                                          platform: .watchOS,
+                                                          product: .framework,
+                                                          swift: true)
+
+        // Then
+        assertEqualSettings(results, [
+            "APPLICATION_EXTENSION_API_ONLY": "YES",
+            "CODE_SIGN_IDENTITY": "",
+            "CURRENT_PROJECT_VERSION": "1",
+            "DEFINES_MODULE": "YES",
+            "DYLIB_COMPATIBILITY_VERSION": "1",
+            "DYLIB_CURRENT_VERSION": "1",
+            "DYLIB_INSTALL_NAME_BASE": "@rpath",
+            "INSTALL_PATH": "$(LOCAL_LIBRARY_DIR)/Frameworks",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@loader_path/Frameworks",
+            ],
+            "PRODUCT_NAME": "$(TARGET_NAME:c99extidentifier)",
+            "SDKROOT": "watchos",
+            "SKIP_INSTALL": "YES",
+            "SWIFT_COMPILATION_MODE": "wholemodule",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+            "TARGETED_DEVICE_FAMILY": "4",
+            "VERSIONING_SYSTEM": "apple-generic",
+            "VERSION_INFO_PREFIX": "",
+        ])
+    }
+
+    func test_targetSettings_watchOSExtension() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .release,
+                                                          platform: .watchOS,
+                                                          product: .appExtension,
+                                                          swift: true)
+
+        // Then
+        assertEqualSettings(results, [
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@executable_path/../../Frameworks",
+                "@executable_path/../../../../Frameworks",
+            ],
+            "SDKROOT": "watchos",
+            "SWIFT_COMPILATION_MODE": "wholemodule",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+            "TARGETED_DEVICE_FAMILY": "4",
+        ])
+    }
+
     func test_targetSettings_visionOSAplication() {
         // Given / When
         let results = BuildSettingsProvider.targetDefault(variant: .release,
@@ -155,6 +210,7 @@ class BuildSettingProviderTests: XCTestCase {
 
         // Then
         assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "iPhone Developer",
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "ENABLE_PREVIEWS": "YES",
             "LD_RUNPATH_SEARCH_PATHS": [
@@ -197,6 +253,28 @@ class BuildSettingProviderTests: XCTestCase {
             "TARGETED_DEVICE_FAMILY": "1,2,7",
             "VERSIONING_SYSTEM": "apple-generic",
             "VERSION_INFO_PREFIX": "",
+        ])
+    }
+
+    func test_targetSettings_visionOSExtension() {
+        // Given / When
+        let results = BuildSettingsProvider.targetDefault(variant: .release,
+                                                          platform: .visionOS,
+                                                          product: .appExtension,
+                                                          swift: true)
+
+        // Then
+        assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "iPhone Developer",
+            "LD_RUNPATH_SEARCH_PATHS": [
+                "$(inherited)",
+                "@executable_path/Frameworks",
+                "@executable_path/../../Frameworks",
+            ],
+            "SDKROOT": "xros",
+            "SWIFT_COMPILATION_MODE": "wholemodule",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+            "TARGETED_DEVICE_FAMILY": "1,2,7",
         ])
     }
 
@@ -299,6 +377,7 @@ class BuildSettingProviderTests: XCTestCase {
 
         // Then
         assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "iPhone Developer",
             "SDKROOT": "xros",
             "LD_RUNPATH_SEARCH_PATHS": [
                 "$(inherited)",
@@ -321,6 +400,7 @@ class BuildSettingProviderTests: XCTestCase {
 
         // Then
         assertEqualSettings(results, [
+            "CODE_SIGN_IDENTITY": "iPhone Developer",
             "SDKROOT": "xros",
             "LD_RUNPATH_SEARCH_PATHS": [
                 "$(inherited)",


### PR DESCRIPTION
### Short description 📝

`Tuist` introduced `XcodeGraph` at version 0.19.4 with this PR https://github.com/tuist/tuist/pull/7083. This in fact caused this PR to take effect https://github.com/tuist/XcodeGraph/pull/79. This then ultimately caused this codepath https://github.com/tuist/tuist/blob/main/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift#L115 to not include `visionOS` related default settings.

### Solution 📦
I added the mapping of `visionOS` to the `BuildSettingsProvider` in order to also correctly set the settings for `visionOS`.

### Implementation 👩‍💻👨‍💻
- [x] Add `visionOS` mappings to `BuildSettingsProvider`
- [x] Update `BuildSettingProviderTests` to test the newly added mappings

### Questions 

- @fortmarek / @pepicrft I was not quite sure if we should also set `CODE_SIGN_IDENTITY` on the `visionOS` platform in order to be aligned with the `iOS` one - what do you think ? 
- Please let me know if the explanation is good enough or if I missed something or have invalid reasoning. 
