### PR TITLE
chore: auto-release only when SwiftPM dependencies are updated

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -90,6 +90,22 @@ commit_preprocessors = [
   # remove issue numbers from commits
   { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
 ]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(spm.*\\)", skip = false },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous Tasks" },
+    { body = ".*security", group = "Security" },
+]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,12 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeType": "pr",
-      "automergeStrategy": "auto"
+      "automergeStrategy": "auto",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchManagers": ["swift"],
+      "semanticCommitScope": "spm"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
I noticed we were creating new releases when dependencies other than SwiftPM's got updated (e.g. Mise dependencies). We should not do this because an update of a Mise dependency has no relation with the XcodeProj package itself.
I'm mimicking the model that we adopted in [Command](https://github.com/tuist/command) where we configure Renovabebot differently to label PRs based on the package manager, and use the convention in the Git configuration to exclude some commits from the detection logic.