### PR TITLE
fix: Missing TargetAttributes from Fastlane

### DIFF
--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -572,9 +572,7 @@ extension PBXProject: PlistSerializable {
             plistTargetAttributes[reference.value] = value
         }
 
-        if !plistTargetAttributes.isEmpty {
-            plistAttributes[PBXProject.targetAttributesKey] = .attributeDictionary(plistTargetAttributes)
-        }
+        plistAttributes[PBXProject.targetAttributesKey] = .attributeDictionary(plistTargetAttributes)
 
         dictionary["attributes"] = plistAttributes.plist()
 


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/6914

### Short description 📝
> Fix Fastlane error
update_code_signing_settings
Seems to be a very old project file format - please open your project file in a more recent version of Xcode
https://github.com/fastlane/fastlane/issues/22187

### Solution 📦
> Add TargetAttributes even if it is empty 

### Implementation 👩‍💻👨‍💻
> revert last commit of https://github.com/tuist/XcodeProj/pull/865
<img width="745" alt="스크린샷 2025-03-27 오후 9 00 15" src="https://github.com/user-attachments/assets/605959ae-a8c0-4f33-b344-a55e845dc024" />

>Test

- [✓] Install new XcodeProj into Tuist
  + <img width="706" alt="스크린샷 2025-03-31 오후 7 40 34" src="https://github.com/user-attachments/assets/ec188f97-563d-4f87-89fb-d3f55fec6923" />  
- [✓] Generate App with modified Tuist.  
  + <img width="364" alt="스크린샷 2025-03-31 오후 7 50 16" src="https://github.com/user-attachments/assets/dcabf9fb-1d7b-4cc4-b118-d1c7065e6737" />  
- [✓] Find Empty TargetAttribute in the .pbxroj  
  + <img width="341" alt="스크린샷 2025-03-31 오후 7 52 36" src="https://github.com/user-attachments/assets/2c684b21-088b-4875-843b-53755b64e82c" />  