### PR TITLE
fix: allow empty `PBXProject.TargetAttributes`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "8a13a61314cb0e10f1d22dddaabfebd1ab407a7b9ab06aa42fc1e38041a202a5",
   "pins" : [
     {
       "identity" : "aexml",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tadija/AEXML.git",
       "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
       }
     },
     {
@@ -28,5 +29,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/XcodeProj/Objects/Project/PBXProject.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProject.swift
@@ -572,9 +572,7 @@ extension PBXProject: PlistSerializable {
             plistTargetAttributes[reference.value] = value
         }
 
-        if !plistTargetAttributes.isEmpty {
-            plistAttributes[PBXProject.targetAttributesKey] = .attributeDictionary(plistTargetAttributes)
-        }
+        plistAttributes[PBXProject.targetAttributesKey] = .attributeDictionary(plistTargetAttributes)
 
         dictionary["attributes"] = plistAttributes.plist()
 

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -81,14 +81,12 @@ final class PBXProjectTests: XCTestCase {
                                  minimizedProjectReferenceProxies: nil,
                                  mainGroup: PBXGroup())
 
-        project.setTargetAttributes(["custom": "abc", "TestTargetID": .targetReference(testTarget)], target: target)
-
         // When
         let plist = try project.plistKeyAndValue(proj: PBXProj(), reference: "")
 
         // Then
-        let attributes: [CommentedString: PlistValue]? = plist.value.dictionary?["TargetAttributes"]?.dictionary
-        XCTAssertNil(attributes)
+        let attributes = plist.value.dictionary?["attributes"]?.dictionary?["TargetAttributes"]?.dictionary
+        XCTAssertEqual(attributes, [:])
     }
 
     func test_addLocalSwiftPackage() throws {

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjectTests.swift
@@ -66,7 +66,7 @@ final class PBXProjectTests: XCTestCase {
         XCTAssertEqual(attributes, expectedAttributes)
     }
 
-    func test_plistKeyAndValue_doesntReturnTargetAttributes_when_itsEmpty() throws {
+    func test_plistKeyAndValue_returnsEmptyTargetAttributes_when_itsEmpty() throws {
         // Given
         let target = PBXTarget(name: "")
         target.reference.fix("app")


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6914

### Short description 📝
The change introduced in this PR https://github.com/tuist/XcodeProj/pull/865 caused the `Fastlane`'s  `automatic_code_signing` action to fail, although the original PR author did recommend not merging that PR until Fastlane merges the other -_unfortunately forgotten_- PR https://github.com/fastlane/fastlane/pull/23872 (which was supposed to fix the issue from `Fastlane` action side). It was recommended by @fortmarek [here](https://github.com/tuist/tuist/issues/6914#issuecomment-2757134432) to revert these changes.

### Solution 📦
The fix is to revert the other PR's changes, by allowing empty `TargetAttributes` entry to be generated again. (at least until `Fastlane` fixes the issue from their side).

### Implementation 👩‍💻👨‍💻
- Allow empty `TargetAttributes`.
- Fix unit tests (previous unit test were always successful even if the `TargetAttributes` was empty, because they used to point to the wrong place in the dictionary _- always resulting nil -_ )