### PR TITLE
feat: implement support for the App Clip's URL

### DIFF
--- a/Fixtures/Schemes/AppClip.xcscheme
+++ b/Fixtures/Schemes/AppClip.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CC725022DA91FB6004D43D4"
+               BuildableName = "app_clip.app"
+               BlueprintName = "app_clip"
+               ReferencedContainer = "container:example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      appClipInvocationURLString = "https://example.com/"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CC725022DA91FB6004D43D4"
+            BuildableName = "app_clip.app"
+            BlueprintName = "app_clip"
+            ReferencedContainer = "container:example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      appClipInvocationURLString = "https://example.com/"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CC725022DA91FB6004D43D4"
+            BuildableName = "app_clip.app"
+            BlueprintName = "app_clip"
+            ReferencedContainer = "container:example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -84,6 +84,7 @@ public extension XCScheme {
         // To enable the option in Xcode: defaults write com.apple.dt.Xcode IDEDebuggerFeatureSetting 12
         public var customLaunchCommand: String?
         public var customLLDBInitFile: String?
+        public var appClipInvocationURLString: String?
 
         // MARK: - Init
 
@@ -126,7 +127,8 @@ public extension XCScheme {
                     launchAutomaticallySubstyle: String? = nil,
                     storeKitConfigurationFileReference: StoreKitConfigurationFileReference? = nil,
                     customLaunchCommand: String? = nil,
-                    customLLDBInitFile: String? = nil) {
+                    customLLDBInitFile: String? = nil,
+                    appClipInvocationURLString: String? = nil) {
             self.runnable = runnable
             self.macroExpansion = macroExpansion
             self.buildConfiguration = buildConfiguration
@@ -165,6 +167,7 @@ public extension XCScheme {
             self.storeKitConfigurationFileReference = storeKitConfigurationFileReference
             self.customLaunchCommand = customLaunchCommand
             self.customLLDBInitFile = customLLDBInitFile
+            self.appClipInvocationURLString = appClipInvocationURLString
             super.init(preActions, postActions)
         }
 
@@ -210,7 +213,8 @@ public extension XCScheme {
             launchAutomaticallySubstyle: String? = nil,
             storeKitConfigurationFileReference: StoreKitConfigurationFileReference? = nil,
             customLaunchCommand: String? = nil,
-            customLLDBInitFile: String? = nil
+            customLLDBInitFile: String? = nil,
+            appClipInvocationURLString: String? = nil
         ) {
             self.init(
                 runnable: pathRunnable,
@@ -252,7 +256,8 @@ public extension XCScheme {
                 launchAutomaticallySubstyle: launchAutomaticallySubstyle,
                 storeKitConfigurationFileReference: storeKitConfigurationFileReference,
                 customLaunchCommand: customLaunchCommand,
-                customLLDBInitFile: customLLDBInitFile
+                customLLDBInitFile: customLLDBInitFile,
+                appClipInvocationURLString: appClipInvocationURLString
             )
         }
 
@@ -338,6 +343,8 @@ public extension XCScheme {
                 customWorkingDirectory = elementCustomWorkingDirectory
             }
 
+            appClipInvocationURLString = element.attributes["appClipInvocationURLString"]
+
             try super.init(element: element)
         }
 
@@ -403,6 +410,9 @@ public extension XCScheme {
             }
             if let customWorkingDirectory {
                 attributes["customWorkingDirectory"] = customWorkingDirectory
+            }
+            if let appClipInvocationURLString {
+                attributes["appClipInvocationURLString"] = appClipInvocationURLString
             }
 
             return attributes
@@ -513,7 +523,8 @@ public extension XCScheme {
                 launchAutomaticallySubstyle == rhs.launchAutomaticallySubstyle &&
                 storeKitConfigurationFileReference == rhs.storeKitConfigurationFileReference &&
                 customLaunchCommand == rhs.customLaunchCommand &&
-                customLLDBInitFile == rhs.customLLDBInitFile
+                customLLDBInitFile == rhs.customLLDBInitFile &&
+                appClipInvocationURLString == rhs.appClipInvocationURLString
         }
     }
 }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -21,6 +21,14 @@ final class XCSchemeIntegrationTests: XCTestCase {
                                         initModel: XCScheme.init(path:))
     }
 
+    func test_read_appClipScheme() {
+        let subject = try? XCScheme(path: appClipScheme)
+        XCTAssertNotNil(subject)
+        if let subject {
+            assert(appClip: subject)
+        }
+    }
+
     func test_read_runnableWithoutBuildableReferenceScheme() {
         let subject = try? XCScheme(path: runnableWithoutBuildableReferenceSchemePath)
 
@@ -586,6 +594,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.disablePerformanceAntipatternChecker, false)
         XCTAssertEqual(scheme.launchAction?.stopOnEveryMainThreadCheckerIssue, false)
         XCTAssertEqual(scheme.launchAction?.additionalOptions.isEmpty, true)
+        XCTAssertEqual(scheme.launchAction?.appClipInvocationURLString, nil)
 
         let launchEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.launchAction?.environmentVariables)
         XCTAssertEqual(launchEnvironmentVariables.count, 1)
@@ -679,6 +688,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.macroExpansion?.blueprintName, "core-ava")
         XCTAssertEqual(scheme.launchAction?.macroExpansion?.referencedContainer, "container:core-ava.xcodeproj")
         XCTAssertNil(scheme.launchAction?.environmentVariables)
+        XCTAssertNil(scheme.launchAction?.appClipInvocationURLString)
 
         // Profile action
         XCTAssertEqual(scheme.profileAction?.runnable?.runnableDebuggingMode, "0")
@@ -769,6 +779,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.stopOnEveryMainThreadCheckerIssue, false)
         XCTAssertEqual(scheme.launchAction?.additionalOptions.isEmpty, true)
         XCTAssertNil(scheme.launchAction?.storeKitConfigurationFileReference)
+        XCTAssertNil(scheme.launchAction?.appClipInvocationURLString)
 
         let launchEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.launchAction?.environmentVariables)
         XCTAssertEqual(launchEnvironmentVariables.count, 1)
@@ -789,6 +800,95 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertNil(scheme.profileAction?.environmentVariables)
 
         // Analzye action
+        XCTAssertEqual(scheme.analyzeAction?.buildConfiguration, "Debug")
+
+        // Archive action
+        XCTAssertEqual(scheme.archiveAction?.buildConfiguration, "Release")
+        XCTAssertTrue(scheme.archiveAction?.revealArchiveInOrganizer == true)
+        XCTAssertNil(scheme.archiveAction?.customArchiveName)
+    }
+
+    private func assert(appClip scheme: XCScheme) {
+        XCTAssertEqual(scheme.version, "1.7")
+        XCTAssertEqual(scheme.lastUpgradeVersion, "1600", "\(scheme.lastUpgradeVersion!) not equals 1600")
+
+        // Build action
+        XCTAssertTrue(scheme.buildAction?.parallelizeBuild == true)
+        XCTAssertTrue(scheme.buildAction?.buildImplicitDependencies == true)
+        XCTAssertNil(scheme.buildAction?.runPostActionsOnFailure)
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries.count, 1)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries[0].buildFor.contains(.testing) == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries[0].buildFor.contains(.running) == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries[0].buildFor.contains(.profiling) == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries[0].buildFor.contains(.archiving) == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries[0].buildFor.contains(.analyzing) == true)
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries[0].buildableReference.buildableIdentifier, "primary")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries[0].buildableReference.blueprintIdentifier, "5CC725022DA91FB6004D43D4")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries[0].buildableReference.buildableName, "app_clip.app")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries[0].buildableReference.blueprintName, "app_clip")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries[0].buildableReference.referencedContainer, "container:example.xcodeproj")
+
+        // Test action
+        XCTAssertEqual(scheme.testAction?.buildConfiguration, "Debug")
+        XCTAssertEqual(scheme.testAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(scheme.testAction?.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
+        XCTAssertTrue(scheme.testAction?.shouldUseLaunchSchemeArgsEnv == true)
+        XCTAssertTrue(scheme.testAction?.codeCoverageEnabled == false)
+        XCTAssertEqual(scheme.testAction?.onlyGenerateCoverageForSpecifiedTargets, nil)
+        XCTAssertNil(scheme.testAction?.macroExpansion)
+        XCTAssertEqual(scheme.testAction?.enableAddressSanitizer, false)
+        XCTAssertEqual(scheme.testAction?.enableASanStackUseAfterReturn, false)
+        XCTAssertEqual(scheme.testAction?.enableThreadSanitizer, false)
+        XCTAssertEqual(scheme.testAction?.enableUBSanitizer, false)
+        XCTAssertEqual(scheme.testAction?.disableMainThreadChecker, false)
+        XCTAssertEqual(scheme.testAction?.additionalOptions.isEmpty, true)
+        XCTAssertNil(scheme.testAction?.commandlineArguments)
+        XCTAssertNil(scheme.testAction?.environmentVariables)
+
+        // Launch action
+        XCTAssertEqual(scheme.launchAction?.selectedDebuggerIdentifier, XCScheme.defaultDebugger)
+        XCTAssertEqual(scheme.launchAction?.selectedLauncherIdentifier, XCScheme.defaultLauncher)
+        XCTAssertEqual(scheme.launchAction?.buildConfiguration, "Debug")
+        XCTAssertEqual(scheme.launchAction?.launchStyle, XCScheme.LaunchAction.Style.auto)
+        XCTAssertNil(scheme.launchAction?.askForAppToLaunch)
+        XCTAssertNil(scheme.launchAction?.customWorkingDirectory)
+        XCTAssertTrue(scheme.launchAction?.useCustomWorkingDirectory == false)
+        XCTAssertTrue(scheme.launchAction?.ignoresPersistentStateOnLaunch == false)
+        XCTAssertTrue(scheme.launchAction?.debugDocumentVersioning == true)
+        XCTAssertEqual(scheme.launchAction?.debugServiceExtension, XCScheme.LaunchAction.defaultDebugServiceExtension)
+        XCTAssertTrue(scheme.launchAction?.allowLocationSimulation == true)
+        XCTAssertNil(scheme.launchAction?.locationScenarioReference)
+        XCTAssertNil(scheme.launchAction?.commandlineArguments)
+        XCTAssertEqual(scheme.launchAction?.enableAddressSanitizer, false)
+        XCTAssertEqual(scheme.launchAction?.enableASanStackUseAfterReturn, false)
+        XCTAssertEqual(scheme.launchAction?.enableThreadSanitizer, false)
+        XCTAssertEqual(scheme.launchAction?.stopOnEveryThreadSanitizerIssue, false)
+        XCTAssertEqual(scheme.launchAction?.enableUBSanitizer, false)
+        XCTAssertEqual(scheme.launchAction?.stopOnEveryUBSanitizerIssue, false)
+        XCTAssertEqual(scheme.launchAction?.disableMainThreadChecker, false)
+        XCTAssertEqual(scheme.launchAction?.disablePerformanceAntipatternChecker, false)
+        XCTAssertEqual(scheme.launchAction?.stopOnEveryMainThreadCheckerIssue, false)
+        XCTAssertEqual(scheme.launchAction?.additionalOptions.isEmpty, true)
+        XCTAssertNil(scheme.launchAction?.storeKitConfigurationFileReference)
+        XCTAssertNil(scheme.launchAction?.macroExpansion?.referencedContainer)
+        XCTAssertNil(scheme.launchAction?.environmentVariables)
+        XCTAssertEqual(scheme.launchAction?.appClipInvocationURLString, "https://example.com/")
+
+        // Profile action
+        XCTAssertEqual(scheme.profileAction?.runnable?.runnableDebuggingMode, "0")
+        XCTAssertEqual(scheme.profileAction?.runnable?.buildableReference?.referencedContainer, "container:example.xcodeproj")
+        XCTAssertEqual(scheme.profileAction?.buildConfiguration, "Release")
+        XCTAssertTrue(scheme.profileAction?.shouldUseLaunchSchemeArgsEnv == true)
+        XCTAssertEqual(scheme.profileAction?.savedToolIdentifier, "")
+        XCTAssertNil(scheme.profileAction?.customWorkingDirectory)
+        XCTAssertTrue(scheme.profileAction?.useCustomWorkingDirectory == false)
+        XCTAssertTrue(scheme.profileAction?.debugDocumentVersioning == true)
+        XCTAssertNil(scheme.profileAction?.askForAppToLaunch)
+        XCTAssertNil(scheme.profileAction?.commandlineArguments)
+        XCTAssertNil(scheme.profileAction?.environmentVariables)
+        XCTAssertNil(scheme.profileAction?.launchAutomaticallySubstyle)
+
+        // Analyze action
         XCTAssertEqual(scheme.analyzeAction?.buildConfiguration, "Debug")
 
         // Archive action
@@ -841,5 +941,9 @@ final class XCSchemeIntegrationTests: XCTestCase {
     /// A scheme that `buildArchitectures` is specified "Automatic".
     private var buildArchitecturesSchemePath: Path {
         fixturesPath() + "Schemes/BuildArchitectures.xcscheme"
+    }
+
+    private var appClipScheme: Path {
+        fixturesPath() + "Schemes/AppClip.xcscheme"
     }
 }


### PR DESCRIPTION
### Short description 📝
Implement support for the App Clip's URL

### Solution 📦
Added a new `appClipInvocationURLString` parameter to XCScheme+LaunchAction.swift to handle the App Clip's URL.
