### PR TITLE
Add .apinotes support

### DIFF
--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -60,7 +60,7 @@ public enum Xcode {
     public static let inheritedKeywords = ["${inherited}", "$(inherited)"]
 
     /// Header files extensions.
-    public static let headersExtensions = [".h", ".hh", ".hpp", ".ipp", ".tpp", ".hxx", ".def", ".inl", ".inc", ".pch"]
+    public static let headersExtensions = [".h", ".hh", ".hpp", ".ipp", ".tpp", ".hxx", ".def", ".inl", ".inc", ".pch", ".apinotes"]
 
     /// Supported values.
     public enum Supported {


### PR DESCRIPTION
### Short description 📝
> API notes is a YAML based sidecar file that adds additional information for Swift interoperability with other languages. For framework based modules, it needs to be included in the headers list.
> See Also: https://clang.llvm.org/docs/APINotes.html

### Solution 📦
> Add `.apinotes` to the supported headersExtensions list