### PR TITLE
fix: Align the sorting of project references with Xcode 16

### DIFF
--- a/Fixtures/Xcode16ProjectReferenceOrder/Sources/AppDelegate.swift
+++ b/Fixtures/Xcode16ProjectReferenceOrder/Sources/AppDelegate.swift
@@ -1,0 +1,16 @@
+import Framework1
+import Framework2
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func applicationDidFinishLaunching(_: UIApplication) {
+        print(hello())
+    }
+
+    func hello() -> String {
+        "AppDelegate.hello()"
+    }
+}

--- a/Fixtures/Xcode16ProjectReferenceOrder/Test.xcodeproj/project.pbxproj
+++ b/Fixtures/Xcode16ProjectReferenceOrder/Test.xcodeproj/project.pbxproj
@@ -1,0 +1,450 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3108C05C7B0C4FD6AC077294 /* Framework2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6D728BF5C49E97251DA378AE /* Framework2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5D8C48ABB7D5D013DDBD67AA /* Framework1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */; };
+		C2317A164A6A4F635FE4CCD7 /* Framework1.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C57CB036110A3D5DCC9E437A /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D728BF5C49E97251DA378AE /* Framework2.framework */; };
+		D2AE54DED6608D5B956A5E45 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020631B5E0BB47399A2CE86B /* AppDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		063E6B9654162D044FC79E65 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C779969BD4C211DD5C3B641C;
+			remoteInfo = Framework2;
+		};
+		811B516259EFC3D33371D664 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E44C53B0829E6D20396C5BB6;
+			remoteInfo = Framework1;
+		};
+		CA6C894E871DDE6DC2017E72 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = DC40FA3F02AF8EB1A758B163;
+			remoteInfo = Framework2;
+		};
+		E6EBF03BE94A8028ED821B7B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 006F8DE332EBBD68331EC394;
+			remoteInfo = Framework1;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		BF31C3A479ECD7CBA0640A2F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C2317A164A6A4F635FE4CCD7 /* Framework1.framework in Embed Frameworks */,
+				3108C05C7B0C4FD6AC077294 /* Framework2.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		020631B5E0BB47399A2CE86B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		08931D1475E84509040F7FEA /* Framework2.xcodeproj */ = {isa = PBXFileReference; explicitFileType = "wrapper.pb-project"; includeInIndex = 0; name = Framework2.xcodeproj; path = ../Framework2/Framework2.xcodeproj; sourceTree = SOURCE_ROOT; };
+		0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework1.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D728BF5C49E97251DA378AE /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */ = {isa = PBXFileReference; explicitFileType = "wrapper.pb-project"; includeInIndex = 0; name = Framework1.xcodeproj; path = ../Framework1/Framework1.xcodeproj; sourceTree = SOURCE_ROOT; };
+		E203E65EDD1A90FCBAA42C9E /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F09268C492FF78A6C82868C6 /* App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "App-Info.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B27C7CF4B617049554976EFD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5D8C48ABB7D5D013DDBD67AA /* Framework1.framework in Frameworks */,
+				C57CB036110A3D5DCC9E437A /* Framework2.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0767F0D2E9F7C0B23673A1B1 = {
+			isa = PBXGroup;
+			children = (
+				C7A7B9165A3588E4002596F4 /* Project */,
+				67F182DC08786FF3C82D39E8 /* Frameworks */,
+				73B13978C93862E5AD69BCC8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		15ACBAE4CF0A973AED8CC371 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BBE8CAF8BA821ED44E58C6F5 /* Framework2.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		20C83B4860AC239B5E5FDF3C /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				F09268C492FF78A6C82868C6 /* App-Info.plist */,
+			);
+			path = InfoPlists;
+			sourceTree = "<group>";
+		};
+		30CD57449DD0BAD1F51809C3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8CBE43B9129D34973556D4F /* Framework1.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		67F182DC08786FF3C82D39E8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6BB3FD9AE4757E7AE14C43B7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				020631B5E0BB47399A2CE86B /* AppDelegate.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		73B13978C93862E5AD69BCC8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E203E65EDD1A90FCBAA42C9E /* App.app */,
+				0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */,
+				6D728BF5C49E97251DA378AE /* Framework2.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C7A7B9165A3588E4002596F4 /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				6BB3FD9AE4757E7AE14C43B7 /* Sources */,
+			);
+			name = Project;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8359F535E312088875AB7F4E /* App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BAA38452720711B406475F28 /* Build configuration list for PBXNativeTarget "App" */;
+			buildPhases = (
+				2053EE4C6238D6C3AEB2ADB3 /* Sources */,
+				F1BC716AD69EACCBD2A2DDBC /* Resources */,
+				BF31C3A479ECD7CBA0640A2F /* Embed Frameworks */,
+				B27C7CF4B617049554976EFD /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				58FB5C08E20463C938366127 /* PBXTargetDependency */,
+				CD591349E38A6A3EB5AA81DD /* PBXTargetDependency */,
+			);
+			name = App;
+			packageProductDependencies = (
+			);
+			productName = App;
+			productReference = E203E65EDD1A90FCBAA42C9E /* App.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		22E4F0B4EBDBD2631840392B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+			};
+			buildConfigurationList = C94346B8B75719D8319921C2 /* Build configuration list for PBXProject "Test" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 0767F0D2E9F7C0B23673A1B1;
+			productRefGroup = 73B13978C93862E5AD69BCC8 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 30CD57449DD0BAD1F51809C3 /* Products */;
+					ProjectRef = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;
+				},
+				{
+					ProductGroup = 15ACBAE4CF0A973AED8CC371 /* Products */;
+					ProjectRef = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				8359F535E312088875AB7F4E /* App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		BBE8CAF8BA821ED44E58C6F5 /* Framework2.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Framework2.framework;
+			remoteRef = 063E6B9654162D044FC79E65 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8CBE43B9129D34973556D4F /* Framework1.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Framework1.framework;
+			remoteRef = 811B516259EFC3D33371D664 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F1BC716AD69EACCBD2A2DDBC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2053EE4C6238D6C3AEB2ADB3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2AE54DED6608D5B956A5E45 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		58FB5C08E20463C938366127 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Framework2;
+			targetProxy = CA6C894E871DDE6DC2017E72 /* PBXContainerItemProxy */;
+		};
+		CD591349E38A6A3EB5AA81DD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Framework1;
+			targetProxy = E6EBF03BE94A8028ED821B7B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0B98A64D6F621FDCEEA0CE44 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "Derived/InfoPlists/App-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.App;
+				PRODUCT_NAME = App;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		58BAFCCFAE3AD62113BBEDEF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		5904C1CCA86A83838723C772 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5E15950A8DD3B82ED1ED7849 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "Derived/InfoPlists/App-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.App;
+				PRODUCT_NAME = App;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BAA38452720711B406475F28 /* Build configuration list for PBXNativeTarget "App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0B98A64D6F621FDCEEA0CE44 /* Debug */,
+				5E15950A8DD3B82ED1ED7849 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C94346B8B75719D8319921C2 /* Build configuration list for PBXProject "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58BAFCCFAE3AD62113BBEDEF /* Debug */,
+				5904C1CCA86A83838723C772 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 22E4F0B4EBDBD2631840392B /* Project object */;
+}

--- a/Fixtures/Xcode16ProjectReferenceOrder/Test.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/Fixtures/Xcode16ProjectReferenceOrder/Test.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8359F535E312088875AB7F4E"
+               BuildableName = "App.app"
+               BlueprintName = "App"
+               ReferencedContainer = "container:MainApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      disableMainThreadChecker = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8359F535E312088875AB7F4E"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:MainApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8359F535E312088875AB7F4E"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:MainApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Fixtures/Xcode16ProjectReferenceOrder/Wrong.xcodeproj/project.pbxproj
+++ b/Fixtures/Xcode16ProjectReferenceOrder/Wrong.xcodeproj/project.pbxproj
@@ -1,0 +1,450 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3108C05C7B0C4FD6AC077294 /* Framework2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6D728BF5C49E97251DA378AE /* Framework2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5D8C48ABB7D5D013DDBD67AA /* Framework1.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */; };
+		C2317A164A6A4F635FE4CCD7 /* Framework1.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C57CB036110A3D5DCC9E437A /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D728BF5C49E97251DA378AE /* Framework2.framework */; };
+		D2AE54DED6608D5B956A5E45 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020631B5E0BB47399A2CE86B /* AppDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		063E6B9654162D044FC79E65 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C779969BD4C211DD5C3B641C;
+			remoteInfo = Framework2;
+		};
+		811B516259EFC3D33371D664 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E44C53B0829E6D20396C5BB6;
+			remoteInfo = Framework1;
+		};
+		CA6C894E871DDE6DC2017E72 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = DC40FA3F02AF8EB1A758B163;
+			remoteInfo = Framework2;
+		};
+		E6EBF03BE94A8028ED821B7B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 006F8DE332EBBD68331EC394;
+			remoteInfo = Framework1;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		BF31C3A479ECD7CBA0640A2F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C2317A164A6A4F635FE4CCD7 /* Framework1.framework in Embed Frameworks */,
+				3108C05C7B0C4FD6AC077294 /* Framework2.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		020631B5E0BB47399A2CE86B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		08931D1475E84509040F7FEA /* Framework2.xcodeproj */ = {isa = PBXFileReference; explicitFileType = "wrapper.pb-project"; includeInIndex = 0; name = Framework2.xcodeproj; path = ../Framework2/Framework2.xcodeproj; sourceTree = SOURCE_ROOT; };
+		0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework1.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D728BF5C49E97251DA378AE /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */ = {isa = PBXFileReference; explicitFileType = "wrapper.pb-project"; includeInIndex = 0; name = Framework1.xcodeproj; path = ../Framework1/Framework1.xcodeproj; sourceTree = SOURCE_ROOT; };
+		E203E65EDD1A90FCBAA42C9E /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F09268C492FF78A6C82868C6 /* App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "App-Info.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B27C7CF4B617049554976EFD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5D8C48ABB7D5D013DDBD67AA /* Framework1.framework in Frameworks */,
+				C57CB036110A3D5DCC9E437A /* Framework2.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0767F0D2E9F7C0B23673A1B1 = {
+			isa = PBXGroup;
+			children = (
+				C7A7B9165A3588E4002596F4 /* Project */,
+				67F182DC08786FF3C82D39E8 /* Frameworks */,
+				73B13978C93862E5AD69BCC8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		15ACBAE4CF0A973AED8CC371 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BBE8CAF8BA821ED44E58C6F5 /* Framework2.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		20C83B4860AC239B5E5FDF3C /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				F09268C492FF78A6C82868C6 /* App-Info.plist */,
+			);
+			path = InfoPlists;
+			sourceTree = "<group>";
+		};
+		30CD57449DD0BAD1F51809C3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8CBE43B9129D34973556D4F /* Framework1.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		67F182DC08786FF3C82D39E8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6BB3FD9AE4757E7AE14C43B7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				020631B5E0BB47399A2CE86B /* AppDelegate.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		73B13978C93862E5AD69BCC8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E203E65EDD1A90FCBAA42C9E /* App.app */,
+				0FCDEDB6CEA64BD069DC9EA9 /* Framework1.framework */,
+				6D728BF5C49E97251DA378AE /* Framework2.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C7A7B9165A3588E4002596F4 /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				6BB3FD9AE4757E7AE14C43B7 /* Sources */,
+			);
+			name = Project;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8359F535E312088875AB7F4E /* App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BAA38452720711B406475F28 /* Build configuration list for PBXNativeTarget "App" */;
+			buildPhases = (
+				2053EE4C6238D6C3AEB2ADB3 /* Sources */,
+				F1BC716AD69EACCBD2A2DDBC /* Resources */,
+				BF31C3A479ECD7CBA0640A2F /* Embed Frameworks */,
+				B27C7CF4B617049554976EFD /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				58FB5C08E20463C938366127 /* PBXTargetDependency */,
+				CD591349E38A6A3EB5AA81DD /* PBXTargetDependency */,
+			);
+			name = App;
+			packageProductDependencies = (
+			);
+			productName = App;
+			productReference = E203E65EDD1A90FCBAA42C9E /* App.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		22E4F0B4EBDBD2631840392B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+			};
+			buildConfigurationList = C94346B8B75719D8319921C2 /* Build configuration list for PBXProject "MainApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 0767F0D2E9F7C0B23673A1B1;
+			productRefGroup = 73B13978C93862E5AD69BCC8 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 15ACBAE4CF0A973AED8CC371 /* Products */;
+					ProjectRef = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;
+				},
+				{
+					ProductGroup = 30CD57449DD0BAD1F51809C3 /* Products */;
+					ProjectRef = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				8359F535E312088875AB7F4E /* App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		BBE8CAF8BA821ED44E58C6F5 /* Framework2.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Framework2.framework;
+			remoteRef = 063E6B9654162D044FC79E65 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8CBE43B9129D34973556D4F /* Framework1.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Framework1.framework;
+			remoteRef = 811B516259EFC3D33371D664 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F1BC716AD69EACCBD2A2DDBC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2053EE4C6238D6C3AEB2ADB3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2AE54DED6608D5B956A5E45 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		58FB5C08E20463C938366127 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Framework2;
+			targetProxy = CA6C894E871DDE6DC2017E72 /* PBXContainerItemProxy */;
+		};
+		CD591349E38A6A3EB5AA81DD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Framework1;
+			targetProxy = E6EBF03BE94A8028ED821B7B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0B98A64D6F621FDCEEA0CE44 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "Derived/InfoPlists/App-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.App;
+				PRODUCT_NAME = App;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		58BAFCCFAE3AD62113BBEDEF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		5904C1CCA86A83838723C772 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		5E15950A8DD3B82ED1ED7849 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "Derived/InfoPlists/App-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.App;
+				PRODUCT_NAME = App;
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BAA38452720711B406475F28 /* Build configuration list for PBXNativeTarget "App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0B98A64D6F621FDCEEA0CE44 /* Debug */,
+				5E15950A8DD3B82ED1ED7849 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C94346B8B75719D8319921C2 /* Build configuration list for PBXProject "MainApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58BAFCCFAE3AD62113BBEDEF /* Debug */,
+				5904C1CCA86A83838723C772 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 22E4F0B4EBDBD2631840392B /* Project object */;
+}

--- a/Fixtures/Xcode16ProjectReferenceOrder/Wrong.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/Fixtures/Xcode16ProjectReferenceOrder/Wrong.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8359F535E312088875AB7F4E"
+               BuildableName = "App.app"
+               BlueprintName = "App"
+               ReferencedContainer = "container:MainApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      disableMainThreadChecker = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8359F535E312088875AB7F4E"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:MainApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8359F535E312088875AB7F4E"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:MainApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
@@ -507,7 +507,9 @@ final class PBXProjEncoder {
                 })
             } catch {
                 print("Unable to sort as Xcode 16 do: \(error)")
-                fatalError("\(error)")
+                // actually we could do even fatalError here
+                // but it could be too brave for common repository
+                // fatalError("\(error)")
             }
         }
     }

--- a/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
+++ b/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift
@@ -482,39 +482,16 @@ final class PBXProjEncoder {
         }
 
         for project in projects {
-            do {
-                project.projectReferences = try project.projectReferences.sorted(by: { lhs, rhs in
-                    guard let lProjectRef = lhs["ProjectRef"] else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let lFile: PBXFileElement = lProjectRef.getObject() else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let rProjectRef = rhs["ProjectRef"] else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let rFile: PBXFileElement = rProjectRef.getObject() else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let lName = lFile.name else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-                    guard let rName = rFile.name else {
-                        throw Errors.unexpectedPbxProj()
-                    }
-
-                    return lName.compare(rName, options: .caseInsensitive) == .orderedAscending
-                })
-            } catch {
-                print("Unable to sort as Xcode 16 do: \(error)")
-                // actually we could do even fatalError here
-                // but it could be too brave for common repository
-                // fatalError("\(error)")
-            }
+            /// The project references are sorted alphabetically based on the name of the project it's being referenced.
+            project.projectReferences = project.projectReferences.sorted(by: { lhs, rhs in
+                let lProjectRef = lhs["ProjectRef"]!
+                let lFile: PBXFileElement = lProjectRef.getObject()!
+                let rProjectRef = rhs["ProjectRef"]!
+                let rFile: PBXFileElement = rProjectRef.getObject()!
+                let lName = lFile.name!
+                let rName = rFile.name!
+                return lName.compare(rName, options: .caseInsensitive) == .orderedAscending
+            })
         }
     }
-}
-
-private enum Errors: Error {
-    case unexpectedPbxProj(_ id: Int = #line)
 }

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
@@ -342,16 +342,17 @@
         }
 
         // MARK: - Projects
+
         func test_ProjectReferenceOrder() throws {
-          try loadProjectWithWrongProjectReferencesOrder()
+            try loadProjectWithWrongProjectReferencesOrder()
 
-          let lines = lines(fromFile: encodeProject())
+            let lines = lines(fromFile: encodeProject())
 
-          let beginGroup = lines.findLine("/* Begin PBXProject section */")
-          let beginReferences = lines.findLine("projectReferences = (", after: beginGroup)
-          let endReferences = lines.findLine(");", after: beginReferences)
-          let firstReferenceLine = lines.validate(line: "ProjectRef = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;", betweenLine: beginReferences, andLine: endReferences)
-          lines.validate(line: "ProjectRef = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;", betweenLine: firstReferenceLine, andLine: endReferences)
+            let beginGroup = lines.findLine("/* Begin PBXProject section */")
+            let beginReferences = lines.findLine("projectReferences = (", after: beginGroup)
+            let endReferences = lines.findLine(");", after: beginReferences)
+            let firstReferenceLine = lines.validate(line: "ProjectRef = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;", betweenLine: beginReferences, andLine: endReferences)
+            lines.validate(line: "ProjectRef = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;", betweenLine: firstReferenceLine, andLine: endReferences)
         }
 
         // MARK: - Build phases

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
@@ -341,6 +341,19 @@
             line = lines.validate(line: "/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */", after: line)
         }
 
+        // MARK: - Projects
+        func test_ProjectReferenceOrder() throws {
+          try loadProjectWithWrongProjectReferencesOrder()
+
+          let lines = lines(fromFile: encodeProject())
+
+          let beginGroup = lines.findLine("/* Begin PBXProject section */")
+          let beginReferences = lines.findLine("projectReferences = (", after: beginGroup)
+          let endReferences = lines.findLine(");", after: beginReferences)
+          let firstReferenceLine = lines.validate(line: "ProjectRef = 87A3E8A0727A99EE88ED4E64 /* Framework1.xcodeproj */;", betweenLine: beginReferences, andLine: endReferences)
+          lines.validate(line: "ProjectRef = 08931D1475E84509040F7FEA /* Framework2.xcodeproj */;", betweenLine: firstReferenceLine, andLine: endReferences)
+        }
+
         // MARK: - Build phases
 
         func test_build_phase_sources_unsorted_when_iOSProject() throws {
@@ -535,6 +548,10 @@
 
         private func loadProjectWithRelativeXCLocalSwiftPackageReference() throws {
             proj = try PBXProj(data: iosProjectWithRelativeXCLocalSwiftPackageReferences())
+        }
+
+        private func loadProjectWithWrongProjectReferencesOrder() throws {
+            proj = try PBXProj(data: projectWithWrongProjectReferencesOrder())
         }
     }
 

--- a/Tests/XcodeProjTests/Tests/Fixtures.swift
+++ b/Tests/XcodeProjTests/Tests/Fixtures.swift
@@ -40,3 +40,8 @@ func iosProjectWithXCLocalSwiftPackageReferences() throws -> Data {
     let iosProjectWithXCLocalSwiftPackageReference = fixturesPath() + "iOS/ProjectWithXCLocalSwiftPackageReferences.xcodeproj/project.pbxproj"
     return try Data(contentsOf: iosProjectWithXCLocalSwiftPackageReference.url)
 }
+
+func projectWithWrongProjectReferencesOrder() throws -> Data {
+    let iosProjectWithProjectReferences = fixturesPath() + "Xcode16ProjectReferenceOrder/Wrong.xcodeproj/project.pbxproj"
+    return try Data(contentsOf: iosProjectWithProjectReferences.url)
+}


### PR DESCRIPTION
### Short description 📝
If project saved with XcodeProj then opening it with Xcode 16 generate some changes. So we could respect Xcode 16 sorting by sorting our result with the same way.

### Solution 📦
Do the same sorting as Xcode 16 do

---
NB! This PR is copy of https://github.com/tuist/XcodeProj/pull/867 with proper tests added.
