### PR TITLE
chore: make XCScheme static path functions public.

### DIFF
--- a/Sources/XcodeProj/Scheme/XCScheme.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme.swift
@@ -144,12 +144,12 @@ public final class XCScheme: Writable, Equatable {
     }
 }
 
-extension XCScheme {
+public extension XCScheme {
     /// Returns schemes folder path relative to the given path.
     ///
     /// - Parameter path: parent folder of schemes folder (xcshareddata or xcuserdata)
     /// - Returns: schemes folder path relative to the given path.
-    public static func schemesPath(_ path: Path) -> Path {
+    static func schemesPath(_ path: Path) -> Path {
         path + "xcschemes"
     }
 
@@ -158,7 +158,7 @@ extension XCScheme {
     /// - Parameter path: parent folder of schemes folder (xcshareddata or xcuserdata)
     /// - Parameter schemeName: scheme name
     /// - Returns: scheme file path relative to the given path.
-    public static func path(_ path: Path, schemeName: String) -> Path {
+    static func path(_ path: Path, schemeName: String) -> Path {
         XCScheme.schemesPath(path) + "\(schemeName).xcscheme"
     }
 }

--- a/Sources/XcodeProj/Scheme/XCScheme.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme.swift
@@ -149,7 +149,7 @@ extension XCScheme {
     ///
     /// - Parameter path: parent folder of schemes folder (xcshareddata or xcuserdata)
     /// - Returns: schemes folder path relative to the given path.
-    static func schemesPath(_ path: Path) -> Path {
+    public static func schemesPath(_ path: Path) -> Path {
         path + "xcschemes"
     }
 
@@ -158,7 +158,7 @@ extension XCScheme {
     /// - Parameter path: parent folder of schemes folder (xcshareddata or xcuserdata)
     /// - Parameter schemeName: scheme name
     /// - Returns: scheme file path relative to the given path.
-    static func path(_ path: Path, schemeName: String) -> Path {
+    public static func path(_ path: Path, schemeName: String) -> Path {
         XCScheme.schemesPath(path) + "\(schemeName).xcscheme"
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/939

### Short description 📝

Static `XCScheme` functions intended to be public are internal. I made them public.

### Solution 📦

Internal > Public 

### Implementation 👩‍💻👨‍💻

Not much to speak of here.
