### PR TITLE
docs: add XcodeProjectCLI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,17 @@ XcodeProj is a library written in Swift for parsing and working with Xcode proje
 
 ## Projects Using XcodeProj
 
-| Project         | Repository                                                                                   |
-| --------------- | -------------------------------------------------------------------------------------------- |
-| ProjLint        | [github.com/JamitLabs/ProjLint](https://github.com/JamitLabs/ProjLint)                       |
-| rules_xcodeproj | [github.com/buildbuddy-io/rules_xcodeproj](https://github.com/buildbuddy-io/rules_xcodeproj) |
-| Rugby           | [github.com/swiftyfinch/Rugby](https://github.com/swiftyfinch/Rugby)                         |
-| Sourcery        | [github.com/krzysztofzablocki/Sourcery](https://github.com/krzysztofzablocki/Sourcery)       |
-| Tuist           | [github.com/tuist/tuist](https://github.com/tuist/tuist)                                     |
-| XcodeGen        | [github.com/yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen)                       |
-| xspm            | [gitlab.com/Pyroh/xspm](https://gitlab.com/Pyroh/xspm)                                       |
-| Privacy Manifest| [github.com/stelabouras/privacy-manifest](https://github.com/stelabouras/privacy-manifest)   |
+| Project         | Repository                                                                                       |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| ProjLint        | [github.com/JamitLabs/ProjLint](https://github.com/JamitLabs/ProjLint)                           |
+| rules_xcodeproj | [github.com/buildbuddy-io/rules_xcodeproj](https://github.com/buildbuddy-io/rules_xcodeproj)     |
+| Rugby           | [github.com/swiftyfinch/Rugby](https://github.com/swiftyfinch/Rugby)                             |
+| Sourcery        | [github.com/krzysztofzablocki/Sourcery](https://github.com/krzysztofzablocki/Sourcery)           |
+| Tuist           | [github.com/tuist/tuist](https://github.com/tuist/tuist)                                         |
+| XcodeGen        | [github.com/yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen)                           |
+| xspm            | [gitlab.com/Pyroh/xspm](https://gitlab.com/Pyroh/xspm)                                           |
+| Privacy Manifest| [github.com/stelabouras/privacy-manifest](https://github.com/stelabouras/privacy-manifest)       |
+| XcodeProjectCLI | [github.com/wojciech-kulik/XcodeProjectCLI](https://github.com/wojciech-kulik/XcodeProjectCLI)   |
 
 If you are also leveraging XcodeProj in your project, feel free to open a PR to include it in the list above.
 


### PR DESCRIPTION
Thank you for this amazing Swift Package!

Thanks to it, I was able to migrate my Ruby-based integration used in [xcodebuild.nvim](https://github.com/wojciech-kulik/xcodebuild.nvim) plugin 🍻 

I built a small tool on top of this package to easily manage Xcode project file from terminal. The goal was to expose an easy interface to interact with the project, wrapping all the complex logic :).

[XcodeProjectCLI](https://github.com/wojciech-kulik/XcodeProjectCLI)