### PR TITLE
feat: Compatibility with the iOS platform

### DIFF
--- a/.github/workflows/xcodeproj.yml
+++ b/.github/workflows/xcodeproj.yml
@@ -33,6 +33,14 @@ jobs:
       - run: mise use swift@6.0.2
       - name: Build
         run: swift build --configuration release
+  build-ios:
+    name: Build (iOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build for iOS Simulator
+        run: xcodebuild build -scheme XcodeProj -destination 'platform=iOS Simulator,name=iPhone 16'
+  
   test:
     name: Test (macOS / Xcode)
     runs-on: macos-latest
@@ -41,7 +49,6 @@ jobs:
       - uses: jdx/mise-action@v2
       - name: Run tests
         run: mise run test
-
   test-linux:
     name: Test (Linux)
     runs-on: ubuntu-latest
@@ -55,6 +62,13 @@ jobs:
           git config --global init.defaultBranch main
       - name: Test
         run: swift test
+  test-ios:
+    name: Test (iOS / Xcode)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests on iOS Simulator
+        run: xcodebuild test -scheme XcodeProj -destination 'platform=iOS Simulator,name=iPhone 16'
 
   lint:
     name: Lint

--- a/.github/workflows/xcodeproj.yml
+++ b/.github/workflows/xcodeproj.yml
@@ -39,8 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build for iOS Simulator
-        run: xcodebuild build -scheme XcodeProj -destination 'platform=iOS Simulator,name=iPhone 16'
-  
+        run: xcodebuild build -scheme XcodeProj -destination 'generic/platform=iOS Simulator'
   test:
     name: Test (macOS / Xcode)
     runs-on: macos-latest
@@ -67,8 +66,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Select iOS Simulator
+        run: |
+          simulator_id="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ { print $2; exit }')"
+          if [ -z "$simulator_id" ]; then
+            echo "No available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "IOS_SIMULATOR_ID=$simulator_id" >> "$GITHUB_ENV"
       - name: Run tests on iOS Simulator
-        run: xcodebuild test -scheme XcodeProj -destination 'platform=iOS Simulator,name=iPhone 16'
+        run: xcodebuild test -scheme XcodeProj -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_ID"
 
   lint:
     name: Lint

--- a/Sources/XcodeProj/Extensions/Path+Extras.swift
+++ b/Sources/XcodeProj/Extensions/Path+Extras.swift
@@ -6,7 +6,7 @@ import PathKit
 // MARK: - Path extras.
 
 func systemGlob(_ pattern: UnsafePointer<CChar>!, _ flags: Int32, _ errfunc: (@convention(c) (UnsafePointer<CChar>?, Int32) -> Int32)!, _ vector_ptr: UnsafeMutablePointer<glob_t>!) -> Int32 {
-    #if os(macOS)
+    #if os(macOS) || os(iOS)
         return Darwin.glob(pattern, flags, errfunc, vector_ptr)
     #else
         return Glibc.glob(pattern, flags, errfunc, vector_ptr)

--- a/Sources/XcodeProj/Extensions/String+md5.swift
+++ b/Sources/XcodeProj/Extensions/String+md5.swift
@@ -31,7 +31,7 @@ extension String {
             return self
         }
         #if canImport(CryptoKit)
-            if #available(OSX 10.15, *) {
+            if #available(OSX 10.15, iOS 13.0, *) {
                 return Insecure.MD5.hash(data: data)
                     .withUnsafeBytes { Array($0) }.hexString
             } else {

--- a/Tests/XcodeProjTests/Extensions/XCTestCase+Shell.swift
+++ b/Tests/XcodeProjTests/Extensions/XCTestCase+Shell.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Returns the output of running `executable` with `args`. Throws an error if the process exits indicating failure.
 @discardableResult
 func checkedOutput(_ executable: String, _ args: [String]) throws -> String? {
+    #if os(macOS)
     let process = Process()
     let output = Pipe()
 
@@ -22,4 +23,7 @@ func checkedOutput(_ executable: String, _ args: [String]) throws -> String? {
     }
 
     return String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    #else
+    return nil
+    #endif
 }

--- a/Tests/XcodeProjTests/Extensions/XCTestCase+Shell.swift
+++ b/Tests/XcodeProjTests/Extensions/XCTestCase+Shell.swift
@@ -3,27 +3,27 @@ import Foundation
 /// Returns the output of running `executable` with `args`. Throws an error if the process exits indicating failure.
 @discardableResult
 func checkedOutput(_ executable: String, _ args: [String]) throws -> String? {
-    #if os(macOS)
-    let process = Process()
-    let output = Pipe()
-
-    if executable.contains("/") {
-        process.launchPath = executable
-    } else {
-        process.launchPath = try checkedOutput("/usr/bin/which", [executable])?.trimmingCharacters(in: .newlines)
-    }
-
-    process.arguments = args
-    process.standardOutput = output
-    process.launch()
-    process.waitUntilExit()
-
-    guard process.terminationStatus == 0 else {
-        throw NSError(domain: NSPOSIXErrorDomain, code: Int(process.terminationStatus))
-    }
-
-    return String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    #if os(iOS)
+        return nil
     #else
-    return nil
+        let process = Process()
+        let output = Pipe()
+
+        if executable.contains("/") {
+            process.launchPath = executable
+        } else {
+            process.launchPath = try checkedOutput("/usr/bin/which", [executable])?.trimmingCharacters(in: .newlines)
+        }
+
+        process.arguments = args
+        process.standardOutput = output
+        process.launch()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(process.terminationStatus))
+        }
+
+        return String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
     #endif
 }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeManagementTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeManagementTests.swift
@@ -45,6 +45,9 @@ final class XCSchemeManagementTests: XCTestCase {
     }
 
     func test_write_produces_no_diff() throws {
+        #if os(iOS)
+        throw XCTSkip("'Process' API is unavailable on iOS platform")
+        #else
         let tmpDir = try Path.uniqueTemporary()
         defer {
             try? tmpDir.delete()
@@ -77,6 +80,7 @@ final class XCSchemeManagementTests: XCTestCase {
             let got = try checkedOutput("git", ["status"])
             XCTAssertTrue(got?.contains("nothing to commit") ?? false)
         }
+        #endif
     }
 
     private var xcschememanagementPath: Path {

--- a/Tests/XcodeProjTests/Scheme/XCSchemeManagementTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeManagementTests.swift
@@ -46,40 +46,40 @@ final class XCSchemeManagementTests: XCTestCase {
 
     func test_write_produces_no_diff() throws {
         #if os(iOS)
-        throw XCTSkip("'Process' API is unavailable on iOS platform")
+            throw XCTSkip("'Process' API is unavailable on iOS platform")
         #else
-        let tmpDir = try Path.uniqueTemporary()
-        defer {
-            try? tmpDir.delete()
-        }
+            let tmpDir = try Path.uniqueTemporary()
+            defer {
+                try? tmpDir.delete()
+            }
 
-        try tmpDir.chdir {
-            // Write
-            let plistPath = tmpDir + "xcschememanagement.plist"
-            let subject = XCSchemeManagement(
-                schemeUserState: [
-                    .init(name: "Test 0.xcscheme", shared: true, orderHint: 0, isShown: true),
-                    .init(name: "Test 1.xcscheme", shared: true, orderHint: 1, isShown: true),
-                    .init(name: "Test 2.xcscheme", shared: true, orderHint: 2, isShown: false),
-                    .init(name: "Test 3.xcscheme", shared: true, orderHint: 3, isShown: true),
-                ],
-                suppressBuildableAutocreation: [
-                    "E525238B16245A900012E2BA": .init(primary: true),
-                ]
-            )
-            try subject.write(path: plistPath, override: true)
+            try tmpDir.chdir {
+                // Write
+                let plistPath = tmpDir + "xcschememanagement.plist"
+                let subject = XCSchemeManagement(
+                    schemeUserState: [
+                        .init(name: "Test 0.xcscheme", shared: true, orderHint: 0, isShown: true),
+                        .init(name: "Test 1.xcscheme", shared: true, orderHint: 1, isShown: true),
+                        .init(name: "Test 2.xcscheme", shared: true, orderHint: 2, isShown: false),
+                        .init(name: "Test 3.xcscheme", shared: true, orderHint: 3, isShown: true),
+                    ],
+                    suppressBuildableAutocreation: [
+                        "E525238B16245A900012E2BA": .init(primary: true),
+                    ]
+                )
+                try subject.write(path: plistPath, override: true)
 
-            // Create a commit
-            try checkedOutput("git", ["init"])
-            try checkedOutput("git", ["add", "."])
-            try checkedOutput("git", ["commit", "-m", "test"])
+                // Create a commit
+                try checkedOutput("git", ["init"])
+                try checkedOutput("git", ["add", "."])
+                try checkedOutput("git", ["commit", "-m", "test"])
 
-            // Write again
-            try subject.write(path: plistPath, override: true)
+                // Write again
+                try subject.write(path: plistPath, override: true)
 
-            let got = try checkedOutput("git", ["status"])
-            XCTAssertTrue(got?.contains("nothing to commit") ?? false)
-        }
+                let got = try checkedOutput("git", ["status"])
+                XCTAssertTrue(got?.contains("nothing to commit") ?? false)
+            }
         #endif
     }
 

--- a/Tests/XcodeProjTests/Tests/testWrite.swift
+++ b/Tests/XcodeProjTests/Tests/testWrite.swift
@@ -45,6 +45,9 @@ func testReadWriteProducesNoDiff(file _: StaticString = #file,
                                  from path: Path,
                                  initModel: (Path) throws -> some Writable) throws
 {
+    #if os(iOS)
+    throw XCTSkip("'Process' API is unavailable on iOS platform")
+    #else
     let tmpDir = try Path.uniqueTemporary()
     defer {
         try? tmpDir.delete()
@@ -69,4 +72,5 @@ func testReadWriteProducesNoDiff(file _: StaticString = #file,
         let diff = try XCTUnwrap(checkedOutput("git", ["diff"]))
         XCTAssertEqual(diff, "")
     }
+    #endif
 }

--- a/Tests/XcodeProjTests/Tests/testWrite.swift
+++ b/Tests/XcodeProjTests/Tests/testWrite.swift
@@ -46,31 +46,31 @@ func testReadWriteProducesNoDiff(file _: StaticString = #file,
                                  initModel: (Path) throws -> some Writable) throws
 {
     #if os(iOS)
-    throw XCTSkip("'Process' API is unavailable on iOS platform")
+        throw XCTSkip("'Process' API is unavailable on iOS platform")
     #else
-    let tmpDir = try Path.uniqueTemporary()
-    defer {
-        try? tmpDir.delete()
-    }
+        let tmpDir = try Path.uniqueTemporary()
+        defer {
+            try? tmpDir.delete()
+        }
 
-    let fileName = path.lastComponent
-    let tmpPath = tmpDir + fileName
-    try path.copy(tmpPath)
+        let fileName = path.lastComponent
+        let tmpPath = tmpDir + fileName
+        try path.copy(tmpPath)
 
-    try tmpDir.chdir {
-        // Create a commit
-        try checkedOutput("git", ["init"])
-        try checkedOutput("git", ["add", "."])
-        try checkedOutput("git", [
-            "-c", "user.email=test@example.com", "-c", "user.name=Test User",
-            "commit", "-m", "test",
-        ])
+        try tmpDir.chdir {
+            // Create a commit
+            try checkedOutput("git", ["init"])
+            try checkedOutput("git", ["add", "."])
+            try checkedOutput("git", [
+                "-c", "user.email=test@example.com", "-c", "user.name=Test User",
+                "commit", "-m", "test",
+            ])
 
-        let object = try initModel(tmpPath)
-        try object.write(path: tmpPath, override: true)
+            let object = try initModel(tmpPath)
+            try object.write(path: tmpPath, override: true)
 
-        let diff = try XCTUnwrap(checkedOutput("git", ["diff"]))
-        XCTAssertEqual(diff, "")
-    }
+            let diff = try XCTUnwrap(checkedOutput("git", ["diff"]))
+            XCTAssertEqual(diff, "")
+        }
     #endif
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/1015

### Short description 📝
> Currently, XcodeProj is not compilable on iOS platform. This is an issue when attempting to compile products that have XcodeProj as a (transitive) dependency

### Solution 📦
> Add appropriate iOS compiler flag and version check to ensure symbols are available and guarantee successful compilation.

### Implementation 👩‍💻👨‍💻
> Detail in a checklist the steps that you took to implement the PR.

- [x] Add compiler flags
- [x] Add iOS version checks
- [x] Build XcodeProj target
- [x] Compile XcodeProj tests
