### PR TITLE
feat: Added support for Xcode 26's `dstSubfolder`

### DIFF
--- a/Sources/XcodeProj/Objects/BuildPhase/PBXCopyFilesBuildPhase.swift
+++ b/Sources/XcodeProj/Objects/BuildPhase/PBXCopyFilesBuildPhase.swift
@@ -2,9 +2,7 @@ import Foundation
 
 /// This is the element for the copy file build phase.
 public final class PBXCopyFilesBuildPhase: PBXBuildPhase {
-    
-    @available(*, deprecated, renamed: "SubFolder", message: "May become obsolete in the future in favor of dstSubfolder")
-    public enum SubFolderSpec: UInt, Decodable {
+    public enum SubFolder: UInt, Decodable {
         case absolutePath = 0
         case productsDirectory = 16
         case wrapper = 1
@@ -17,21 +15,66 @@ public final class PBXCopyFilesBuildPhase: PBXBuildPhase {
         case plugins = 13
         case other
     }
-  
-    public enum SubFolder: String, Decodable {
-        case absolutePath = "AbsolutePath"
-        case productsDirectory = "ProductsDirectory"
-        case wrapper = "Wrapper"
-        case executables = "Executables"
-        case resources = "Resources"
-        case javaResources = "JavaResources"
-        case frameworks = "Frameworks"
-        case sharedFrameworks = "SharedFrameworks"
-        case sharedSupport = "SharedSupport"
-        case plugins = "PlugIns"
-        case other = "Other"
-        case product = "Product"
-        case none = "None"
+
+    public enum DstSubfolder: Equatable, Decodable {
+        case absolutePath
+        case productsDirectory
+        case wrapper
+        case executables
+        case resources
+        case javaResources
+        case frameworks
+        case sharedFrameworks
+        case sharedSupport
+        case plugins
+        case other
+        case product
+        case none
+        case unknown(String)
+
+        public init(rawValue: String) {
+            switch rawValue {
+            case "AbsolutePath": self = .absolutePath
+            case "ProductsDirectory": self = .productsDirectory
+            case "Wrapper": self = .wrapper
+            case "Executables": self = .executables
+            case "Resources": self = .resources
+            case "JavaResources": self = .javaResources
+            case "Frameworks": self = .frameworks
+            case "SharedFrameworks": self = .sharedFrameworks
+            case "SharedSupport": self = .sharedSupport
+            case "PlugIns": self = .plugins
+            case "Other": self = .other
+            case "Product": self = .product
+            case "None": self = .none
+            default: self = .unknown(rawValue)
+            }
+        }
+
+        public var rawValue: String {
+            switch self {
+            case .absolutePath: "AbsolutePath"
+            case .productsDirectory: "ProductsDirectory"
+            case .wrapper: "Wrapper"
+            case .executables: "Executables"
+            case .resources: "Resources"
+            case .javaResources: "JavaResources"
+            case .frameworks: "Frameworks"
+            case .sharedFrameworks: "SharedFrameworks"
+            case .sharedSupport: "SharedSupport"
+            case .plugins: "PlugIns"
+            case .other: "Other"
+            case .product: "Product"
+            case .none: "None"
+            case let .unknown(rawValue): rawValue
+            }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            self = .init(rawValue: rawValue)
+        }
     }
 
     // MARK: - Attributes
@@ -40,9 +83,9 @@ public final class PBXCopyFilesBuildPhase: PBXBuildPhase {
     public var dstPath: String?
 
     /// Element destination subfolder spec
-    public var dstSubfolderSpec: SubFolderSpec?
-  
-    public var dstSubfolder: SubFolder?
+    public var dstSubfolderSpec: SubFolder?
+
+    public var dstSubfolder: DstSubfolder?
 
     /// Copy files build phase name
     public var name: String?
@@ -58,12 +101,13 @@ public final class PBXCopyFilesBuildPhase: PBXBuildPhase {
     /// - Parameters:
     ///   - dstPath: Destination path.
     ///   - dstSubfolderSpec: Destination subfolder spec.
+    ///   - dstSubfolder: Destination subfolder.
     ///   - buildActionMask: Build action mask.
     ///   - files: Build files to copy.
     ///   - runOnlyForDeploymentPostprocessing: Run only for deployment post processing.
     public init(dstPath: String? = nil,
-                dstSubfolderSpec: SubFolderSpec? = nil,
-                dstSubfolder: SubFolder? = nil,
+                dstSubfolderSpec: SubFolder? = nil,
+                dstSubfolder: DstSubfolder? = nil,
                 name: String? = nil,
                 buildActionMask: UInt = defaultBuildActionMask,
                 files: [PBXBuildFile] = [],
@@ -90,7 +134,7 @@ public final class PBXCopyFilesBuildPhase: PBXBuildPhase {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         dstPath = try container.decodeIfPresent(.dstPath)
-        dstSubfolderSpec = try container.decodeIntIfPresent(.dstSubfolderSpec).flatMap(SubFolderSpec.init)
+        dstSubfolderSpec = try container.decodeIntIfPresent(.dstSubfolderSpec).flatMap(SubFolder.init)
         dstSubfolder = try container.decodeIfPresent(.dstSubfolder)
         name = try container.decodeIfPresent(.name)
         try super.init(from: decoder)

--- a/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
+++ b/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift
@@ -75,6 +75,7 @@ extension PBXCopyFilesBuildPhase {
     func isEqual(to rhs: PBXCopyFilesBuildPhase) -> Bool {
         if dstPath != rhs.dstPath { return false }
         if dstSubfolderSpec != rhs.dstSubfolderSpec { return false }
+        if dstSubfolder != rhs.dstSubfolder { return false }
         if name != rhs.name { return false }
         return super.isEqual(to: rhs)
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/XcodeProj/issues/1034

### Short description 📝

Added support for `dstSubfoler`

### Solution 📦

Added support for `dstSubfolder`. Tried to find all cases for the new one, but not sure
Deprecated the `dstSubfolderSpec`

### Implementation 👩‍💻👨‍💻

- [X] Added new string enum for `dstSubfolder`
- [X] Marked the old one as deprecated

(This is my first contribution to the project. I'm happy to make changes if needed)