### PR TITLE
feat: Xcode 26.3 format updates

### DIFF
--- a/Fixtures/Schemes/DebugAsRoot.xcscheme
+++ b/Fixtures/Schemes/DebugAsRoot.xcscheme
@@ -28,8 +28,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Fixtures/SynchronizedRootGroups/SynchronizedRootGroups.xcodeproj/project.pbxproj
+++ b/Fixtures/SynchronizedRootGroups/SynchronizedRootGroups.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 73;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -23,7 +23,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		6CF05BA32C53F97F00EF267F /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		6CF05BA32C53F97F00EF267F /* Exceptions for "SynchronizedRootGroups" folder in "SynchronizedRootGroups" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Exception/Exception.swift,
@@ -33,7 +33,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
-		F841A9D12D63B00A00059ED6 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {
+		F841A9D12D63B00A00059ED6 /* Exceptions for "SynchronizedRootGroups" folder in "Copy Files" phase from "SynchronizedRootGroups" target */ = {
 			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
 			attributesByRelativePath = {
 				XPCService.xpc = (
@@ -48,7 +48,15 @@
 /* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		6CF05B9D2C53F64800EF267F /* SynchronizedRootGroups */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (6CF05BA32C53F97F00EF267F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, F841A9D12D63B00A00059ED6 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SynchronizedRootGroups; sourceTree = "<group>"; };
+		6CF05B9D2C53F64800EF267F /* SynchronizedRootGroups */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				6CF05BA32C53F97F00EF267F /* Exceptions for "SynchronizedRootGroups" folder in "SynchronizedRootGroups" target */,
+				F841A9D12D63B00A00059ED6 /* Exceptions for "SynchronizedRootGroups" folder in "Copy Files" phase from "SynchronizedRootGroups" target */,
+			);
+			path = SynchronizedRootGroups;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,7 +146,7 @@
 				Base,
 			);
 			mainGroup = 6CF05B822C53F5F200EF267F;
-			preferredProjectObjectVersion = 60;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 6CF05B8D2C53F5F200EF267F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/Fixtures/SynchronizedRootGroups/SynchronizedRootGroups/XPCService.xpc/Info.plist
+++ b/Fixtures/SynchronizedRootGroups/SynchronizedRootGroups/XPCService.xpc/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.XPCService</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>XPCService</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+	</dict>
+</dict>
+</plist>

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -81,12 +81,6 @@
             </ActionContent>
          </ExecutionAction>
       </PostActions>
-      <TestPlans>
-         <TestPlanReference
-            default = "YES"
-            reference = "container:iOS.xctestplan">
-         </TestPlanReference>
-      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -96,19 +90,6 @@
             ReferencedContainer = "container:Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            useTestSelectionWhitelist = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "23766C251EAA3484007A9026"
-               BuildableName = "iOSTests.xctest"
-               BlueprintName = "iOSTests"
-               ReferencedContainer = "container:Project.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "MyTestArgument"
@@ -122,6 +103,24 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:iOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "23766C251EAA3484007A9026"
+               BuildableName = "iOSTests.xctest"
+               BlueprintName = "iOSTests"
+               ReferencedContainer = "container:Project.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -131,9 +130,9 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      customLaunchCommand = "custom command"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      customLaunchCommand = "custom command">
+      allowLocationSimulation = "YES">
       <PreActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
@@ -180,10 +179,6 @@
             ReferencedContainer = "container:Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <LocationScenarioReference
-         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
-         referenceType = "1">
-      </LocationScenarioReference>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "MyLaunchArgument"
@@ -197,6 +192,10 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
       <StoreKitConfigurationFileReference
          identifier = "../../Configuration.storekit">
       </StoreKitConfigurationFileReference>

--- a/Fixtures/iOS/Project.xcodeproj/xcuserdata/username1.xcuserdatad/xcschemes/iOS-debug.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcuserdata/username1.xcuserdatad/xcschemes/iOS-debug.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Fixtures/iOS/Project.xcodeproj/xcuserdata/username1.xcuserdatad/xcschemes/iOS-other.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcuserdata/username1.xcuserdatad/xcschemes/iOS-other.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Fixtures/iOS/Project.xcodeproj/xcuserdata/username1.xcuserdatad/xcschemes/iOS-release.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcuserdata/username1.xcuserdatad/xcschemes/iOS-release.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"

--- a/Fixtures/iOS/Project.xcodeproj/xcuserdata/username2.xcuserdatad/xcschemes/iOSTests.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcuserdata/username2.xcuserdatad/xcschemes/iOSTests.xcscheme
@@ -15,8 +15,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            useTestSelectionWhitelist = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "23766C251EAA3484007A9026"

--- a/Fixtures/iOS/Project.xcodeproj/xcuserdata/username3.xcuserdatad/xcschemes/custom-scheme.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcuserdata/username3.xcuserdatad/xcschemes/custom-scheme.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
@@ -58,6 +58,7 @@ let attributesOrder: [String: [String]] = [
         "customWorkingDirectory",
         "ignoresPersistentStateOnLaunch",
         "debugDocumentVersioning",
+        "customLaunchCommand",
         "debugServiceExtension",
         "enableGPUFrameCaptureMode",
         "enableGPUValidationMode",
@@ -90,6 +91,10 @@ let attributesOrder: [String: [String]] = [
         "skipped",
         "parallelizable",
         "testExecutionOrdering",
+    ],
+    "TestPlanReference": [
+        "reference",
+        "default",
     ],
     "BreakpointContent": [
         "shouldBeEnabled",

--- a/Sources/XcodeProj/Objects/BuildPhase/PBXBuildPhase.swift
+++ b/Sources/XcodeProj/Objects/BuildPhase/PBXBuildPhase.swift
@@ -144,6 +144,29 @@ public extension PBXBuildPhase {
         buildPhase
     }
 
+    /// Returns the target this build phase belongs to, if any.
+    ///
+    /// - Returns: the owning target, or nil if not found.
+    func target() -> PBXTarget? {
+        guard let projectObjects = try? objects() else { return nil }
+        let allTargets: [PBXTarget] = Array(projectObjects.nativeTargets.values)
+            + Array(projectObjects.legacyTargets.values)
+            + Array(projectObjects.aggregateTargets.values)
+        return allTargets.first { $0.buildPhaseReferences.map(\.value).contains(reference.value) }
+    }
+
+    /// Human-readable display name, used in descriptive comment strings.
+    ///
+    /// - Returns: display name matching Xcode's comment format.
+    func displayName() -> String? {
+        if let phase = self as? PBXCopyFilesBuildPhase {
+            return phase.name ?? "Copy Files"
+        } else if let phase = self as? PBXShellScriptBuildPhase {
+            return phase.name ?? "Run Script"
+        }
+        return name()
+    }
+
     /// Build phase name.
     ///
     /// - Returns: build phase name.

--- a/Sources/XcodeProj/Objects/Files/PBXFileElement.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileElement.swift
@@ -139,6 +139,16 @@ public class PBXFileElement: PBXContainerItem, PlistSerializable {
         guard let rhs = object as? PBXFileElement else { return false }
         return isEqual(to: rhs)
     }
+
+    // This method is needed to recursively set the parent to all elements.
+    // This allows us to more quickly find the full path to the elements.
+    func assignParentToChildren() {
+        guard let group = self as? PBXGroup else { return }
+        for child in group.children {
+            child.parent = self
+            child.assignParentToChildren()
+        }
+    }
 }
 
 // MARK: - Helpers
@@ -205,15 +215,5 @@ public extension PBXFileElement {
             .compactMap({ try $0.getThrowingObject() as PBXFileElement })
             .first(where: { $0.name == "Base" }) else { return nil }
         return baseReference.path
-    }
-
-    // This method is needed to recursively set the parent to all elements.
-    // This allows us to more quickly find the full path to the elements.
-    func assignParentToChildren() {
-        guard let group = self as? PBXGroup else { return }
-        for child in group.children {
-            child.parent = self
-            child.assignParentToChildren()
-        }
     }
 }

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedBuildFileExceptionSet.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedBuildFileExceptionSet.swift
@@ -96,6 +96,11 @@ public class PBXFileSystemSynchronizedBuildFileExceptionSet: PBXFileSystemSynchr
 
     // MARK: - PlistSerializable
 
+    override var plistComment: String {
+        let folder = synchronizedRootGroup?.fileName() ?? ""
+        return "Exceptions for \"\(folder)\" folder in \"\(target.name)\" target"
+    }
+
     func plistKeyAndValue(proj _: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(PBXFileSystemSynchronizedBuildFileExceptionSet.isa))
@@ -124,6 +129,6 @@ public class PBXFileSystemSynchronizedBuildFileExceptionSet: PBXFileSystemSynchr
             }))
         }
         dictionary["target"] = .string(CommentedString(target.reference.value, comment: target.name))
-        return (key: CommentedString(reference, comment: "PBXFileSystemSynchronizedBuildFileExceptionSet"), value: .dictionary(dictionary))
+        return (key: CommentedString(reference, comment: plistComment), value: .dictionary(dictionary))
     }
 }

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedExceptionSet.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedExceptionSet.swift
@@ -1,4 +1,10 @@
 import Foundation
 
 /// Common class for exception sets, such as `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet` and `PBXFileSystemSynchronizedBuildFileExceptionSet`
-public class PBXFileSystemSynchronizedExceptionSet: PBXObject {}
+public class PBXFileSystemSynchronizedExceptionSet: PBXObject {
+    /// The synchronized root group this exception set belongs to.
+    public internal(set) weak var synchronizedRootGroup: PBXFileSystemSynchronizedRootGroup?
+
+    /// The comment string used when this object is referenced in a plist.
+    var plistComment: String { type(of: self).isa }
+}

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet.swift
@@ -66,6 +66,14 @@ public class PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet: PBX
 
     // MARK: - PlistSerializable
 
+    override var plistComment: String {
+        guard let group = synchronizedRootGroup else { return type(of: self).isa }
+        let folder = group.fileName() ?? ""
+        let phase = buildPhase.displayName() ?? ""
+        let target = buildPhase.target()?.name ?? ""
+        return "Exceptions for \"\(folder)\" folder in \"\(phase)\" phase from \"\(target)\" target"
+    }
+
     func plistKeyAndValue(proj _: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(type(of: self).isa))
@@ -78,6 +86,6 @@ public class PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet: PBX
             }))
         }
         dictionary["buildPhase"] = .string(CommentedString(buildPhase.reference.value, comment: buildPhase.name() ?? "CopyFiles"))
-        return (key: CommentedString(reference, comment: "PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet"), value: .dictionary(dictionary))
+        return (key: CommentedString(reference, comment: plistComment), value: .dictionary(dictionary))
     }
 }

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
@@ -84,8 +84,6 @@ public class PBXFileSystemSynchronizedRootGroup: PBXFileElement {
 
     // MARK: - PlistSerializable
 
-    override var multiline: Bool { (exceptions?.count ?? 0) < 2 }
-
     override func assignParentToChildren() {
         super.assignParentToChildren()
         exceptions?.forEach { $0.synchronizedRootGroup = self }

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
@@ -15,6 +15,7 @@ public class PBXFileSystemSynchronizedRootGroup: PBXFileElement {
     public var exceptions: [PBXFileSystemSynchronizedExceptionSet]? {
         set {
             exceptionsReferences = newValue?.references()
+            newValue?.forEach { $0.synchronizedRootGroup = self }
         }
         get {
             exceptionsReferences?.objects()
@@ -85,12 +86,17 @@ public class PBXFileSystemSynchronizedRootGroup: PBXFileElement {
 
     override var multiline: Bool { (exceptions?.count ?? 0) < 2 }
 
+    override func assignParentToChildren() {
+        super.assignParentToChildren()
+        exceptions?.forEach { $0.synchronizedRootGroup = self }
+    }
+
     override func plistKeyAndValue(proj: PBXProj, reference: String) throws -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = try super.plistKeyAndValue(proj: proj, reference: reference).value.dictionary ?? [:]
         dictionary["isa"] = .string(CommentedString(type(of: self).isa))
         if let exceptions, !exceptions.isEmpty {
             dictionary["exceptions"] = .array(exceptions.map { exception in
-                .string(CommentedString(exception.reference.value, comment: type(of: exception).isa))
+                .string(CommentedString(exception.reference.value, comment: exception.plistComment))
             })
         }
         if let explicitFileTypes, !explicitFileTypes.isEmpty {

--- a/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
+++ b/Sources/XcodeProj/Objects/Files/PBXFileSystemSynchronizedRootGroup.swift
@@ -93,13 +93,16 @@ public class PBXFileSystemSynchronizedRootGroup: PBXFileElement {
                 .string(CommentedString(exception.reference.value, comment: type(of: exception).isa))
             })
         }
-        if let explicitFileTypes {
+        if let explicitFileTypes, !explicitFileTypes.isEmpty {
             dictionary["explicitFileTypes"] = .dictionary(Dictionary(uniqueKeysWithValues: explicitFileTypes.map { relativePath, fileType in
                 (CommentedString(relativePath), .string(CommentedString(fileType)))
             }))
         }
-        if let explicitFolders {
+        if let explicitFolders, !explicitFolders.isEmpty {
             dictionary["explicitFolders"] = .array(explicitFolders.map { .string(CommentedString($0)) })
+        }
+        if name == path {
+            dictionary["name"] = nil
         }
         return (key: CommentedString(reference,
                                      comment: name ?? path),

--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -328,6 +328,7 @@ public enum Xcode {
         "xcsynspec": "text.plist.xcsynspec",
         "xctarget": "wrapper.pb-target",
         "xctest": "wrapper.cfbundle",
+        "xctestplan": "text",
         "xctxtmacro": "text.plist.xctxtmacro",
         "xcworkspace": "wrapper.workspace",
         "xhtml": "text.xml",

--- a/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift
@@ -158,8 +158,8 @@ public extension XCScheme {
                 attributes["buildArchitectures"] = buildArchitecturesXMLString
             }
 
-            if let runPostActionsOnFailure {
-                attributes["runPostActionsOnFailure"] = runPostActionsOnFailure.xmlString
+            if runPostActionsOnFailure == true {
+                attributes["runPostActionsOnFailure"] = "YES"
             }
 
             let element = AEXMLElement(name: "BuildAction",

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -436,6 +436,14 @@ public extension XCScheme {
                 element.addChild(runnable.xmlElement())
             }
 
+            if let commandlineArguments, !commandlineArguments.arguments.isEmpty {
+                element.addChild(commandlineArguments.xmlElement())
+            }
+
+            if let environmentVariables {
+                element.addChild(EnvironmentVariable.xmlElement(from: environmentVariables))
+            }
+
             if let locationScenarioReference {
                 element.addChild(locationScenarioReference.xmlElement())
             }
@@ -443,14 +451,6 @@ public extension XCScheme {
             if let macroExpansion {
                 let macro = element.addChild(name: "MacroExpansion")
                 macro.addChild(macroExpansion.xmlElement())
-            }
-
-            if let commandlineArguments {
-                element.addChild(commandlineArguments.xmlElement())
-            }
-
-            if let environmentVariables {
-                element.addChild(EnvironmentVariable.xmlElement(from: environmentVariables))
             }
 
             if let language {

--- a/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift
@@ -167,8 +167,8 @@ public extension XCScheme {
             if codeCoverageEnabled {
                 attributes["codeCoverageEnabled"] = codeCoverageEnabled.xmlString
             }
-            if let onlyGenerateCoverageForSpecifiedTargets {
-                attributes["onlyGenerateCoverageForSpecifiedTargets"] = onlyGenerateCoverageForSpecifiedTargets.xmlString
+            if onlyGenerateCoverageForSpecifiedTargets == true {
+                attributes["onlyGenerateCoverageForSpecifiedTargets"] = "YES"
             }
             if enableAddressSanitizer {
                 attributes["enableAddressSanitizer"] = enableAddressSanitizer.xmlString
@@ -204,6 +204,19 @@ public extension XCScheme {
             let element = AEXMLElement(name: "TestAction", value: nil, attributes: attributes)
             super.writeXML(parent: element)
 
+            if let macroExpansion {
+                let macro = element.addChild(name: "MacroExpansion")
+                macro.addChild(macroExpansion.xmlElement())
+            }
+
+            if let commandlineArguments, !commandlineArguments.arguments.isEmpty {
+                element.addChild(commandlineArguments.xmlElement())
+            }
+
+            if let environmentVariables {
+                element.addChild(EnvironmentVariable.xmlElement(from: environmentVariables))
+            }
+
             if let testPlans {
                 let testPlansElement = element.addChild(name: "TestPlans")
                 for testPlan in testPlans {
@@ -211,22 +224,11 @@ public extension XCScheme {
                 }
             }
 
-            if let macroExpansion {
-                let macro = element.addChild(name: "MacroExpansion")
-                macro.addChild(macroExpansion.xmlElement())
-            }
-
-            let testablesElement = element.addChild(name: "Testables")
-            for testable in testables {
-                testablesElement.addChild(testable.xmlElement())
-            }
-
-            if let commandlineArguments {
-                element.addChild(commandlineArguments.xmlElement())
-            }
-
-            if let environmentVariables {
-                element.addChild(EnvironmentVariable.xmlElement(from: environmentVariables))
+            if !testables.isEmpty {
+                let testablesElement = element.addChild(name: "Testables")
+                for testable in testables {
+                    testablesElement.addChild(testable.xmlElement())
+                }
             }
 
             if !additionalOptions.isEmpty {

--- a/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift
@@ -43,7 +43,7 @@ public extension XCScheme {
                 parallelization = .swiftTestingOnly
             }
 
-            useTestSelectionWhitelist = element.attributes["useTestSelectionWhitelist"] == "YES"
+            useTestSelectionWhitelist = element.attributes["useTestSelectionWhitelist"].map { $0 == "YES" }
             randomExecutionOrdering = element.attributes["testExecutionOrdering"] == "random"
             buildableReference = try BuildableReference(element: element["BuildableReference"])
 
@@ -79,8 +79,8 @@ public extension XCScheme {
                 break // SwiftTesting is inferred by the lack of a value
             }
 
-            if let useTestSelectionWhitelist {
-                attributes["useTestSelectionWhitelist"] = useTestSelectionWhitelist.xmlString
+            if useTestSelectionWhitelist == true {
+                attributes["useTestSelectionWhitelist"] = "YES"
             }
             attributes["testExecutionOrdering"] = randomExecutionOrdering ? "random" : nil
             let element = AEXMLElement(name: "TestableReference",

--- a/Tests/XcodeProjTests/Objects/Files/PBXFileSystemSynchronizedBuildFileExceptionSetTests.swift
+++ b/Tests/XcodeProjTests/Objects/Files/PBXFileSystemSynchronizedBuildFileExceptionSetTests.swift
@@ -75,4 +75,25 @@ final class PBXFileSystemSynchronizedBuildFileExceptionSetTests: XCTestCase {
 
         XCTAssertNil(plistValue.dictionary?[CommentedString("platformFiltersByRelativePath")])
     }
+
+    func test_plistComment_withSynchronizedRootGroup_returnsDescriptiveComment() {
+        let group = PBXFileSystemSynchronizedRootGroup(sourceTree: .group, path: "Sources", exceptions: [subject])
+        XCTAssertEqual(subject.plistComment, "Exceptions for \"Sources\" folder in \"Test\" target")
+        withExtendedLifetime(group) {}
+    }
+
+    func test_plistComment_exceptionsAssignedViaSetter_returnsDescriptiveComment() {
+        let group = PBXFileSystemSynchronizedRootGroup(sourceTree: .group, path: "Sources")
+        group.exceptions = [subject]
+        XCTAssertEqual(subject.plistComment, "Exceptions for \"Sources\" folder in \"Test\" target")
+        withExtendedLifetime(group) {}
+    }
+
+    func test_plistKeyAndValue_keyComment_matchesPlistComment() throws {
+        let proj = PBXProj()
+        let group = PBXFileSystemSynchronizedRootGroup(sourceTree: .group, path: "Sources", exceptions: [subject])
+        let (key, _) = try subject.plistKeyAndValue(proj: proj, reference: "ref")
+        XCTAssertEqual(key.comment, subject.plistComment)
+        withExtendedLifetime(group) {}
+    }
 }

--- a/Tests/XcodeProjTests/Objects/Files/PBXFileSystemSynchronizedRootGroupTests.swift
+++ b/Tests/XcodeProjTests/Objects/Files/PBXFileSystemSynchronizedRootGroupTests.swift
@@ -48,4 +48,46 @@ final class PBXFileSystemSynchronizedRootGroupTests: XCTestCase {
                                                          explicitFolders: [])
         XCTAssertEqual(subject, another)
     }
+
+    // MARK: - plistKeyAndValue
+
+    func test_plistKeyAndValue_explicitFileTypes_serializedOnlyWhenNonEmpty() throws {
+        let (_, nonEmpty) = try subject.plistKeyAndValue(proj: PBXProj(), reference: "ref")
+        XCTAssertNotNil(nonEmpty.dictionary?[CommentedString("explicitFileTypes")])
+
+        subject.explicitFileTypes = [:]
+        let (_, empty) = try subject.plistKeyAndValue(proj: PBXProj(), reference: "ref")
+        XCTAssertNil(empty.dictionary?[CommentedString("explicitFileTypes")])
+    }
+
+    func test_plistKeyAndValue_explicitFolders_serializedOnlyWhenNonEmpty() throws {
+        let (_, empty) = try subject.plistKeyAndValue(proj: PBXProj(), reference: "ref")
+        XCTAssertNil(empty.dictionary?[CommentedString("explicitFolders")])
+
+        subject.explicitFolders = ["SubFolder"]
+        let (_, nonEmpty) = try subject.plistKeyAndValue(proj: PBXProj(), reference: "ref")
+        XCTAssertNotNil(nonEmpty.dictionary?[CommentedString("explicitFolders")])
+    }
+
+    func test_plistKeyAndValue_name_serializedOnlyWhenDifferentFromPath() throws {
+        let (_, same) = try subject.plistKeyAndValue(proj: PBXProj(), reference: "ref")
+        XCTAssertNil(same.dictionary?[CommentedString("name")])
+
+        subject.name = "Display Name"
+        let (_, different) = try subject.plistKeyAndValue(proj: PBXProj(), reference: "ref")
+        XCTAssertEqual(different.dictionary?[CommentedString("name")], .string(CommentedString("Display Name")))
+    }
+
+    func test_plistKeyAndValue_exceptionReference_usesDescriptiveComment() throws {
+        let (_, value) = try subject.plistKeyAndValue(proj: PBXProj(), reference: "ref")
+        let exceptionsArray = try XCTUnwrap(value.dictionary?[CommentedString("exceptions")]?.array)
+        let entry = try XCTUnwrap(exceptionsArray.first?.string)
+        XCTAssertEqual(entry.comment, "Exceptions for \"synchronized\" folder in \"Test\" target")
+    }
+
+    // MARK: - assignParentToChildren
+
+    func test_assignParentToChildren_wiresSynchronizedRootGroup() {
+        XCTAssertIdentical(exception.synchronizedRootGroup, subject)
+    }
 }

--- a/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
+++ b/Tests/XcodeProjTests/Objects/Project/PBXProjEncoderTests.swift
@@ -294,7 +294,15 @@
             let lines = lines(fromFile: encodeProject(settings: settings))
 
             let beginGroup = lines.findLine("/* Begin PBXFileSystemSynchronizedRootGroup section */")
-            var line = lines.validate(line: "6CF05B9D2C53F64800EF267F /* SynchronizedRootGroups */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (6CF05BA32C53F97F00EF267F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, F841A9D12D63B00A00059ED6 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SynchronizedRootGroups; sourceTree = \"<group>\"; };", after: beginGroup)
+            var line = lines.validate(line: "6CF05B9D2C53F64800EF267F /* SynchronizedRootGroups */ = {", after: beginGroup)
+            line = lines.validate(line: "isa = PBXFileSystemSynchronizedRootGroup;", after: line)
+            line = lines.validate(line: "exceptions = (", after: line)
+            line = lines.validate(line: "6CF05BA32C53F97F00EF267F /* Exceptions for \"SynchronizedRootGroups\" folder in \"SynchronizedRootGroups\" target */,", after: line)
+            line = lines.validate(line: "F841A9D12D63B00A00059ED6 /* Exceptions for \"SynchronizedRootGroups\" folder in \"Copy Files\" phase from \"SynchronizedRootGroups\" target */,", after: line)
+            line = lines.validate(line: ");", after: line)
+            line = lines.validate(line: "path = SynchronizedRootGroups;", after: line)
+            line = lines.validate(line: "sourceTree = \"<group>\";", after: line)
+            line = lines.validate(line: "};", after: line)
             line = lines.validate(line: "/* End PBXFileSystemSynchronizedRootGroup section */", after: line)
         }
 
@@ -307,7 +315,7 @@
             let lines = lines(fromFile: encodeProject(settings: settings))
 
             let beginGroup = lines.findLine("/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */")
-            var line = lines.validate(line: "6CF05BA32C53F97F00EF267F /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {", after: beginGroup)
+            var line = lines.validate(line: "6CF05BA32C53F97F00EF267F /* Exceptions for \"SynchronizedRootGroups\" folder in \"SynchronizedRootGroups\" target */ = {", after: beginGroup)
             line = lines.validate(line: "isa = PBXFileSystemSynchronizedBuildFileExceptionSet;", after: line)
             line = lines.validate(line: "membershipExceptions = (", after: line)
             line = lines.validate(line: "Exception/Exception.swift,", after: line)
@@ -326,7 +334,7 @@
             let lines = lines(fromFile: encodeProject(settings: settings))
 
             let beginGroup = lines.findLine("/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */")
-            var line = lines.validate(line: "F841A9D12D63B00A00059ED6 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {", after: beginGroup)
+            var line = lines.validate(line: "F841A9D12D63B00A00059ED6 /* Exceptions for \"SynchronizedRootGroups\" folder in \"Copy Files\" phase from \"SynchronizedRootGroups\" target */ = {", after: beginGroup)
             line = lines.validate(line: "isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;", after: line)
             line = lines.validate(line: "attributesByRelativePath = {", after: line)
             line = lines.validate(line: "XPCService.xpc = (", after: line)

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -491,7 +491,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
         XCTAssertEqual(scheme.testAction?.testables.first?.skipped, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.parallelization, .swiftTestingOnly)
         XCTAssertEqual(scheme.testAction?.testables.first?.randomExecutionOrdering, false)
-        XCTAssertEqual(scheme.testAction?.testables.first?.useTestSelectionWhitelist, false)
+        XCTAssertNil(scheme.testAction?.testables.first?.useTestSelectionWhitelist)
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableIdentifier, "primary")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.blueprintIdentifier, "23766C251EAA3484007A9026")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableName, "iOSTests.xctest")


### PR DESCRIPTION
Updates xcscheme and pbxproj serialization to better match the format written by Xcode 26.3.

### Short description 📝
Opening projects generated with XcodeProj creates diffs in the generated files. I understand this is an endless cat-and-mice game, but thought it's generally a design aspect of this project, to get as close to what Xcode does as possible. As such, I've taken the chance and addressed the things that came to my attention, with absolutely no guarantee these are complete or anything. They just address the issues I've ran into.

### Solution 📦
The changes are mostly just formatting fixes, some default value changes and one minor code extension to comments generated for synchronized folder exceptions.

### Implementation 👩‍💻👨‍💻

#### Changes to XCScheme

- Reorder TestAction children: MacroExpansion, CommandLineArguments, EnvironmentVariables now precede TestPlans and Testables
- Reorder LaunchAction children: CommandLineArguments and   EnvironmentVariables now precede LocationScenarioReference
- Add TestPlanReference to attribute ordering (reference before default)
- Add customLaunchCommand to LaunchAction attribute ordering (between debugDocumentVersioning and debugServiceExtension)
- Omit empty Testables and CommandLineArguments elements (Xcode strips them when empty)
- Write runPostActionsOnFailure, onlyGenerateCoverageForSpecifiedTargets, and useTestSelectionWhitelist attributes only when true (Xcode strips the redundant "NO" default)
- Fix useTestSelectionWhitelist parsing to distinguish absent (nil) from explicitly set to "NO"

#### Changes to PBXProj

- Add `xctestplan` → `text` to the file type table so `.xctestplan` references get `lastKnownFileType = text`
- Omit empty `explicitFileTypes` and `explicitFolders` on `PBXFileSystemSynchronizedRootGroup`
- Omit `name` from `PBXFileSystemSynchronizedRootGroup` when it is identical to `path`, matching Xcode's normalization
- Generate descriptive plist comments for PBXFileSystemSynchronizedExceptionSet classes

### Notes 📝

The very last change is a bit more complex, since the comments need more info than currently present in the classes. Introduce a `plistComment` property on `PBXFileSystemSynchronizedExceptionSet` (base, returns ISA) and override it in subclasses to produce Xcode 26.3's format: `Exceptions for "<folder>" folder in "<target>" target`. The back-reference to the owning root group is established via an `assignParentToChildren()` override, consistent with how `PBXFileElement.parent` is wired up for the group hierarchy.

I've also updated tests and hope the changes match the projects style. Happy to make any changes as needed.