### PR TITLE
feat: add optional debugAsWhichUser to XCScheme.LaunchAction

### DIFF
--- a/Fixtures/Schemes/DebugAsRoot.xcscheme
+++ b/Fixtures/Schemes/DebugAsRoot.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XcodeProj"
+               BuildableName = "XcodeProj"
+               BlueprintName = "XcodeProj"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      debugAsWhichUser = "root">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CC725022DA91FB6004D43D4"
+            BuildableName = "app_clip.app"
+            BlueprintName = "app_clip"
+            ReferencedContainer = "container:example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "XcodeProj"
+            BuildableName = "XcodeProj"
+            BlueprintName = "XcodeProj"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
+++ b/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
@@ -62,6 +62,7 @@ let attributesOrder: [String: [String]] = [
         "enableGPUFrameCaptureMode",
         "enableGPUValidationMode",
         "allowLocationSimulation",
+        "debugAsWhichUser",
         "storeKitConfigurationFileReference",
     ],
     "ProfileAction": [

--- a/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
+++ b/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift
@@ -85,6 +85,7 @@ public extension XCScheme {
         public var customLaunchCommand: String?
         public var customLLDBInitFile: String?
         public var appClipInvocationURLString: String?
+        public var debugAsWhichUser: String?
 
         // MARK: - Init
 
@@ -128,7 +129,8 @@ public extension XCScheme {
                     storeKitConfigurationFileReference: StoreKitConfigurationFileReference? = nil,
                     customLaunchCommand: String? = nil,
                     customLLDBInitFile: String? = nil,
-                    appClipInvocationURLString: String? = nil) {
+                    appClipInvocationURLString: String? = nil,
+                    debugAsWhichUser: String? = nil) {
             self.runnable = runnable
             self.macroExpansion = macroExpansion
             self.buildConfiguration = buildConfiguration
@@ -168,6 +170,7 @@ public extension XCScheme {
             self.customLaunchCommand = customLaunchCommand
             self.customLLDBInitFile = customLLDBInitFile
             self.appClipInvocationURLString = appClipInvocationURLString
+            self.debugAsWhichUser = debugAsWhichUser
             super.init(preActions, postActions)
         }
 
@@ -214,7 +217,8 @@ public extension XCScheme {
             storeKitConfigurationFileReference: StoreKitConfigurationFileReference? = nil,
             customLaunchCommand: String? = nil,
             customLLDBInitFile: String? = nil,
-            appClipInvocationURLString: String? = nil
+            appClipInvocationURLString: String? = nil,
+            debugAsWhichUser: String? = nil
         ) {
             self.init(
                 runnable: pathRunnable,
@@ -257,7 +261,8 @@ public extension XCScheme {
                 storeKitConfigurationFileReference: storeKitConfigurationFileReference,
                 customLaunchCommand: customLaunchCommand,
                 customLLDBInitFile: customLLDBInitFile,
-                appClipInvocationURLString: appClipInvocationURLString
+                appClipInvocationURLString: appClipInvocationURLString,
+                debugAsWhichUser: debugAsWhichUser
             )
         }
 
@@ -344,6 +349,7 @@ public extension XCScheme {
             }
 
             appClipInvocationURLString = element.attributes["appClipInvocationURLString"]
+            debugAsWhichUser = element.attributes["debugAsWhichUser"]
 
             try super.init(element: element)
         }
@@ -413,6 +419,9 @@ public extension XCScheme {
             }
             if let appClipInvocationURLString {
                 attributes["appClipInvocationURLString"] = appClipInvocationURLString
+            }
+            if let debugAsWhichUser {
+                attributes["debugAsWhichUser"] = debugAsWhichUser
             }
 
             return attributes
@@ -524,7 +533,8 @@ public extension XCScheme {
                 storeKitConfigurationFileReference == rhs.storeKitConfigurationFileReference &&
                 customLaunchCommand == rhs.customLaunchCommand &&
                 customLLDBInitFile == rhs.customLLDBInitFile &&
-                appClipInvocationURLString == rhs.appClipInvocationURLString
+                appClipInvocationURLString == rhs.appClipInvocationURLString &&
+                debugAsWhichUser == rhs.debugAsWhichUser
         }
     }
 }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -75,7 +75,7 @@ final class XCSchemeIntegrationTests: XCTestCase {
 
     func test_read_debugAsRootScheme() throws {
         let subject = try XCScheme(path: debugAsRootSchemePath)
-        
+
         XCTAssertNotNil(subject.launchAction)
         XCTAssertEqual(subject.launchAction?.debugAsWhichUser, "root")
     }

--- a/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
+++ b/Tests/XcodeProjTests/Scheme/XCSchemeTests.swift
@@ -73,6 +73,27 @@ final class XCSchemeIntegrationTests: XCTestCase {
                       assertion: { assert(minimalScheme: $1) })
     }
 
+    func test_read_debugAsRootScheme() throws {
+        let subject = try XCScheme(path: debugAsRootSchemePath)
+        
+        XCTAssertNotNil(subject.launchAction)
+        XCTAssertEqual(subject.launchAction?.debugAsWhichUser, "root")
+    }
+
+    func test_write_debugAsRootScheme() throws {
+        try testWrite(from: debugAsRootSchemePath,
+                      initModel: { try? XCScheme(path: $0) },
+                      modify: { $0 },
+                      assertion: { _, scheme in
+                          XCTAssertEqual(scheme.launchAction?.debugAsWhichUser, "root")
+                      })
+    }
+
+    func test_read_write_debugAsRootScheme_produces_no_diff() throws {
+        try testReadWriteProducesNoDiff(from: debugAsRootSchemePath,
+                                        initModel: XCScheme.init(path:))
+    }
+
     func test_write_testableReferenceDefaultAttributesValuesAreOmitted() {
         let reference = XCScheme.TestableReference(
             skipped: false,
@@ -945,5 +966,9 @@ final class XCSchemeIntegrationTests: XCTestCase {
 
     private var appClipScheme: Path {
         fixturesPath() + "Schemes/AppClip.xcscheme"
+    }
+
+    private var debugAsRootSchemePath: Path {
+        fixturesPath() + "Schemes/DebugAsRoot.xcscheme"
     }
 }


### PR DESCRIPTION
### Short description 📝
> As a developer I want to be able to control the "Debug Process as..." setting within the Run action of a scheme so that I can easily construct projects that will launch scripts as root or test multi-user macOS apps.

### Solution 📦
> I first created a proof-of-concept scheme and used Xcode's GUI to set the "Debug Process as.." setting to "root".  Then I looked at the resulting .xcscheme file and saw that it used an XML property named "debugAsWhichUser".  I added that property to the `XCScheme.LaunchAction` type which models the Run action from the scheme file.

### Implementation 👩‍💻👨‍💻
> Detail in a checklist the steps that you took to implement the PR.

- [x] Added the optional property.
- [x] Added a fixture .xcscheme file to the unit tests that is copied from Xcode's GUI creation of schemes.
- [x] Added unit tests showing the `XCScheme.LaunchAction.debugAsWhichUser` property is both read from and written to .xcscheme files.
- [x] All other unit tests pass with no changes.
