### PR TITLE
Fix Icon Composer file type detection

### DIFF
--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -175,6 +175,7 @@ public enum Xcode {
         "i": "sourcecode.c.c.preprocessed",
         "icns": "image.icns",
         "ico": "image.ico",
+        "icon": "folder.iconcomposer.icon",
         "iconset": "folder.iconset",
         "ii": "sourcecode.cpp.cpp.preprocessed",
         "iig": "sourcecode.iig",

--- a/Tests/XcodeProjTests/Project/XcodeTests.swift
+++ b/Tests/XcodeProjTests/Project/XcodeTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+@testable import XcodeProj
+
+final class XcodeTests: XCTestCase {
+    func test_filetype_whenIconComposerBundle() {
+        XCTAssertEqual(Xcode.filetype(extension: "icon"), "folder.iconcomposer.icon")
+    }
+}


### PR DESCRIPTION
## What changed

- Map the `.icon` extension to Xcode’s `folder.iconcomposer.icon` file type.
- Add a regression test for Icon Composer bundles.

## Why

Icon Composer introduced `.icon` bundles in Xcode 26. XcodeProj currently has no mapping for that extension, so generated `PBXFileReference` objects omit `lastKnownFileType`. In clean Xcode Cloud environments, the bundle can then be treated as an ordinary copied resource instead of an asset-catalog input. `actool` receives only `Assets.xcassets` and archive fails with: `None of the input catalogs contained ... AppIcon`.

Explicitly identifying the bundle with Xcode’s native file type makes generated projects deterministic and ensures Icon Composer files participate in asset compilation.

## Validation

- `swift test --filter XcodeTests`
- Confirmed the generated reference becomes `lastKnownFileType = folder.iconcomposer.icon`.
- Confirmed an affected iOS project completes a Release device archive and IPA export with the explicit type.