### PR TITLE
fix: recognize Icon Composer .icon file type

### DIFF
--- a/Sources/XcodeProj/Project/Xcode.swift
+++ b/Sources/XcodeProj/Project/Xcode.swift
@@ -175,6 +175,7 @@ public enum Xcode {
         "i": "sourcecode.c.c.preprocessed",
         "icns": "image.icns",
         "ico": "image.ico",
+        "icon": "folder.iconcomposer.icon",
         "iconset": "folder.iconset",
         "ii": "sourcecode.cpp.cpp.preprocessed",
         "iig": "sourcecode.iig",

--- a/Tests/XcodeProjTests/Project/XcodeTests.swift
+++ b/Tests/XcodeProjTests/Project/XcodeTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+@testable import XcodeProj
+
+final class XcodeTests: XCTestCase {
+    func test_filetype_whenIconComposerBundle() {
+        XCTAssertEqual(Xcode.filetype(extension: "icon"), "folder.iconcomposer.icon")
+    }
+}


### PR DESCRIPTION
### Short description 📝

This change recognizes Xcode 26 Icon Composer `.icon` bundles during file-reference generation.

### Solution 📦

Xcode maps the `icon` extension to `folder.iconcomposer.icon`.

XcodeProj did not contain this mapping. Thus, Tuist-generated projects created `PBXFileReference` entries without a `lastKnownFileType` value for `AppIcon.icon`.

Local Xcode inferred the file type. Xcode Cloud did not infer the file type. It treated the bundle as a plain folder.

As a result, `actool` received only `Assets.xcassets`. It did not find `AppIcon`.

This change adds the missing mapping to `Xcode.filetype(extension:)`.

### Implementation 👩‍💻👨‍💻

- This change maps `.icon` to `folder.iconcomposer.icon`.
- A regression test covers this mapping.
- `swift test --filter XcodeTests` passes.
- The affected project archives and exports an IPA locally with this mapping.
- Xcode Cloud now includes `AppIcon.icon` in the asset-compiler inputs.
- The project team handles a separate resource-ownership error in that repository.
