### PR TITLE
fix: support the Swift Static Linux SDK (musl)

### DIFF
--- a/Sources/XcodeProj/Extensions/Path+Extras.swift
+++ b/Sources/XcodeProj/Extensions/Path+Extras.swift
@@ -8,6 +8,8 @@ import PathKit
 func systemGlob(_ pattern: UnsafePointer<CChar>!, _ flags: Int32, _ errfunc: (@convention(c) (UnsafePointer<CChar>?, Int32) -> Int32)!, _ vector_ptr: UnsafeMutablePointer<glob_t>!) -> Int32 {
     #if os(macOS) || os(iOS)
         return Darwin.glob(pattern, flags, errfunc, vector_ptr)
+    #elseif os(Linux) && canImport(Musl)
+        return Musl.glob(pattern, flags, errfunc, vector_ptr)
     #else
         return Glibc.glob(pattern, flags, errfunc, vector_ptr)
     #endif
@@ -35,7 +37,12 @@ extension Path {
             free(cPattern)
         }
 
+        #if os(Linux) && canImport(Musl)
+        // musl's glob() doesn't support brace expansion (GLOB_BRACE is a GNU extension)
+        let flags = GLOB_TILDE | GLOB_MARK
+        #else
         let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
+        #endif
         if systemGlob(cPattern, flags, nil, &gt) == 0 {
             #if os(macOS)
                 let matchc = gt.gl_matchc

--- a/Sources/XcodeProj/Extensions/Path+Extras.swift
+++ b/Sources/XcodeProj/Extensions/Path+Extras.swift
@@ -38,10 +38,10 @@ extension Path {
         }
 
         #if os(Linux) && canImport(Musl)
-        // musl's glob() doesn't support brace expansion (GLOB_BRACE is a GNU extension)
-        let flags = GLOB_TILDE | GLOB_MARK
+            // musl's glob() doesn't support brace expansion (GLOB_BRACE is a GNU extension)
+            let flags = GLOB_TILDE | GLOB_MARK
         #else
-        let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
+            let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
         #endif
         if systemGlob(cPattern, flags, nil, &gt) == 0 {
             #if os(macOS)


### PR DESCRIPTION
Resolves https://github.com/tuist/xcodeproj/issues/1167

### Short description 📝
> Make XcodeProj buildable with the Swift Static Linux SDK (musl): use `Musl.glob` via `canImport(Musl)` and drop the GNU-only `GLOB_BRACE` flag on musl.

### Solution 📦
> The musl libc is exposed as the `Musl` module (not `Glibc`) and musl's `glob()` has no brace expansion. Add an additive `#if os(Linux) && canImport(Musl)` branch in `systemGlob` and guard the flags. Behavior on glibc/macOS is unchanged — same pattern already merged upstream in `jpsim/Yams` (PR #477).

### Implementation 👩‍💻👨‍💻
> Detail in a checklist the steps that you took to implement the PR.

- [x] `canImport(Musl)` branch in `systemGlob` → `Musl.glob`
- [x] Guard `GLOB_BRACE` out on musl only
- [x] Verified `swift build --swift-sdk x86_64-swift-linux-musl` succeeds
- [x] Verified glibc/macOS paths untouched (existing CI covers them)