### PR TITLE
feat: Add the host build tool product type

### DIFF
--- a/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
+++ b/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
@@ -14,6 +14,7 @@ public enum PBXProductType: String, Decodable {
     case appExtension = "com.apple.product-type.app-extension"
     case extensionKitExtension = "com.apple.product-type.extensionkit-extension"
     case commandLineTool = "com.apple.product-type.tool"
+    case hostBuildTool = "com.apple.product-type.tool.host-build"
     case watchApp = "com.apple.product-type.application.watchapp"
     case watch2App = "com.apple.product-type.application.watchapp2"
     case watch2AppContainer = "com.apple.product-type.application.watchapp2-container"
@@ -51,7 +52,7 @@ public enum PBXProductType: String, Decodable {
         case .appExtension, .extensionKitExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension,
              .intentsServiceExtension:
             "appex"
-        case .commandLineTool:
+        case .commandLineTool, .hostBuildTool:
             nil
         case .xpcService:
             "xpc"

--- a/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
+++ b/Tests/XcodeProjTests/Objects/Targets/PBXProductTypeTests.swift
@@ -47,6 +47,11 @@ final class PBXProductTypeTests: XCTestCase {
         XCTAssertEqual(PBXProductType.commandLineTool.rawValue, "com.apple.product-type.tool")
     }
 
+    func test_hostBuildTool_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.hostBuildTool.rawValue, "com.apple.product-type.tool.host-build")
+        XCTAssertNil(PBXProductType.hostBuildTool.fileExtension)
+    }
+
     func test_watchApp_hasTheRightValue() {
         XCTAssertEqual(PBXProductType.watchApp.rawValue, "com.apple.product-type.application.watchapp")
     }


### PR DESCRIPTION
## What changed

Added `PBXProductType.hostBuildTool` for Xcode projects using `com.apple.product-type.tool.host-build`. The type is treated as a tool with no file extension.

## Why

Build systems use this product type for executable tools that must be prepared when indexing a project, including Swift macro implementations.

## Root cause

XcodeProj could not model the existing Xcode product type, so project generators had to emit a regular command-line tool instead.

## Impact

Generators can now opt into the native host-build-tool representation without custom project-file workarounds.

## Validation

- `mise run test -- --filter PBXProductTypeTests`
- `mise run lint`